### PR TITLE
fix: require type field for assets in schema and seed helpers

### DIFF
--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -17,7 +17,8 @@ test('assets table reflects filters and aggregate totals', async ({ page }) => {
 		name: 'Growth Fund',
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		owner: user.id,
-		balanceType: 'ETF'
+		balanceType: 'ETF',
+		type: AssetsTypeOptions.WHOLE
 	});
 	await seedAssetBalance({
 		asset: ownedAsset.id,
@@ -31,6 +32,7 @@ test('assets table reflects filters and aggregate totals', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
 		balanceType: 'Collectible',
+		type: AssetsTypeOptions.WHOLE,
 		excluded: new Date().toISOString()
 	});
 	await seedAssetBalance({
@@ -45,6 +47,7 @@ test('assets table reflects filters and aggregate totals', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		owner: user.id,
 		balanceType: 'Stock',
+		type: AssetsTypeOptions.WHOLE,
 		sold: new Date().toISOString()
 	});
 	await seedAssetBalance({
@@ -95,7 +98,8 @@ test('assets table shows appreciation and depreciation for whole assets', async 
 		name: 'Primary Residence',
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
-		balanceType: 'Real Estate'
+		balanceType: 'Real Estate',
+		type: AssetsTypeOptions.WHOLE
 	});
 	await seedAssetBalance({
 		asset: appreciatingHouse.id,
@@ -109,7 +113,8 @@ test('assets table shows appreciation and depreciation for whole assets', async 
 		name: 'Vehicle',
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
-		balanceType: 'Vehicle'
+		balanceType: 'Vehicle',
+		type: AssetsTypeOptions.WHOLE
 	});
 	await seedAssetBalance({
 		asset: depreciatingCar.id,
@@ -123,7 +128,8 @@ test('assets table shows appreciation and depreciation for whole assets', async 
 		name: 'Stable Fund',
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		owner: user.id,
-		balanceType: 'ETF'
+		balanceType: 'ETF',
+		type: AssetsTypeOptions.WHOLE
 	});
 	await seedAssetBalance({
 		asset: breakEvenAsset.id,
@@ -170,7 +176,8 @@ test('assets table shows appreciation and depreciation for shares assets', async
 		symbol: 'NVDA',
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		owner: user.id,
-		balanceType: 'Stock'
+		balanceType: 'Stock',
+		type: AssetsTypeOptions.SHARES
 	});
 	await seedAssetBalance({
 		asset: gainStock.id,
@@ -188,7 +195,8 @@ test('assets table shows appreciation and depreciation for shares assets', async
 		symbol: 'XYZ',
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		owner: user.id,
-		balanceType: 'Stock'
+		balanceType: 'Stock',
+		type: AssetsTypeOptions.SHARES
 	});
 	await seedAssetBalance({
 		asset: lossStock.id,

--- a/e2e/balance-sheet.test.ts
+++ b/e2e/balance-sheet.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from '@playwright/test';
 
 import {
 	AccountsBalanceGroupOptions,
-	AssetsBalanceGroupOptions
+	AssetsBalanceGroupOptions,
+	AssetsTypeOptions
 } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
@@ -108,7 +109,8 @@ test('balance sheet', async ({ page }) => {
 		name: 'Las Meninas',
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
-		balanceType: 'Paintings'
+		balanceType: 'Paintings',
+		type: AssetsTypeOptions.WHOLE
 	});
 
 	await seedAssetBalance({
@@ -148,6 +150,7 @@ test('balance sheet', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
 		balanceType: 'Paintings',
+		type: AssetsTypeOptions.WHOLE,
 		sold: new Date().toISOString()
 	});
 
@@ -163,6 +166,7 @@ test('balance sheet', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
 		balanceType: 'Paintings',
+		type: AssetsTypeOptions.WHOLE,
 		excluded: new Date().toISOString()
 	});
 

--- a/e2e/big-picture.summary.test.ts
+++ b/e2e/big-picture.summary.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from '@playwright/test';
 
 import {
 	AccountsBalanceGroupOptions,
-	AssetsBalanceGroupOptions
+	AssetsBalanceGroupOptions,
+	AssetsTypeOptions
 } from '../src/lib/pocketbase.schema';
 import { signIn } from './playwright.helpers';
 import {
@@ -95,7 +96,8 @@ test('big picture summary', async ({ page }) => {
 		name: 'Decorative Sculpture',
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		owner: user.id,
-		balanceType: 'Other asset'
+		balanceType: 'Other asset',
+		type: AssetsTypeOptions.WHOLE
 	});
 
 	await seedAssetBalance({
@@ -131,6 +133,7 @@ test('big picture summary', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.CASH,
 		owner: user.id,
 		balanceType: 'Other asset',
+		type: AssetsTypeOptions.WHOLE,
 		sold: new Date().toISOString()
 	});
 
@@ -146,6 +149,7 @@ test('big picture summary', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.CASH,
 		owner: user.id,
 		balanceType: 'Other asset',
+		type: AssetsTypeOptions.WHOLE,
 		excluded: new Date().toISOString()
 	});
 

--- a/e2e/pocketbase.helpers.ts
+++ b/e2e/pocketbase.helpers.ts
@@ -96,7 +96,7 @@ export async function seedAsset(assetInput: {
 	balanceGroup: AssetsRecord['balanceGroup'];
 	balanceType: BalanceTypesRecord['name'];
 	owner: UsersRecord['id'];
-	type?: AssetsRecord['type'];
+	type: AssetsRecord['type'];
 	symbol?: AssetsRecord['symbol'];
 	sold?: AssetsRecord['sold'];
 	excluded?: AssetsRecord['excluded'];

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -3,7 +3,8 @@ import { setHours, startOfYear, subDays, subMonths, subYears } from 'date-fns';
 
 import {
 	AccountsBalanceGroupOptions,
-	AssetsBalanceGroupOptions
+	AssetsBalanceGroupOptions,
+	AssetsTypeOptions
 } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
@@ -138,6 +139,7 @@ test('trends performance table', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
 		balanceType: 'Stock',
 		owner: user.id,
+		type: AssetsTypeOptions.WHOLE,
 		sold: now.toISOString()
 	});
 	const excludedDebtAsset = await seedAsset({
@@ -145,6 +147,7 @@ test('trends performance table', async ({ page }) => {
 		balanceGroup: AssetsBalanceGroupOptions.DEBT,
 		balanceType: 'Loan',
 		owner: user.id,
+		type: AssetsTypeOptions.WHOLE,
 		excluded: now.toISOString()
 	});
 	for (const [date, marketValue] of [

--- a/pocketbase/pb_migrations/1767282344_updated_assets.js
+++ b/pocketbase/pb_migrations/1767282344_updated_assets.js
@@ -1,0 +1,42 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1321337024")
+
+  // update field
+  collection.fields.addAt(8, new Field({
+    "hidden": false,
+    "id": "select2363381545",
+    "maxSelect": 1,
+    "name": "type",
+    "presentable": false,
+    "required": true,
+    "system": false,
+    "type": "select",
+    "values": [
+      "WHOLE",
+      "SHARES"
+    ]
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1321337024")
+
+  // update field
+  collection.fields.addAt(8, new Field({
+    "hidden": false,
+    "id": "select2363381545",
+    "maxSelect": 1,
+    "name": "type",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "WHOLE",
+      "SHARES"
+    ]
+  }))
+
+  return app.save(collection)
+})

--- a/src/lib/pocketbase.schema.ts
+++ b/src/lib/pocketbase.schema.ts
@@ -162,7 +162,7 @@ export type AssetsRecord = {
 	owner: RecordIdString
 	sold?: IsoDateString
 	symbol?: string
-	type?: AssetsTypeOptions
+	type: AssetsTypeOptions
 	updated?: IsoDateString
 }
 


### PR DESCRIPTION
## Summary
- Adds PocketBase migration to make `type` field required on assets collection
- Updates `seedAsset` helper to require `type` parameter
- Updates all test files to include `type` in `seedAsset` calls

Closes #266