### PR TITLE
Fix: Unclickable CanutinIcon in Windows

### DIFF
--- a/src/app/components/common/TitleBar/styles.ts
+++ b/src/app/components/common/TitleBar/styles.ts
@@ -40,6 +40,7 @@ export const icon = css`
   padding: 16px;
   border-right: 1px solid ${grey10};
   cursor: pointer;
+  -webkit-app-region: no-drag;
 
   &:hover {
     background-color: ${grey3};


### PR DESCRIPTION
## What & Why:

Fixes an issue where `<CanutinIcon/>` can't be clicked to open https://canutin.com in an external browser.

## Tasks:

- [x] Tested in macOS (x86)
- [ ] ~~Tested in macOS (ARM)~~
- [x] Tested in Windows
- [ ] ~~Tested in Linux~~
