### PR TITLE
fix: prevent race conditions in realtime subscriptions

### DIFF
--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -94,7 +94,9 @@ class AccountsContext {
 		const newValue = e.record.value ?? 0;
 
 		if (e.action === 'create' || e.action === 'update') {
-			// Optimistic update: use the value from the event directly
+			// Optimistic update: use the value from the event directly.
+			// If account isn't loaded yet (event arrived during initial fetch), we ignore it.
+			// This is safe because init() fetches the latest balance for each account after loading.
 			const account = this.accounts.find((x) => x.id === accountId);
 			if (!account) return;
 

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -5,7 +5,7 @@ import { setBalanceTypesContext } from './balance-types.svelte';
 import type { AccountBalancesResponse, AccountsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
-type AccountWithBalance = AccountsResponse & { balance: number };
+type AccountWithBalance = AccountsResponse & { balance: number; balanceAsOf: string };
 
 class AccountsContext {
 	accounts: AccountWithBalance[] = $state([]);
@@ -38,16 +38,20 @@ class AccountsContext {
 
 	private async init() {
 		try {
+			// Subscribe FIRST to avoid missing events during initial fetch
+			this.realtimeSubscribe();
+
 			const list = await this._pb.authedClient
 				.collection('accounts')
 				.getFullList<AccountsResponse>();
-			this.accounts = list.map((a) => ({ ...a, balance: 0 }));
+			this.accounts = list.map((a) => ({ ...a, balance: 0, balanceAsOf: '' }));
 			for (const a of this.accounts) {
-				const value = await this.getLatestAccountBalance(a.id);
-				this.accounts = this.accounts.map((x) => (x.id === a.id ? { ...x, balance: value } : x));
+				const balanceData = await this.getLatestAccountBalance(a.id);
+				this.accounts = this.accounts.map((x) =>
+					x.id === a.id ? { ...x, balance: balanceData.value, balanceAsOf: balanceData.asOf } : x
+				);
 			}
 			this.lastBalanceEvent = Date.now();
-			this.realtimeSubscribe();
 			this.isLoading = false;
 		} catch (error) {
 			this._pb.handleConnectionError(error, 'accounts', 'init');
@@ -69,27 +73,53 @@ class AccountsContext {
 	private async onAccountEvent(e: RecordSubscription<AccountsResponse>) {
 		if (e.action === 'create') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
-			this.accounts = [...this.accounts, { ...e.record, balance: 0 }];
+			this.accounts = [...this.accounts, { ...e.record, balance: 0, balanceAsOf: '' }];
 		} else if (e.action === 'update') {
-			const balance = this.accounts.find((a) => a.id === e.record.id)?.balance ?? 0;
+			const existing = this.accounts.find((a) => a.id === e.record.id);
+			const balance = existing?.balance ?? 0;
+			const balanceAsOf = existing?.balanceAsOf ?? '';
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			this.accounts = this.accounts.map((x) =>
-				x.id === e.record.id ? { ...e.record, balance } : x
+				x.id === e.record.id ? { ...e.record, balance, balanceAsOf } : x
 			);
 		} else if (e.action === 'delete') {
 			this.accounts = this.accounts.filter((x) => x.id !== e.record.id);
 		}
 	}
 
-	private async onAccountBalanceEvent(e: RecordSubscription<AccountBalancesResponse>) {
+	private onAccountBalanceEvent(e: RecordSubscription<AccountBalancesResponse>) {
 		if (!e.action) return;
 		const accountId = e.record.account;
+		const newAsOf = e.record.asOf;
+		const newValue = e.record.value ?? 0;
+
+		if (e.action === 'create' || e.action === 'update') {
+			// Optimistic update: use the value from the event directly
+			const account = this.accounts.find((x) => x.id === accountId);
+			if (!account) return;
+
+			// Only update if this balance is newer than what we have
+			if (!account.balanceAsOf || newAsOf >= account.balanceAsOf) {
+				this.accounts = this.accounts.map((x) =>
+					x.id === accountId ? { ...x, balance: newValue, balanceAsOf: newAsOf } : x
+				);
+				this.lastBalanceEvent = Date.now();
+			}
+		} else if (e.action === 'delete') {
+			// When a balance is deleted, we need to re-fetch to get the next most recent
+			this.refetchAccountBalance(accountId);
+		}
+	}
+
+	private async refetchAccountBalance(accountId: string) {
 		try {
-			const value = await this.getLatestAccountBalance(accountId);
-			this.accounts = this.accounts.map((x) => (x.id === accountId ? { ...x, balance: value } : x));
+			const balanceData = await this.getLatestAccountBalance(accountId);
+			this.accounts = this.accounts.map((x) =>
+				x.id === accountId ? { ...x, balance: balanceData.value, balanceAsOf: balanceData.asOf } : x
+			);
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
-			console.error('[accounts:update_balance_on_event]', error);
+			console.error('[accounts:refetch_balance]', error);
 		}
 	}
 
@@ -100,7 +130,8 @@ class AccountsContext {
 				filter: `account='${accountId}'`,
 				sort: '-asOf,-created,-id'
 			});
-		return res.items[0]?.value ?? 0;
+		const item = res.items[0];
+		return { value: item?.value ?? 0, asOf: item?.asOf ?? '' };
 	}
 
 	dispose() {

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -100,7 +100,8 @@ class AccountsContext {
 			const account = this.accounts.find((x) => x.id === accountId);
 			if (!account) return;
 
-			// Only update if this balance is newer than what we have
+			// Only update if this balance is newer than what we have.
+			// String comparison works because ISO 8601 dates are lexicographically sortable.
 			if (!account.balanceAsOf || newAsOf >= account.balanceAsOf) {
 				this.accounts = this.accounts.map((x) =>
 					x.id === accountId ? { ...x, balance: newValue, balanceAsOf: newAsOf } : x

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -110,7 +110,7 @@ class AccountsContext {
 			}
 		} else if (e.action === 'delete') {
 			// When a balance is deleted, we need to re-fetch to get the next most recent
-			this.refetchAccountBalance(accountId);
+			void this.refetchAccountBalance(accountId);
 		}
 	}
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -125,7 +125,8 @@ class AssetsContext {
 			const asset = this.assets.find((x) => x.id === assetId);
 			if (!asset) return;
 
-			// Only update if this balance is newer than what we have
+			// Only update if this balance is newer than what we have.
+			// String comparison works because ISO 8601 dates are lexicographically sortable.
 			if (!asset.balanceAsOf || newAsOf >= asset.balanceAsOf) {
 				const balanceData = this.computeBalanceData(e.record);
 				this.assets = this.assets.map((x) => (x.id === assetId ? { ...x, ...balanceData } : x));

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -134,7 +134,7 @@ class AssetsContext {
 			}
 		} else if (e.action === 'delete') {
 			// When a balance is deleted, we need to re-fetch to get the next most recent
-			this.refetchAssetBalance(assetId);
+			void this.refetchAssetBalance(assetId);
 		}
 	}
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -16,6 +16,17 @@ type AssetBalanceData = {
 	balanceAsOf: string;
 };
 
+const DEFAULT_BALANCE_DATA: AssetBalanceData = {
+	marketValue: 0,
+	bookValue: 0,
+	gain: 0,
+	gainPercent: 0,
+	quantity: undefined,
+	bookPrice: undefined,
+	marketPrice: undefined,
+	balanceAsOf: ''
+};
+
 export type AssetWithBalance = AssetsResponse & AssetBalanceData;
 
 class AssetsContext {
@@ -53,17 +64,7 @@ class AssetsContext {
 			this.realtimeSubscribe();
 
 			const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>();
-			this.assets = list.map((a) => ({
-				...a,
-				marketValue: 0,
-				bookValue: 0,
-				gain: 0,
-				gainPercent: 0,
-				quantity: undefined,
-				bookPrice: undefined,
-				marketPrice: undefined,
-				balanceAsOf: ''
-			}));
+			this.assets = list.map((a) => ({ ...a, ...DEFAULT_BALANCE_DATA }));
 			for (const a of this.assets) {
 				const balanceData = await this.getLatestAssetBalance(a.id);
 				this.assets = this.assets.map((x) => (x.id === a.id ? { ...x, ...balanceData } : x));
@@ -90,20 +91,7 @@ class AssetsContext {
 	private async onAssetEvent(e: RecordSubscription<AssetsResponse>) {
 		if (e.action === 'create') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
-			this.assets = [
-				...this.assets,
-				{
-					...e.record,
-					marketValue: 0,
-					bookValue: 0,
-					gain: 0,
-					gainPercent: 0,
-					quantity: undefined,
-					bookPrice: undefined,
-					marketPrice: undefined,
-					balanceAsOf: ''
-				}
-			];
+			this.assets = [...this.assets, { ...e.record, ...DEFAULT_BALANCE_DATA }];
 		} else if (e.action === 'update') {
 			const existing = this.assets.find((a) => a.id === e.record.id);
 			const balanceData: AssetBalanceData = {
@@ -184,18 +172,7 @@ class AssetsContext {
 				sort: '-asOf,-created,-id'
 			});
 		const balance = res.items[0];
-		if (!balance) {
-			return {
-				marketValue: 0,
-				bookValue: 0,
-				gain: 0,
-				gainPercent: 0,
-				quantity: undefined,
-				bookPrice: undefined,
-				marketPrice: undefined,
-				balanceAsOf: ''
-			};
-		}
+		if (!balance) return DEFAULT_BALANCE_DATA;
 		return this.computeBalanceData(balance);
 	}
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -131,7 +131,9 @@ class AssetsContext {
 		const newAsOf = e.record.asOf;
 
 		if (e.action === 'create' || e.action === 'update') {
-			// Optimistic update: use the value from the event directly
+			// Optimistic update: use the value from the event directly.
+			// If asset isn't loaded yet (event arrived during initial fetch), we ignore it.
+			// This is safe because init() fetches the latest balance for each asset after loading.
 			const asset = this.assets.find((x) => x.id === assetId);
 			if (!asset) return;
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -5,7 +5,7 @@ import { setBalanceTypesContext } from './balance-types.svelte';
 import type { AssetBalancesResponse, AssetsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
-export type AssetWithBalance = AssetsResponse & {
+type AssetBalanceData = {
 	marketValue: number;
 	bookValue: number;
 	gain: number;
@@ -13,7 +13,10 @@ export type AssetWithBalance = AssetsResponse & {
 	quantity?: number;
 	bookPrice?: number;
 	marketPrice?: number;
+	balanceAsOf: string;
 };
+
+export type AssetWithBalance = AssetsResponse & AssetBalanceData;
 
 class AssetsContext {
 	assets: AssetWithBalance[] = $state([]);
@@ -46,6 +49,9 @@ class AssetsContext {
 
 	private async init() {
 		try {
+			// Subscribe FIRST to avoid missing events during initial fetch
+			this.realtimeSubscribe();
+
 			const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>();
 			this.assets = list.map((a) => ({
 				...a,
@@ -55,14 +61,14 @@ class AssetsContext {
 				gainPercent: 0,
 				quantity: undefined,
 				bookPrice: undefined,
-				marketPrice: undefined
+				marketPrice: undefined,
+				balanceAsOf: ''
 			}));
 			for (const a of this.assets) {
 				const balanceData = await this.getLatestAssetBalance(a.id);
 				this.assets = this.assets.map((x) => (x.id === a.id ? { ...x, ...balanceData } : x));
 			}
 			this.lastBalanceEvent = Date.now();
-			this.realtimeSubscribe();
 			this.isLoading = false;
 		} catch (error) {
 			this._pb.handleConnectionError(error, 'assets', 'init');
@@ -94,19 +100,21 @@ class AssetsContext {
 					gainPercent: 0,
 					quantity: undefined,
 					bookPrice: undefined,
-					marketPrice: undefined
+					marketPrice: undefined,
+					balanceAsOf: ''
 				}
 			];
 		} else if (e.action === 'update') {
 			const existing = this.assets.find((a) => a.id === e.record.id);
-			const balanceData = {
+			const balanceData: AssetBalanceData = {
 				marketValue: existing?.marketValue ?? 0,
 				bookValue: existing?.bookValue ?? 0,
 				gain: existing?.gain ?? 0,
 				gainPercent: existing?.gainPercent ?? 0,
 				quantity: existing?.quantity,
 				bookPrice: existing?.bookPrice,
-				marketPrice: existing?.marketPrice
+				marketPrice: existing?.marketPrice,
+				balanceAsOf: existing?.balanceAsOf ?? ''
 			};
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			this.assets = this.assets.map((x) =>
@@ -117,28 +125,31 @@ class AssetsContext {
 		}
 	}
 
-	private async onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>) {
+	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>) {
 		if (!e.action) return;
 		const assetId = e.record.asset;
-		try {
-			const balanceData = await this.getLatestAssetBalance(assetId);
-			this.assets = this.assets.map((x) => (x.id === assetId ? { ...x, ...balanceData } : x));
-			this.lastBalanceEvent = Date.now();
-		} catch (error) {
-			console.error('[assets:update_balance_on_event]', error);
+		const newAsOf = e.record.asOf;
+
+		if (e.action === 'create' || e.action === 'update') {
+			// Optimistic update: use the value from the event directly
+			const asset = this.assets.find((x) => x.id === assetId);
+			if (!asset) return;
+
+			// Only update if this balance is newer than what we have
+			if (!asset.balanceAsOf || newAsOf >= asset.balanceAsOf) {
+				const balanceData = this.computeBalanceData(e.record);
+				this.assets = this.assets.map((x) => (x.id === assetId ? { ...x, ...balanceData } : x));
+				this.lastBalanceEvent = Date.now();
+			}
+		} else if (e.action === 'delete') {
+			// When a balance is deleted, we need to re-fetch to get the next most recent
+			this.refetchAssetBalance(assetId);
 		}
 	}
 
-	private async getLatestAssetBalance(assetId: string) {
-		const res = await this._pb.authedClient
-			.collection('assetBalances')
-			.getList<AssetBalancesResponse>(1, 1, {
-				filter: `asset='${assetId}'`,
-				sort: '-asOf,-created,-id'
-			});
-		const balance = res.items[0];
-		const marketValue = balance?.marketValue ?? 0;
-		const bookValue = balance?.bookValue ?? 0;
+	private computeBalanceData(balance: AssetBalancesResponse): AssetBalanceData {
+		const marketValue = balance.marketValue ?? 0;
+		const bookValue = balance.bookValue ?? 0;
 		const gain = marketValue - bookValue;
 		const gainPercent = bookValue !== 0 ? (gain / bookValue) * 100 : 0;
 		return {
@@ -146,10 +157,44 @@ class AssetsContext {
 			bookValue,
 			gain,
 			gainPercent,
-			quantity: balance?.quantity,
-			bookPrice: balance?.bookPrice,
-			marketPrice: balance?.marketPrice
+			quantity: balance.quantity,
+			bookPrice: balance.bookPrice,
+			marketPrice: balance.marketPrice,
+			balanceAsOf: balance.asOf
 		};
+	}
+
+	private async refetchAssetBalance(assetId: string) {
+		try {
+			const balanceData = await this.getLatestAssetBalance(assetId);
+			this.assets = this.assets.map((x) => (x.id === assetId ? { ...x, ...balanceData } : x));
+			this.lastBalanceEvent = Date.now();
+		} catch (error) {
+			console.error('[assets:refetch_balance]', error);
+		}
+	}
+
+	private async getLatestAssetBalance(assetId: string): Promise<AssetBalanceData> {
+		const res = await this._pb.authedClient
+			.collection('assetBalances')
+			.getList<AssetBalancesResponse>(1, 1, {
+				filter: `asset='${assetId}'`,
+				sort: '-asOf,-created,-id'
+			});
+		const balance = res.items[0];
+		if (!balance) {
+			return {
+				marketValue: 0,
+				bookValue: 0,
+				gain: 0,
+				gainPercent: 0,
+				quantity: undefined,
+				bookPrice: undefined,
+				marketPrice: undefined,
+				balanceAsOf: ''
+			};
+		}
+		return this.computeBalanceData(balance);
 	}
 
 	dispose() {

--- a/src/lib/balance-types.svelte.ts
+++ b/src/lib/balance-types.svelte.ts
@@ -15,6 +15,8 @@ class BalanceTypesContext {
 	}
 
 	private async init() {
+		// Subscribe FIRST to avoid missing events during initial fetch
+		this.realtimeSubscribe();
 		try {
 			const list = await this._pb.authedClient
 				.collection('balanceTypes')
@@ -22,7 +24,6 @@ class BalanceTypesContext {
 			const map: Record<string, BalanceTypesResponse> = {};
 			for (const bt of list) map[bt.id] = bt;
 			this.byId = map;
-			this.realtimeSubscribe();
 		} catch (error) {
 			this._pb.handleConnectionError(error, 'balance_types', 'init');
 		}

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -23,8 +23,9 @@ class CashflowContext {
 
 	private async init() {
 		try {
-			await this.recomputeAll();
+			// Subscribe FIRST to avoid missing events during initial fetch
 			this.realtimeSubscribe();
+			await this.recomputeAll();
 		} catch (error) {
 			this._pb.handleConnectionError(error, 'cashflow', 'init');
 		}

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -136,8 +136,9 @@ class TransactionsContext {
 	}
 
 	private async init() {
-		await this.refreshTransactions();
+		// Subscribe FIRST to avoid missing events during initial fetch
 		this.realtimeSubscribe();
+		await this.refreshTransactions();
 	}
 
 	setSearch(query: string) {


### PR DESCRIPTION
## Summary
- Subscribe to realtime events BEFORE fetching initial data in all contexts (accounts, assets, transactions, cashflow)
- Use optimistic updates for balance events instead of re-fetching
- Track `balanceAsOf` to only apply newer balance updates

Closes #273