### PR TITLE
Fix: Loading old vaults displays blank screen

### DIFF
--- a/src/app/components/App/index.tsx
+++ b/src/app/components/App/index.tsx
@@ -4,7 +4,12 @@ import { Switch, Route, HashRouter, Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { routesConfig, RouteConfigProps, routesPaths } from '@routes';
-import { DATABASE_CONNECTED, DATABASE_NOT_DETECTED, DATABASE_DOES_NOT_EXIST } from '@constants';
+import {
+  DATABASE_CONNECTED,
+  DATABASE_NOT_DETECTED,
+  DATABASE_DOES_NOT_EXIST,
+  DATABASE_NOT_VALID,
+} from '@constants';
 
 import { EntitiesContext } from '@app/context/entitiesContext';
 import { AppContext } from '@app/context/appContext';
@@ -63,10 +68,20 @@ const App = () => {
       });
     });
 
+    ipcRenderer.on(DATABASE_NOT_VALID, () => {
+      setIsLoading(false);
+      setStatusMessage({
+        sentiment: StatusEnum.NEGATIVE,
+        message: 'The chosen file is not a valid Canutin vault',
+        isLoading: false,
+      });
+    });
+
     return () => {
       ipcRenderer.removeAllListeners(DATABASE_CONNECTED);
       ipcRenderer.removeAllListeners(DATABASE_NOT_DETECTED);
       ipcRenderer.removeAllListeners(DATABASE_DOES_NOT_EXIST);
+      ipcRenderer.removeAllListeners(DATABASE_NOT_VALID);
     };
   }, []);
 

--- a/src/app/pages/Setup/index.tsx
+++ b/src/app/pages/Setup/index.tsx
@@ -12,35 +12,21 @@ import PrimaryCardRow from '@components/common/PrimaryCardRow';
 import { ReactComponent as Vault } from '@assets/icons/Vault.svg';
 import { ReactComponent as Browse } from '@assets/icons/Browse.svg';
 import { OPEN_CREATE_VAULT, OPEN_EXISTING_VAULT } from '@constants/events';
-import { DATABASE_NOT_VALID } from '@constants';
-import { StatusEnum } from '@app/constants/misc';
 import { routesPaths } from '@routes';
-import { AppContext } from '@app/context/appContext';
 import { emptyStatusMessage, StatusBarContext } from '@app/context/statusBarContext';
 
 const noVaultBreadcrumbs = [{ breadcrumb: 'Canutin setup', path: '/' }];
 
 const Setup = () => {
-  const { setIsLoading } = useContext(AppContext);
   const { setStatusMessage, setBreadcrumbs } = useContext(StatusBarContext);
   const breadcrumbItems = useBreadcrumbs(noVaultBreadcrumbs, {
     excludePaths: Object.values(routesPaths),
   });
 
   useEffect(() => {
-    ipcRenderer.on(DATABASE_NOT_VALID, () => {
-      setIsLoading(false);
-      setStatusMessage({
-        sentiment: StatusEnum.NEGATIVE,
-        message: 'The chosen file is not a valid Canutin vault',
-        isLoading: false,
-      });
-    });
-
     setBreadcrumbs(<Breadcrumbs items={breadcrumbItems} />);
 
     return () => {
-      ipcRenderer.removeAllListeners(DATABASE_NOT_VALID);
       setStatusMessage(emptyStatusMessage);
       setBreadcrumbs(undefined);
     };


### PR DESCRIPTION
## What & Why:

The event `DATABASE_NOT_VALID` was being listened from the `<Setup>` component that wasn't loaded during initial boot.
Moved the event to the `AppContext` together with the other `DATABASE_XXX` events.

## Tasks:

- [x] Tested in macOS (x86)
- [ ] ~~Tested in macOS (ARM)~~
- [x] Tested in Windows
- [ ] ~~Tested in Linux~~

