### PR TITLE
feat: add transaction search with URL persistence

### DIFF
--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -879,3 +879,161 @@ test('transactions list updates in real-time when new transaction is added', asy
 
 	await expect(page.getByText('Fresh Groceries Market')).toHaveCount(1);
 });
+
+test('transactions can be searched by description', async ({ page }) => {
+	const user = await seedUser('grace');
+
+	const account = await seedAccount({
+		name: 'Search Test Account',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 5000
+	});
+
+	const now = new UTCDate();
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Whole Foods Grocery Store',
+		value: -150
+	});
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Amazon Prime Subscription',
+		value: -14.99
+	});
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Trader Joes Grocery',
+		value: -85
+	});
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Netflix Monthly',
+		value: -15.99
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	await expect(page.getByText('Whole Foods Grocery Store')).toBeVisible();
+	await expect(page.getByText('Amazon Prime Subscription')).toBeVisible();
+	await expect(page.getByText('Trader Joes Grocery')).toBeVisible();
+	await expect(page.getByText('Netflix Monthly')).toBeVisible();
+
+	const searchInput = page.getByPlaceholder('Search transactions');
+	await searchInput.fill('Grocery');
+
+	await expect(page.getByText('Whole Foods Grocery Store')).toBeVisible();
+	await expect(page.getByText('Trader Joes Grocery')).toBeVisible();
+	await expect(page.getByText('Amazon Prime Subscription')).not.toBeVisible();
+	await expect(page.getByText('Netflix Monthly')).not.toBeVisible();
+
+	await searchInput.fill('Amazon');
+
+	await expect(page.getByText('Amazon Prime Subscription')).toBeVisible();
+	await expect(page.getByText('Whole Foods Grocery Store')).not.toBeVisible();
+	await expect(page.getByText('Trader Joes Grocery')).not.toBeVisible();
+	await expect(page.getByText('Netflix Monthly')).not.toBeVisible();
+
+	await page.reload();
+
+	await expect(searchInput).toHaveValue('Amazon');
+	await expect(page.getByText('Amazon Prime Subscription')).toBeVisible();
+	await expect(page.getByText('Whole Foods Grocery Store')).not.toBeVisible();
+
+	await page.getByLabel('Clear search').click();
+
+	await expect(page.getByText('Whole Foods Grocery Store')).toBeVisible();
+	await expect(page.getByText('Amazon Prime Subscription')).toBeVisible();
+	await expect(page.getByText('Trader Joes Grocery')).toBeVisible();
+	await expect(page.getByText('Netflix Monthly')).toBeVisible();
+});
+
+test('transaction search persists in URL and combines with filters', async ({ page }) => {
+	const user = await seedUser('henry');
+
+	const account = await seedAccount({
+		name: 'URL Search Account',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 3000
+	});
+
+	const now = new UTCDate();
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Salary Deposit',
+		value: 5000
+	});
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Salary Bonus',
+		value: 1000
+	});
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Coffee Shop',
+		value: -5.5
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	const searchInput = page.getByPlaceholder('Search transactions');
+	await searchInput.fill('Salary');
+
+	await expect(page.url()).toContain('q=Salary');
+
+	await expect(page.getByText('Salary Deposit')).toBeVisible();
+	await expect(page.getByText('Salary Bonus')).toBeVisible();
+	await expect(page.getByText('Coffee Shop')).not.toBeVisible();
+
+	await page.reload();
+
+	await expect(searchInput).toHaveValue('Salary');
+	await expect(page.getByText('Salary Deposit')).toBeVisible();
+	await expect(page.getByText('Salary Bonus')).toBeVisible();
+	await expect(page.getByText('Coffee Shop')).not.toBeVisible();
+
+	await page.getByLabel('Type').click();
+	await page.getByRole('option', { name: 'Credits only' }).click();
+
+	await expect(page.getByText('Salary Deposit')).toBeVisible();
+	await expect(page.getByText('Salary Bonus')).toBeVisible();
+
+	await page.getByLabel('Clear search').click();
+
+	await expect(page.getByText('Salary Deposit')).toBeVisible();
+	await expect(page.getByText('Salary Bonus')).toBeVisible();
+	await expect(page.getByText('Coffee Shop')).not.toBeVisible();
+});

--- a/messages/en.json
+++ b/messages/en.json
@@ -255,5 +255,6 @@
 	"transactions_delete_confirm_cancel": "Cancel",
 	"transactions_delete_confirm_continue": "Continue",
 	"transactions_delete_success": "Transaction deleted",
-	"transactions_delete_failed": "Failed to delete transaction"
+	"transactions_delete_failed": "Failed to delete transaction",
+	"transactions_search_placeholder": "Search transactions"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -255,5 +255,6 @@
 	"transactions_delete_confirm_cancel": "Cancelar",
 	"transactions_delete_confirm_continue": "Continuar",
 	"transactions_delete_success": "Transacción eliminada",
