### PR TITLE
fix: logout user when session becomes invalid

### DIFF
--- a/e2e/error-handling.test.ts
+++ b/e2e/error-handling.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
-import { seedUser } from './pocketbase.helpers';
+import { deleteUser, seedUser } from './pocketbase.helpers';
 
 test('shows connection error toast when PocketBase is unreachable', async ({ page }) => {
 	const user = await seedUser('charlie');
@@ -70,4 +70,18 @@ test('shows auth error toast when session expires', async ({ page }) => {
 
 	await goToPageViaSidebar(page, 'Accounts');
 	await expect(page).toHaveURL('/auth');
+});
+
+test('logs out user automatically when their account is deleted', async ({ page }) => {
+	const user = await seedUser('george');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
+	await expect(page).not.toHaveURL('/auth');
+	await expect(page.getByRole('button', { name: 'Login' })).not.toBeVisible();
+
+	await deleteUser(user.id);
+	await expect(page).toHaveURL('/auth');
+	await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
 });

--- a/e2e/error-handling.test.ts
+++ b/e2e/error-handling.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { goToPageViaSidebar, signIn } from './playwright.helpers';
+import { signIn } from './playwright.helpers';
 import { deleteUser, seedUser } from './pocketbase.helpers';
 
 test('shows connection error toast when PocketBase is unreachable', async ({ page }) => {
@@ -48,6 +48,7 @@ test('shows auth error toast when session expires', async ({ page }) => {
 	await signIn(page, user.email);
 	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
 	await expect(page.getByText('Your session has expired')).not.toBeVisible();
+	await expect(page).not.toHaveURL('/auth');
 
 	await page.route('**/api/collections/**', (route) => {
 		route.fulfill({
@@ -62,14 +63,13 @@ test('shows auth error toast when session expires', async ({ page }) => {
 	});
 
 	await page.reload();
+	await expect(page).toHaveURL('/auth');
+	await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
 	await expect(
 		page.locator('[data-sonner-toast]', {
 			hasText: 'Your session has expired'
 		})
 	).toBeVisible();
-
-	await goToPageViaSidebar(page, 'Accounts');
-	await expect(page).toHaveURL('/auth');
 });
 
 test('logs out user automatically when their account is deleted', async ({ page }) => {

--- a/e2e/pocketbase.helpers.ts
+++ b/e2e/pocketbase.helpers.ts
@@ -172,7 +172,7 @@ export async function recordExists(collection: string, id: string): Promise<bool
 	}
 }
 
-export async function deleteUser(id: string): Promise<void> {
+export async function deleteUser(id: string) {
 	const pb = await getAdminPB();
 	await pb.collection('users').delete(id);
 }

--- a/e2e/pocketbase.helpers.ts
+++ b/e2e/pocketbase.helpers.ts
@@ -171,3 +171,8 @@ export async function recordExists(collection: string, id: string): Promise<bool
 		return false;
 	}
 }
+
+export async function deleteUser(id: string): Promise<void> {
+	const pb = await getAdminPB();
+	await pb.collection('users').delete(id);
+}

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,7 +1,8 @@
-import PocketBase, { type BaseAuthStore } from 'pocketbase';
+import PocketBase, { type BaseAuthStore, type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
 import { m } from '$lib/paraglide/messages.js';
+import type { UsersResponse } from '$lib/pocketbase.schema';
 
 export class AuthContext {
 	currentUser: BaseAuthStore | null = $state(null);
@@ -13,7 +14,48 @@ export class AuthContext {
 	constructor(pb: PocketBase) {
 		this._pb = pb;
 		this.currentUser = this._pb.authStore;
+		this.init();
+	}
+
+	private async init() {
+		const isValid = await this.validateSession();
+		if (isValid) {
+			this.subscribeToCurrentUser();
+		}
 		this.isLoading = false;
+	}
+
+	private async validateSession() {
+		if (!this._pb.authStore.isValid) {
+			return false;
+		}
+
+		try {
+			await this._pb.collection('users').authRefresh();
+			this.currentUser = this._pb.authStore;
+			return true;
+		} catch {
+			this._pb.authStore.clear();
+			this.currentUser = null;
+			return false;
+		}
+	}
+
+	private subscribeToCurrentUser() {
+		const userId = this._pb.authStore.record?.id;
+		if (!userId) return;
+
+		this._pb
+			.collection('users')
+			.subscribe(userId, this.onCurrentUserEvent.bind(this))
+			.catch((error) => console.error('[auth:subscribe]', error));
+	}
+
+	private onCurrentUserEvent(e: RecordSubscription<UsersResponse>) {
+		if (e.action === 'delete') {
+			this._pb.authStore.clear();
+			this.currentUser = null;
+		}
 	}
 
 	private getErrorMessage(err: unknown, fallback: string): string {

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,5 +1,6 @@
 import PocketBase, { type BaseAuthStore, type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
+import { toast } from 'svelte-sonner';
 
 import { m } from '$lib/paraglide/messages.js';
 import type { UsersResponse } from '$lib/pocketbase.schema';
@@ -35,8 +36,10 @@ export class AuthContext {
 			this.currentUser = this._pb.authStore;
 			return true;
 		} catch {
+			this.unsubscribeFromCurrentUser();
 			this._pb.authStore.clear();
 			this.currentUser = null;
+			toast.error(m.error_auth_failed(), { id: 'auth-error' });
 			return false;
 		}
 	}
@@ -51,8 +54,19 @@ export class AuthContext {
 			.catch((error) => console.error('[auth:subscribe]', error));
 	}
 
+	private unsubscribeFromCurrentUser() {
+		const userId = this._pb.authStore.record?.id;
+		if (!userId) return;
+
+		this._pb
+			.collection('users')
+			.unsubscribe(userId)
+			.catch((error) => console.error('[auth:unsubscribe]', error));
+	}
+
 	private onCurrentUserEvent(e: RecordSubscription<UsersResponse>) {
 		if (e.action === 'delete') {
+			this.unsubscribeFromCurrentUser();
 			this._pb.authStore.clear();
 			this.currentUser = null;
 		}
@@ -75,6 +89,7 @@ export class AuthContext {
 		try {
 			await this._pb.collection('users').authWithPassword(email, password);
 			this.currentUser = this._pb.authStore;
+			this.subscribeToCurrentUser();
 			return { success: true } as const;
 		} catch (e: unknown) {
 			this.error = this.getErrorMessage(e, m.auth_login_failed());
@@ -102,6 +117,7 @@ export class AuthContext {
 	async logout() {
 		this.error = null;
 		try {
+			this.unsubscribeFromCurrentUser();
 			this._pb.authStore.clear();
 		} finally {
 			this.currentUser = null;

--- a/src/routes/(guest)/auth/dev-auth-shortcuts.svelte
+++ b/src/routes/(guest)/auth/dev-auth-shortcuts.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { dev } from '$app/environment';
 	import { getAuthContext } from '$lib/auth.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -10,7 +9,7 @@
 	type DevUser = { id: string; email: string };
 	let users: DevUser[] = $state([]);
 
-	async function fetchUsers(): Promise<void> {
+	async function fetchUsers() {
 		try {
 			const url = pb.authedClient.buildURL('/api/dev/example-users');
 			const res = await fetch(url.toString());
@@ -22,11 +21,10 @@
 	}
 
 	$effect(() => {
-		if (!dev) return;
 		void fetchUsers();
 	});
 
-	async function handleAutoLogin(email: string): Promise<void> {
+	async function handleAutoLogin(email: string) {
 		await auth.login(email, '123qweasdzxc');
 	}
 </script>


### PR DESCRIPTION
## Summary

- Validates user session on app init using `authRefresh()` to detect deleted/invalid accounts
- Subscribes to current user's record for real-time logout when account is deleted
- Adds real-time updates to dev auth shortcuts using superadmin-authenticated client

Closes #265