### PR TITLE
feat: add account and asset links to balance sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,13 @@ Sort order (handled by Prettier):
 - **Avoid adding comments** - Only add comments when explicitly requested by the user
 - **Never run dev automatically** - Always assume the user is running dev server in a separate terminal
 
+### Branches and Pull Requests
+
+- **Branch naming**: Use `{issue-number}-{short-description}` (e.g., `256-balance-sheet-links`)
+- **Base branch**: Always use `next` as the base branch for v2 features
+- **Title format**: Use the same format as commit messages: `type: description` (e.g., `feat: add account links to balance sheet`). This is important for semantic versioning (`feat:` → minor, `fix:` → patch)
+- **Body format**: Keep it short and high-level, minimal formatting. Always include `Closes #123` to reference the issue
+
 ### Background Processes
 
 Developers typically run these processes constantly in separate terminals:

--- a/e2e/balance-sheet.test.ts
+++ b/e2e/balance-sheet.test.ts
@@ -226,4 +226,15 @@ test('balance sheet', async ({ page }) => {
 	await expect(balanceRegions.nth(1)).toContainText('$1,500');
 	await expect(balanceRegions.nth(2)).toContainText('Savings');
 	await expect(balanceRegions.nth(2)).toContainText('$500');
+
+	// Clicking on an account navigates to its detail page
+	await page.getByRole('link', { name: 'Willow Everyday' }).click();
+	await expect(page).toHaveURL(`/accounts/${checkingAccount.id}`);
+	await expect(page.getByText('Willow Everyday')).toBeVisible();
+
+	// Go back to balance sheet and click on an asset
+	await goToPageViaSidebar(page, 'Balance sheet');
+	await page.getByRole('link', { name: 'Las Meninas' }).click();
+	await expect(page).toHaveURL(`/assets/${otherAsset.id}`);
+	await expect(page.getByText('Las Meninas')).toBeVisible();
 });

--- a/src/lib/components/link.svelte
+++ b/src/lib/components/link.svelte
@@ -16,7 +16,7 @@
 	bind:this={ref}
 	{href}
 	class={cn(
-		'border-foreground/20 hover:text-primary hover:border-primary border-b transition-colors [text-decoration:none]',
+		'text-foreground/90 decoration-foreground/20 hover:text-primary hover:decoration-primary underline underline-offset-4 transition-colors',
 		className
 	)}
 	{...restProps}

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -3,6 +3,7 @@
 	import { getAssetsContext } from '$lib/assets.svelte';
 	import Currency from '$lib/components/currency.svelte';
 	import KeyValue from '$lib/components/key-value.svelte';
+	import Link from '$lib/components/link.svelte';
 	import Page from '$lib/components/page.svelte';
 	import SectionTitle from '$lib/components/section-title.svelte';
 	import Section from '$lib/components/section.svelte';
@@ -47,7 +48,13 @@
 					id: string;
 					name: string;
 					total: number;
-					items: Array<{ id: string; name: string; balance: number; excluded: boolean }>;
+					items: Array<{
+						id: string;
+						name: string;
+						balance: number;
+						excluded: boolean;
+						type: 'account' | 'asset';
+					}>;
 				}>;
 			}
 		> = {
@@ -78,11 +85,17 @@
 			if (a.closed) continue;
 			const group = a.balanceGroup as BalanceGroup;
 			if (!a.excluded) groups[group].total += a.balance ?? 0;
-			const type = upsert(group, a.balanceType, accountsContext.getTypeName(a.balanceType));
-			if (!a.excluded) type.total += a.balance ?? 0;
-			type.items = [
-				...type.items,
-				{ id: a.id, name: a.name, balance: a.balance ?? 0, excluded: Boolean(a.excluded) }
+			const balanceType = upsert(group, a.balanceType, accountsContext.getTypeName(a.balanceType));
+			if (!a.excluded) balanceType.total += a.balance ?? 0;
+			balanceType.items = [
+				...balanceType.items,
+				{
+					id: a.id,
+					name: a.name,
+					balance: a.balance ?? 0,
+					excluded: Boolean(a.excluded),
+					type: 'account'
+				}
 			];
 		}
 
@@ -90,11 +103,17 @@
 			if (a.sold) continue;
 			const group = a.balanceGroup as BalanceGroup;
 			if (!a.excluded) groups[group].total += a.marketValue ?? 0;
-			const type = upsert(group, a.balanceType, assetsContext.getTypeName(a.balanceType));
-			if (!a.excluded) type.total += a.marketValue ?? 0;
-			type.items = [
-				...type.items,
-				{ id: a.id, name: a.name, balance: a.marketValue ?? 0, excluded: Boolean(a.excluded) }
+			const balanceType = upsert(group, a.balanceType, assetsContext.getTypeName(a.balanceType));
+			if (!a.excluded) balanceType.total += a.marketValue ?? 0;
+			balanceType.items = [
+				...balanceType.items,
+				{
+					id: a.id,
+					name: a.name,
+					balance: a.marketValue ?? 0,
+					excluded: Boolean(a.excluded),
+					type: 'asset'
+				}
 			];
 		}
 
@@ -150,12 +169,13 @@
 									<li
 										class="odd:bg-sidebar flex items-center justify-between gap-2 border-b px-4 py-3 text-balance last:border-b-0"
 									>
-										<span
+										<Link
+											href={item.type === 'account' ? `/accounts/${item.id}` : `/assets/${item.id}`}
 											class={'text-sm ' +
 												(item.excluded ? 'text-muted-foreground' : 'text-foreground/90')}
 										>
 											{item.name}
-										</span>
+										</Link>
 										<span
 											class={'font-mono text-xs tabular-nums ' +
 												(item.excluded ? 'text-muted-foreground' : '')}


### PR DESCRIPTION
## Summary
- Account and asset names in the balance sheet are now clickable links to their detail pages
- Fixed Link component to use `text-decoration: underline` instead of `border-bottom` so underlines properly wrap with text

Closes #256