### PR TITLE
Maintenance: Update GitHub Actions to build release on tagged commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Canutin - Build & Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Canutin - Build & Release
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
## What & Why:

- Run **Build & Release** only when commits are tagged `v*` (i.e `v0.0.0-test`)