### PR TITLE
#45 - Add electron-builder.yml

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,32 @@
+productName: Canutin
+appId: com.canutin.desktop
+artifactName: ${name}_v${version}-${os}-${arch}.${ext}
+
+files:
+  - from: "dist/main"
+    to: "."
+  - package.json
+
+directories:
+  buildResources: resources
+
+extraResources:
+  - from: "resources/assets"
+    to: "assets"
+  - from: "resources/sveltekit"
+    to: "sveltekit"
+
+mac:
+  target:
+    - dmg
+
+win:
+  target:
+    - nsis
+
+nsis:
+  allowToChangeInstallationDirectory: true
+
+linux:
+  target:
+    - zip

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,7 @@ win:
     - nsis
 
 nsis:
+  oneClick: false
   allowToChangeInstallationDirectory: true
 
 linux:

--- a/package.json
+++ b/package.json
@@ -26,53 +26,5 @@
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
-  },
-  "build": {
-    "productName": "Canutin",
-    "appId": "com.canutin.desktop",
-    "artifactName": "${name}_v${version}-${os}-${arch}.${ext}",
-    "extraMetadata": {
-      "name": "desktop",
-      "main": "main.js"
-    },
-    "files": [
-      {
-        "from": ".",
-        "filter": [
-          "package.json"
-        ]
-      },
-      {
-        "from": "dist/main"
-      }
-    ],
-    "win": {
-      "target": [
-        "zip"
-      ]
-    },
-    "mac": {
-      "target": [
-        "zip"
-      ]
-    },
-    "linux": {
-      "target": [
-        "zip"
-      ]
-    },
-    "directories": {
-      "buildResources": "resources"
-    },
-    "extraResources": [
-      {
-        "from": "resources/assets",
-        "to": "assets"
-      },
-      {
-        "from": "resources/sveltekit",
-        "to": "sveltekit"
-      }
-    ]
   }
 }


### PR DESCRIPTION
- Move config from `package.json` to `electron-builder.yml` (Fixes #45)
- Add ability to choose installation directory in Windows (Fixes #22)

<img src="https://user-images.githubusercontent.com/1434675/185761283-a2991c7c-ebb4-4620-8b55-ff2983e7bebc.png" width="480" />

- [x] Tested in macOS
- [x] Tested in Windows