### PR TITLE
feat: implement svelte-currency-input for currency fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "canutinx",
+      "dependencies": {
+        "@canutin/svelte-currency-input": "^1.0.0-next.7",
+      },
       "devDependencies": {
         "@date-fns/utc": "^2.1.1",
         "@eslint/compat": "^1.2.5",
@@ -91,6 +94,8 @@
     "@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
+
+    "@canutin/svelte-currency-input": ["@canutin/svelte-currency-input@1.0.0-next.7", "", { "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-aSiv3KrFLOucnHiL3vvUe5dVO5zUD4ar3ZWwB9de5FKTTQ+JU6F9iFSwzAmKaskklDZI8ixKIUmJv46B4h/zbg=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,10 +3,8 @@
   "workspaces": {
     "": {
       "name": "canutinx",
-      "dependencies": {
-        "@canutin/svelte-currency-input": "^1.0.0-next.7",
-      },
       "devDependencies": {
+        "@canutin/svelte-currency-input": "^1.0.0-next.7",
         "@date-fns/utc": "^2.1.1",
         "@eslint/compat": "^1.2.5",
         "@eslint/js": "^9.18.0",

--- a/e2e/accounts.test.ts
+++ b/e2e/accounts.test.ts
@@ -132,7 +132,7 @@ test('user can add a new account', async ({ page }) => {
 	await page.getByLabel('Balance group').click();
 	await page.getByRole('option', { name: 'Cash' }).click();
 	await page.getByLabel('Category').fill('Savings');
-	await page.getByRole('spinbutton', { name: 'Balance' }).fill('5000');
+	await page.getByLabel('Balance', { exact: true }).fill('5000');
 	await page.getByRole('button', { name: 'Add' }).click();
 	await expect(page.getByText('Account added successfully')).toBeVisible();
 	await expect(page).toHaveURL('/accounts');
@@ -152,7 +152,7 @@ test('user can add a new account', async ({ page }) => {
 	await page.getByLabel('Balance group').click();
 	await page.getByRole('option', { name: 'Debt' }).click();
 	await page.getByLabel('Category').fill('Credit card');
-	await page.getByRole('spinbutton', { name: 'Balance' }).fill('-1200');
+	await page.getByLabel('Balance', { exact: true }).fill('-1200');
 	await expect(page.getByText('Account added successfully')).not.toBeVisible();
 
 	await page.getByRole('button', { name: 'Add' }).click();
@@ -215,7 +215,7 @@ test('user can edit account details and update balance', async ({ page }) => {
 		)
 	).not.toBeVisible();
 
-	await page.getByRole('spinbutton', { name: 'Balance' }).fill('4500');
+	await page.getByLabel('Balance', { exact: true }).fill('4500');
 	await page.getByRole('button', { name: 'Update' }).click();
 	await expect(page.getByText('Account added successfully')).toBeVisible();
 
@@ -276,7 +276,7 @@ test('user can directly navigate to account edit page', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('Emergency Fund');
 	await expect(page.getByLabel('Institution')).toHaveValue('Ally Bank');
 	await expect(page.getByLabel('Category')).toHaveValue('Savings');
-	await expect(page.getByRole('spinbutton', { name: 'Balance' })).toHaveValue('10000');
+	await expect(page.getByLabel('Balance', { exact: true })).toHaveValue('$10,000');
 });
 
 test('user sees stale data warning and can refresh form', async ({ page }) => {

--- a/e2e/accounts.test.ts
+++ b/e2e/accounts.test.ts
@@ -276,7 +276,7 @@ test('user can directly navigate to account edit page', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('Emergency Fund');
 	await expect(page.getByLabel('Institution')).toHaveValue('Ally Bank');
 	await expect(page.getByLabel('Category')).toHaveValue('Savings');
-	await expect(page.getByLabel('Balance', { exact: true })).toHaveValue('$10,000');
+	await expect(page.getByLabel('Balance', { exact: true })).toHaveValue('$10,000.00');
 });
 
 test('user sees stale data warning and can refresh form', async ({ page }) => {

--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -302,6 +302,32 @@ test('user can add a new asset with type WHOLE or SHARES', async ({ page }) => {
 	await expect(sharesCells.nth(8)).toContainText('$9,000.00');
 });
 
+test('optional currency fields show placeholder when not set', async ({ page }) => {
+	const user = await seedUser('nina');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Assets');
+
+	await page.getByRole('link', { name: 'Add asset' }).click();
+	await expect(page).toHaveURL('/assets/add');
+
+	await page.getByLabel('Type', { exact: true }).click();
+	await page.getByText('Whole').click();
+	await page.getByLabel('Name').fill('Art Piece');
+	await page.getByLabel('Balance group').click();
+	await page.getByText('Other assets').click();
+	await page.getByLabel('Category').fill('Art');
+	await page.getByLabel('Market value').fill('5000');
+	await page.getByRole('button', { name: 'Add' }).click();
+	await expect(page.getByText('Asset added successfully')).toBeVisible();
+	await expect(page).toHaveURL('/assets');
+
+	await page.getByRole('link', { name: 'Art Piece' }).click();
+	await expect(page.getByLabel('Market value')).toHaveValue('$5,000.00');
+	await expect(page.getByLabel('Book value')).toHaveValue('');
+});
+
 test('user can edit asset details and update balance', async ({ page }) => {
 	const user = await seedUser('maya');
 
@@ -416,9 +442,9 @@ test('user can edit shares asset and update balance', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('Apple Inc');
 	await expect(page.getByLabel('Symbol')).toHaveValue('AAPL');
 	await expect(page.getByLabel('Type', { exact: true })).toBeDisabled();
-	await expect(page.getByLabel('Quantity')).toHaveValue('100');
-	await expect(page.getByLabel('Market price')).toHaveValue('60');
-	await expect(page.getByLabel('Book price')).toHaveValue('50');
+	await expect(page.getByLabel('Quantity')).toHaveValue('$100');
+	await expect(page.getByLabel('Market price')).toHaveValue('$60');
+	await expect(page.getByLabel('Book price')).toHaveValue('$50');
 
 	await page.getByLabel('Name').fill('NVIDIA Corporation');
 	await page.getByLabel('Symbol').fill('NVDA');
@@ -451,9 +477,9 @@ test('user can edit shares asset and update balance', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('NVIDIA Corporation');
 	await expect(page.getByLabel('Symbol')).toHaveValue('NVDA');
 	await expect(page.getByLabel('Category')).toHaveValue('Securities');
-	await expect(page.getByLabel('Quantity')).toHaveValue('150');
-	await expect(page.getByLabel('Market price')).toHaveValue('75');
-	await expect(page.getByLabel('Book price')).toHaveValue('50');
+	await expect(page.getByLabel('Quantity')).toHaveValue('$150');
+	await expect(page.getByLabel('Market price')).toHaveValue('$75');
+	await expect(page.getByLabel('Book price')).toHaveValue('$50');
 });
 
 test('user can directly navigate to asset edit page', async ({ page }) => {
@@ -481,8 +507,8 @@ test('user can directly navigate to asset edit page', async ({ page }) => {
 	await expect(page).toHaveURL(`/assets/${vehicle.id}`);
 	await expect(page.getByLabel('Name')).toHaveValue('2020 Honda Civic');
 	await expect(page.getByLabel('Category')).toHaveValue('Vehicle');
-	await expect(page.getByLabel('Market value')).toHaveValue('18500');
-	await expect(page.getByLabel('Book value')).toHaveValue('20000');
+	await expect(page.getByLabel('Market value')).toHaveValue('$18,500');
+	await expect(page.getByLabel('Book value')).toHaveValue('$20,000');
 });
 
 test('user sees stale data warning and can refresh form', async ({ page }) => {

--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -442,9 +442,9 @@ test('user can edit shares asset and update balance', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('Apple Inc');
 	await expect(page.getByLabel('Symbol')).toHaveValue('AAPL');
 	await expect(page.getByLabel('Type', { exact: true })).toBeDisabled();
-	await expect(page.getByLabel('Quantity')).toHaveValue('$100');
-	await expect(page.getByLabel('Market price')).toHaveValue('$60');
-	await expect(page.getByLabel('Book price')).toHaveValue('$50');
+	await expect(page.getByLabel('Quantity')).toHaveValue('$100.00');
+	await expect(page.getByLabel('Market price')).toHaveValue('$60.00');
+	await expect(page.getByLabel('Book price')).toHaveValue('$50.00');
 
 	await page.getByLabel('Name').fill('NVIDIA Corporation');
 	await page.getByLabel('Symbol').fill('NVDA');
@@ -477,9 +477,9 @@ test('user can edit shares asset and update balance', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('NVIDIA Corporation');
 	await expect(page.getByLabel('Symbol')).toHaveValue('NVDA');
 	await expect(page.getByLabel('Category')).toHaveValue('Securities');
-	await expect(page.getByLabel('Quantity')).toHaveValue('$150');
-	await expect(page.getByLabel('Market price')).toHaveValue('$75');
-	await expect(page.getByLabel('Book price')).toHaveValue('$50');
+	await expect(page.getByLabel('Quantity')).toHaveValue('$150.00');
+	await expect(page.getByLabel('Market price')).toHaveValue('$75.00');
+	await expect(page.getByLabel('Book price')).toHaveValue('$50.00');
 });
 
 test('user can directly navigate to asset edit page', async ({ page }) => {
@@ -507,8 +507,8 @@ test('user can directly navigate to asset edit page', async ({ page }) => {
 	await expect(page).toHaveURL(`/assets/${vehicle.id}`);
 	await expect(page.getByLabel('Name')).toHaveValue('2020 Honda Civic');
 	await expect(page.getByLabel('Category')).toHaveValue('Vehicle');
-	await expect(page.getByLabel('Market value')).toHaveValue('$18,500');
-	await expect(page.getByLabel('Book value')).toHaveValue('$20,000');
+	await expect(page.getByLabel('Market value')).toHaveValue('$18,500.00');
+	await expect(page.getByLabel('Book value')).toHaveValue('$20,000.00');
 });
 
 test('user sees stale data warning and can refresh form', async ({ page }) => {

--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -709,7 +709,7 @@ test('user can edit transaction details', async ({ page }) => {
 	await page.getByRole('link', { name: 'Paperclip Office Supply Co' }).click();
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Paperclip Office Supply Co');
-	await expect(page.getByLabel('Amount')).toHaveValue('-150');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$150');
 	await expect(page.getByLabel('Date')).toHaveValue(formatDateForInput(initialDate));
 	await expect(page.getByLabel('Account')).toHaveText('Northwind Business');
 	await expect(page.getByLabel('Labels')).toHaveValue('Office Supplies');
@@ -736,7 +736,7 @@ test('user can edit transaction details', async ({ page }) => {
 	await page.getByRole('link', { name: 'Skyward Airlines Conference Trip' }).click();
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Skyward Airlines Conference Trip');
-	await expect(page.getByLabel('Amount')).toHaveValue('-450');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$450');
 	await expect(page.getByLabel('Date')).toHaveValue(updatedDateStr);
 	await expect(page.getByLabel('Account')).toHaveText('Eastgate Savings');
 	await expect(page.getByLabel('Labels')).toHaveValue('Business Travel, Conference');
@@ -790,7 +790,7 @@ test('user can directly navigate to transaction edit page', async ({ page }) => 
 	await page.goto(`/transactions/${transaction.id}`);
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Greenleaf Pharmacy');
-	await expect(page.getByLabel('Amount')).toHaveValue('-85');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$85');
 	await expect(page.getByLabel('Date')).toHaveValue(formatDateForInput(transactionDate));
 	await expect(page.getByLabel('Account')).toHaveText('Riverside Community');
 });

--- a/e2e/transactions.test.ts
+++ b/e2e/transactions.test.ts
@@ -709,7 +709,7 @@ test('user can edit transaction details', async ({ page }) => {
 	await page.getByRole('link', { name: 'Paperclip Office Supply Co' }).click();
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Paperclip Office Supply Co');
-	await expect(page.getByLabel('Amount')).toHaveValue('-$150');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$150.00');
 	await expect(page.getByLabel('Date')).toHaveValue(formatDateForInput(initialDate));
 	await expect(page.getByLabel('Account')).toHaveText('Northwind Business');
 	await expect(page.getByLabel('Labels')).toHaveValue('Office Supplies');
@@ -736,7 +736,7 @@ test('user can edit transaction details', async ({ page }) => {
 	await page.getByRole('link', { name: 'Skyward Airlines Conference Trip' }).click();
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Skyward Airlines Conference Trip');
-	await expect(page.getByLabel('Amount')).toHaveValue('-$450');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$450.00');
 	await expect(page.getByLabel('Date')).toHaveValue(updatedDateStr);
 	await expect(page.getByLabel('Account')).toHaveText('Eastgate Savings');
 	await expect(page.getByLabel('Labels')).toHaveValue('Business Travel, Conference');
@@ -790,7 +790,7 @@ test('user can directly navigate to transaction edit page', async ({ page }) => 
 	await page.goto(`/transactions/${transaction.id}`);
 	await expect(page).toHaveURL(`/transactions/${transaction.id}`);
 	await expect(page.getByLabel('Description')).toHaveValue('Greenleaf Pharmacy');
-	await expect(page.getByLabel('Amount')).toHaveValue('-$85');
+	await expect(page.getByLabel('Amount')).toHaveValue('-$85.00');
 	await expect(page.getByLabel('Date')).toHaveValue(formatDateForInput(transactionDate));
 	await expect(page.getByLabel('Account')).toHaveText('Riverside Community');
 });

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
 		"pb:import": "bun scripts/pb-import.ts",
 		"pb:reset": "bun scripts/pb-reset.ts"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@canutin/svelte-currency-input": "^1.0.0-next.7"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
 	"name": "canutin-next",
 	"version": "2.0.0-next.19",
 	"devDependencies": {
-		"@semantic-release/commit-analyzer": "^13.0.1",
-		"@semantic-release/git": "^10.0.1",
-		"@semantic-release/github": "^12.0.2",
-		"@semantic-release/npm": "^13.1.1",
-		"@semantic-release/release-notes-generator": "^14.1.0",
-		"semantic-release": "^25.0.2",
+		"@canutin/svelte-currency-input": "^1.0.0-next.7",
 		"@date-fns/utc": "^2.1.1",
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
@@ -16,6 +11,11 @@
 		"@internationalized/date": "^3.8.1",
 		"@lucide/svelte": "^0.515.0",
 		"@playwright/test": "^1.49.1",
+		"@semantic-release/commit-analyzer": "^13.0.1",
+		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/github": "^12.0.2",
+		"@semantic-release/npm": "^13.1.1",
+		"@semantic-release/release-notes-generator": "^14.1.0",
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.22.0",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -42,6 +42,7 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.6.11",
+		"semantic-release": "^25.0.2",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"svelte-sonner": "^1.0.5",
@@ -71,8 +72,5 @@
 		"pb:import": "bun scripts/pb-import.ts",
 		"pb:reset": "bun scripts/pb-reset.ts"
 	},
-	"type": "module",
-	"dependencies": {
-		"@canutin/svelte-currency-input": "^1.0.0-next.7"
-	}
+	"type": "module"
 }

--- a/scripts/pb-import.ts
+++ b/scripts/pb-import.ts
@@ -371,8 +371,8 @@ async function main() {
 		await pb.collection('assetBalances').create({
 			asset: pbAssetId,
 			marketValue: s.value,
-			quantity: s.quantity ?? undefined,
-			bookValue: s.cost ?? undefined,
+			quantity: s.quantity || undefined,
+			bookValue: s.cost || undefined,
 			asOf: toISODate(s.createdAt),
 			owner: importUserId
 		});

--- a/src/lib/components/currency-field.svelte
+++ b/src/lib/components/currency-field.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { CurrencyInput, formatValue } from '@canutin/svelte-currency-input';
+
+	interface Props {
+		id: string;
+		name?: string;
+		value: string;
+		required?: boolean;
+	}
+
+	let { id, name, value = $bindable(), required = false }: Props = $props();
+
+	const intlConfig = { locale: 'en-US', currency: 'USD' };
+
+	const placeholder = formatValue({ value: '0', intlConfig, decimalScale: 2 });
+
+	const baseClass =
+		'border-input bg-background ring-offset-background selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground dark:bg-input/30 flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] font-mono';
+
+	function getValueColor(val: string) {
+		if (!val || val === '-') return '';
+		const num = parseFloat(val);
+		if (num === 0) return '';
+		return num < 0 ? 'text-rose-600' : 'text-emerald-600';
+	}
+</script>
+
+<CurrencyInput
+	{id}
+	{name}
+	bind:value
+	{required}
+	{intlConfig}
+	{placeholder}
+	decimalScale={2}
+	class="{baseClass} {getValueColor(value)}"
+/>

--- a/src/routes/(app)/accounts/[id]/balance-form.svelte
+++ b/src/routes/(app)/accounts/[id]/balance-form.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { m } from '$lib/paraglide/messages';
 
@@ -29,7 +29,7 @@
 				<Label for="value" class="justify-start pr-0 md:justify-end"
 					>{m.accounts_label_balance()}</Label
 				>
-				<Input id="value" type="number" step="0.01" bind:value={formData.value} />
+				<CurrencyField id="value" name="value" bind:value={formData.value} />
 			</FormFieldRow>
 		</Fieldset>
 

--- a/src/routes/(app)/accounts/add/+page.svelte
+++ b/src/routes/(app)/accounts/add/+page.svelte
@@ -5,6 +5,7 @@
 	import { resolve } from '$app/paths';
 	import { getAuthContext } from '$lib/auth.svelte';
 	import { getBalanceTypesContext } from '$lib/balance-types.svelte';
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -203,7 +204,7 @@
 						<Label for="value" class="justify-start pr-0 md:justify-end"
 							>{m.accounts_label_balance()}</Label
 						>
-						<Input id="value" type="number" step="0.01" bind:value />
+						<CurrencyField id="value" name="value" bind:value />
 					</FormFieldRow>
 				</Fieldset>
 

--- a/src/routes/(app)/assets/[id]/+page.svelte
+++ b/src/routes/(app)/assets/[id]/+page.svelte
@@ -84,6 +84,10 @@
 		return `${assetData.updated || assetData.created}_${assetData.name}_${assetData.balanceGroup}_${assetData.symbol}_${assetData.excluded}_${assetData.sold}_${assetData.marketValue}_${assetData.bookValue}_${assetData.quantity}_${assetData.bookPrice}_${assetData.marketPrice}`;
 	}
 
+	function toFieldValue(value: number | null | undefined) {
+		return value ? value.toString() : '';
+	}
+
 	async function syncFormWithAsset(assetData: typeof asset) {
 		if (!assetData) return;
 
@@ -96,15 +100,14 @@
 			sold: Boolean(assetData.sold),
 			type: assetData.type ?? '',
 			bookValue:
-				assetData.type === AssetsTypeOptions.WHOLE ? (assetData.bookValue?.toString() ?? '') : '',
+				assetData.type === AssetsTypeOptions.WHOLE ? toFieldValue(assetData.bookValue) : '',
 			marketValue:
-				assetData.type === AssetsTypeOptions.WHOLE ? (assetData.marketValue?.toString() ?? '') : '',
-			quantity:
-				assetData.type === AssetsTypeOptions.SHARES ? (assetData.quantity?.toString() ?? '') : '',
+				assetData.type === AssetsTypeOptions.WHOLE ? toFieldValue(assetData.marketValue) : '',
+			quantity: assetData.type === AssetsTypeOptions.SHARES ? toFieldValue(assetData.quantity) : '',
 			bookPrice:
-				assetData.type === AssetsTypeOptions.SHARES ? (assetData.bookPrice?.toString() ?? '') : '',
+				assetData.type === AssetsTypeOptions.SHARES ? toFieldValue(assetData.bookPrice) : '',
 			marketPrice:
-				assetData.type === AssetsTypeOptions.SHARES ? (assetData.marketPrice?.toString() ?? '') : ''
+				assetData.type === AssetsTypeOptions.SHARES ? toFieldValue(assetData.marketPrice) : ''
 		};
 
 		await balanceTypesContext.ensureLoaded(assetData.balanceType);

--- a/src/routes/(app)/assets/[id]/balance-form.svelte
+++ b/src/routes/(app)/assets/[id]/balance-form.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { m } from '$lib/paraglide/messages';
 
@@ -36,7 +36,7 @@
 					<Label for="market-value" class="justify-start pr-0 md:justify-end"
 						>{m.assets_label_market_value()}</Label
 					>
-					<Input id="market-value" type="number" step="0.01" bind:value={formData.marketValue} />
+					<CurrencyField id="market-value" name="market-value" bind:value={formData.marketValue} />
 				</FormFieldRow>
 
 				<FormFieldRow>
@@ -46,21 +46,21 @@
 						>
 						<span class="text-muted-foreground text-sm">{m.assets_text_optional()}</span>
 					</div>
-					<Input id="book-value" type="number" step="0.01" bind:value={formData.bookValue} />
+					<CurrencyField id="book-value" name="book-value" bind:value={formData.bookValue} />
 				</FormFieldRow>
 			{:else if isShares}
 				<FormFieldRow>
 					<Label for="quantity" class="justify-start pr-0 md:justify-end"
 						>{m.assets_label_quantity()}</Label
 					>
-					<Input id="quantity" type="number" step="0.01" bind:value={formData.quantity} />
+					<CurrencyField id="quantity" name="quantity" bind:value={formData.quantity} />
 				</FormFieldRow>
 
 				<FormFieldRow>
 					<Label for="market-price" class="justify-start pr-0 md:justify-end"
 						>{m.assets_label_market_price()}</Label
 					>
-					<Input id="market-price" type="number" step="0.01" bind:value={formData.marketPrice} />
+					<CurrencyField id="market-price" name="market-price" bind:value={formData.marketPrice} />
 				</FormFieldRow>
 
 				<FormFieldRow>
@@ -70,7 +70,7 @@
 						>
 						<span class="text-muted-foreground text-sm">{m.assets_text_optional()}</span>
 					</div>
-					<Input id="book-price" type="number" step="0.01" bind:value={formData.bookPrice} />
+					<CurrencyField id="book-price" name="book-price" bind:value={formData.bookPrice} />
 				</FormFieldRow>
 			{/if}
 		</Fieldset>

--- a/src/routes/(app)/assets/add/+page.svelte
+++ b/src/routes/(app)/assets/add/+page.svelte
@@ -5,6 +5,7 @@
 	import { resolve } from '$app/paths';
 	import { getAuthContext } from '$lib/auth.svelte';
 	import { getBalanceTypesContext } from '$lib/balance-types.svelte';
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -264,7 +265,7 @@
 							<Label for="market-value" class="justify-start pr-0 md:justify-end"
 								>{m.assets_label_market_value()}</Label
 							>
-							<Input id="market-value" type="number" step="0.01" bind:value={marketValue} />
+							<CurrencyField id="market-value" name="market-value" bind:value={marketValue} />
 						</FormFieldRow>
 
 						<FormFieldRow>
@@ -274,21 +275,21 @@
 								>
 								<span class="text-muted-foreground text-sm">{m.assets_text_optional()}</span>
 							</div>
-							<Input id="book-value" type="number" step="0.01" bind:value={bookValue} />
+							<CurrencyField id="book-value" name="book-value" bind:value={bookValue} />
 						</FormFieldRow>
 					{:else if isShares}
 						<FormFieldRow>
 							<Label for="quantity" class="justify-start pr-0 md:justify-end"
 								>{m.assets_label_quantity()}</Label
 							>
-							<Input id="quantity" type="number" step="0.01" bind:value={quantity} />
+							<CurrencyField id="quantity" name="quantity" bind:value={quantity} />
 						</FormFieldRow>
 
 						<FormFieldRow>
 							<Label for="market-price" class="justify-start pr-0 md:justify-end"
 								>{m.assets_label_market_price()}</Label
 							>
-							<Input id="market-price" type="number" step="0.01" bind:value={marketPrice} />
+							<CurrencyField id="market-price" name="market-price" bind:value={marketPrice} />
 						</FormFieldRow>
 
 						<FormFieldRow>
@@ -298,7 +299,7 @@
 								>
 								<span class="text-muted-foreground text-sm">{m.assets_text_optional()}</span>
 							</div>
-							<Input id="book-price" type="number" step="0.01" bind:value={bookPrice} />
+							<CurrencyField id="book-price" name="book-price" bind:value={bookPrice} />
 						</FormFieldRow>
 					{/if}
 				</Fieldset>

--- a/src/routes/(app)/transactions/[id]/+page.svelte
+++ b/src/routes/(app)/transactions/[id]/+page.svelte
@@ -7,6 +7,7 @@
 	import { page } from '$app/state';
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAuthContext } from '$lib/auth.svelte';
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -232,7 +233,7 @@
 							<Label for="amount" class="justify-start pr-0 md:justify-end"
 								>{m.transactions_label_amount()}</Label
 							>
-							<Input id="amount" type="number" step="0.01" bind:value={formData.amount} required />
+							<CurrencyField id="amount" name="amount" bind:value={formData.amount} required />
 						</FormFieldRow>
 
 						<FormFieldRow>

--- a/src/routes/(app)/transactions/add/+page.svelte
+++ b/src/routes/(app)/transactions/add/+page.svelte
@@ -6,6 +6,7 @@
 	import { resolve } from '$app/paths';
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAuthContext } from '$lib/auth.svelte';
+	import CurrencyField from '$lib/components/currency-field.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -156,7 +157,7 @@
 						<Label for="amount" class="justify-start pr-0 md:justify-end"
 							>{m.transactions_label_amount()}</Label
 						>
-						<Input id="amount" type="number" step="0.01" bind:value={amount} required />
+						<CurrencyField id="amount" name="amount" bind:value={amount} required />
 					</FormFieldRow>
 
 					<FormFieldRow>


### PR DESCRIPTION
## Summary
- Add `CurrencyField` component wrapping `@canutin/svelte-currency-input@next`
- Replace number inputs with `CurrencyField` across accounts, assets, and transactions forms
- Format values with USD currency, 2 decimal places, monospace font, and color coding (green for positive, red for negative)
- Show `$0.00` placeholder for empty/zero optional fields
- Fix `pb-import` script to not set `0` for optional balance fields

Closes #262