-	"transactions_delete_failed": "Error al eliminar transacción"
+	"transactions_delete_failed": "Error al eliminar transacción",
+	"transactions_search_placeholder": "Buscar transacciones"
 }

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -54,6 +54,7 @@ class TransactionsContext {
 	private _customFromDate: Date | null = $state(null);
 	private _customToDate: Date | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
 
 	readonly periodOptions: PeriodOption[] = [
 		'this-month',
@@ -172,7 +173,15 @@ class TransactionsContext {
 	}
 
 	async refreshTransactions() {
-		this.isLoading = true;
+		if (this._loadingDelayTimer) {
+			clearTimeout(this._loadingDelayTimer);
+			this._loadingDelayTimer = null;
+		}
+
+		this._loadingDelayTimer = setTimeout(() => {
+			this.isLoading = true;
+		}, 150);
+
 		try {
 			const filterParts: string[] = [];
 
@@ -223,6 +232,10 @@ class TransactionsContext {
 		} catch (error) {
 			this._pb.handleConnectionError(error, 'transactions', 'refresh');
 		} finally {
+			if (this._loadingDelayTimer) {
+				clearTimeout(this._loadingDelayTimer);
+				this._loadingDelayTimer = null;
+			}
 			this.isLoading = false;
 		}
 	}

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -46,12 +46,14 @@ export type TransactionRow = {
 class TransactionsContext {
 	period: PeriodOption = $state('last-3-months');
 	kind: KindFilter = $state('all');
+	search: string = $state('');
 	page: number = $state(1);
 	isLoading: boolean = $state(true);
 	rawTransactions: TransactionsResponse<TransactionExpand>[] = $state([]);
 
 	private _customFromDate: Date | null = $state(null);
 	private _customToDate: Date | null = $state(null);
+	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 	readonly periodOptions: PeriodOption[] = [
 		'this-month',
@@ -89,6 +91,11 @@ class TransactionsContext {
 		const amountParam = params.get('amount');
 		if (amountParam && this.kindOptions.includes(amountParam as KindFilter)) {
 			this.kind = amountParam as KindFilter;
+		}
+
+		const searchParam = params.get('q');
+		if (searchParam) {
+			this.search = searchParam;
 		}
 	}
 
@@ -132,6 +139,38 @@ class TransactionsContext {
 		this.realtimeSubscribe();
 	}
 
+	setSearch(query: string) {
+		this.search = query;
+		this.page = 1;
+		this.syncSearchToUrl();
+
+		if (this._searchDebounceTimer) {
+			clearTimeout(this._searchDebounceTimer);
+		}
+
+		this._searchDebounceTimer = setTimeout(() => {
+			this.refreshTransactions();
+		}, 300);
+	}
+
+	private syncSearchToUrl() {
+		const currentPage = get(page);
+		const params = new SvelteURLSearchParams(currentPage.url.searchParams);
+
+		if (this.search.trim()) {
+			params.set('q', this.search.trim());
+		} else {
+			params.delete('q');
+		}
+
+		const searchStr = params.toString();
+		const newUrl = `${currentPage.url.pathname}${searchStr ? `?${searchStr}` : ''}`;
+
+		if (newUrl !== `${currentPage.url.pathname}${currentPage.url.search}`) {
+			history.replaceState(history.state, '', newUrl);
+		}
+	}
+
 	async refreshTransactions() {
 		this.isLoading = true;
 		try {
@@ -161,6 +200,12 @@ class TransactionsContext {
 				filterParts.push('value < 0');
 			} else if (this.kind === 'excluded') {
 				filterParts.push('excluded != ""');
+			}
+
+			const searchQuery = this.search.trim();
+			if (searchQuery) {
+				const escaped = searchQuery.replace(/'/g, "''");
+				filterParts.push(`description ~ '${escaped}'`);
 			}
 
 			const filter = filterParts.length > 0 ? filterParts.join(' && ') : undefined;

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import XIcon from '@lucide/svelte/icons/x';
+
 	import SectionTitle from '$lib/components/section-title.svelte';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { m } from '$lib/paraglide/messages';
 	import {
@@ -9,6 +14,15 @@
 	} from '$lib/transactions.svelte';
 
 	const txContext = getTransactionsContext();
+
+	function handleSearchInput(e: Event) {
+		const target = e.target as HTMLInputElement;
+		txContext.setSearch(target.value);
+	}
+
+	function clearSearch() {
+		txContext.setSearch('');
+	}
 
 	function periodLabel(option: PeriodOption) {
 		switch (option) {
@@ -50,6 +64,34 @@
 <div class="flex flex-col gap-4">
 	<SectionTitle title={m.transactions_section_title()} />
 	<div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+		<div class="relative flex-1">
+			<div
+				class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
+			>
+				{#if txContext.isLoading}
+					<LoaderCircleIcon class="size-4 animate-spin" />
+				{:else}
+					<SearchIcon class="size-4" />
+				{/if}
+			</div>
+			<Input
+				type="text"
+				placeholder={m.transactions_search_placeholder()}
+				value={txContext.search}
+				oninput={handleSearchInput}
+				class="bg-background pr-9 pl-9"
+			/>
+			{#if txContext.search}
+				<button
+					type="button"
+					onclick={clearSearch}
+					aria-label="Clear search"
+					class="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
+				>
+					<XIcon class="size-4" />
+				</button>
+			{/if}
+		</div>
 		<Select.Root type="single" bind:value={txContext.period}>
 			<Select.Trigger
 				aria-label={m.transactions_filter_period_label()}


### PR DESCRIPTION
## Summary
- Add fuzzy search for transactions by description using PocketBase's contains operator
- Search input with loading spinner, clear button, and 300ms debounce
- Search query persists in URL (`q=`) and combines with existing period/type filters