### PR TITLE
refactor: use formatValue from svelte-currency-input for currency formatting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "canutinx",
       "devDependencies": {
-        "@canutin/svelte-currency-input": "^1.0.0",
+        "@canutin/svelte-currency-input": "^1.1.1",
         "@date-fns/utc": "^2.1.1",
         "@eslint/compat": "^1.2.5",
         "@eslint/js": "^9.18.0",
@@ -93,7 +93,7 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
-    "@canutin/svelte-currency-input": ["@canutin/svelte-currency-input@1.0.0", "", { "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-10s3Ela2145UbgKUMzntSxZpUy7ks2EuVvQrWAMk8V0RrBE+FkvCKezRZ0UqJSY1bw6vWVnofWwEDWUIWKtbOQ=="],
+    "@canutin/svelte-currency-input": ["@canutin/svelte-currency-input@1.1.1", "", { "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-7huhZ2QFjP9JhfSATmdpNtqA7XZrTUv2xjUBLBPU1edFf5ZucJzPbIe1oY/ofDVgpq8WyXbQCrFntjRKMW0fSw=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "canutin-next",
 	"version": "2.0.0-next.20",
 	"devDependencies": {
-		"@canutin/svelte-currency-input": "^1.0.0",
+		"@canutin/svelte-currency-input": "^1.1.1",
 		"@date-fns/utc": "^2.1.1",
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",

--- a/src/lib/components/currency-field.svelte
+++ b/src/lib/components/currency-field.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { CurrencyInput, formatValue } from '@canutin/svelte-currency-input';
 
+	import { intlConfig } from './currency';
+
 	interface Props {
 		id: string;
 		name?: string;
@@ -9,8 +11,6 @@
 	}
 
 	let { id, name, value = $bindable(), required = false }: Props = $props();
-
-	const intlConfig = { locale: 'en-US', currency: 'USD' };
 
 	const placeholder = formatValue({ value: '0', intlConfig, decimalScale: 2 });
 

--- a/src/lib/components/currency.svelte
+++ b/src/lib/components/currency.svelte
@@ -6,29 +6,13 @@
 
 	interface Props {
 		value: number;
-		currency?: string;
-		locale?: string;
-		maximumFractionDigits?: number;
 		decimalScale?: number;
 		sentiment?: Sentiment;
 	}
 
-	let {
-		value,
-		currency = 'USD',
-		locale = 'en-US',
-		maximumFractionDigits = 0,
-		decimalScale,
-		sentiment = 'undefined'
-	}: Props = $props();
+	let { value, decimalScale = 0, sentiment = 'undefined' }: Props = $props();
 
-	const formattedValue = $derived(
-		formatCurrency(value, {
-			currency,
-			locale,
-			maximumFractionDigits: decimalScale ?? maximumFractionDigits
-		})
-	);
+	const formattedValue = $derived.by(() => formatCurrency(value, decimalScale));
 </script>
 
 <Number value={formattedValue} {sentiment} />

--- a/src/lib/components/currency.ts
+++ b/src/lib/components/currency.ts
@@ -1,14 +1,7 @@
-export type CurrencyFormatOptions = {
-	currency?: string;
-	locale?: string;
-	maximumFractionDigits?: number;
-};
+import { formatValue } from '@canutin/svelte-currency-input';
 
-export function formatCurrency(value: number | null | undefined, options?: CurrencyFormatOptions) {
-	const { currency = 'USD', locale = 'en-US', maximumFractionDigits = 0 } = options ?? {};
-	return new Intl.NumberFormat(locale, {
-		currency,
-		style: 'currency',
-		maximumFractionDigits
-	}).format(value ?? 0);
+export const intlConfig = { locale: 'en-US', currency: 'USD' };
+
+export function formatCurrency(value: number | null | undefined, decimalScale = 0) {
+	return formatValue({ value: String(value ?? 0), intlConfig, decimalScale, roundValue: true });
 }

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -318,7 +318,7 @@
 															>
 																<Currency
 																	value={row.balance}
-																	maximumFractionDigits={2}
+																	decimalScale={2}
 																	sentiment={balanceSentiment(row)}
 																/>
 															</Tooltip.Trigger>
@@ -333,7 +333,7 @@
 													{:else}
 														<Currency
 															value={row.balance}
-															maximumFractionDigits={2}
+															decimalScale={2}
 															sentiment={balanceSentiment(row)}
 														/>
 													{/if}
@@ -350,7 +350,7 @@
 												{@const total = totalsByFilter.get(option.key) ?? 0}
 												<Currency
 													value={total}
-													maximumFractionDigits={2}
+													decimalScale={2}
 													sentiment={total > 0 ? 'positive' : total < 0 ? 'negative' : 'neutral'}
 												/>
 											</Table.Cell>

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -280,16 +280,12 @@
 													</div>
 												</Table.Cell>
 												<Table.Cell class="text-muted-foreground text-right text-xs tabular-nums">
-													<Currency
-														value={row.bookValue}
-														maximumFractionDigits={2}
-														sentiment="neutral"
-													/>
+													<Currency value={row.bookValue} decimalScale={2} sentiment="neutral" />
 												</Table.Cell>
 												<Table.Cell class="text-right text-xs tabular-nums">
 													<Currency
 														value={row.gain}
-														maximumFractionDigits={2}
+														decimalScale={2}
 														sentiment={row.gain > 0
 															? 'positive'
 															: row.gain < 0
@@ -315,7 +311,7 @@
 															>
 																<Currency
 																	value={row.marketValue}
-																	maximumFractionDigits={2}
+																	decimalScale={2}
 																	sentiment={balanceSentiment(row)}
 																/>
 															</Tooltip.Trigger>
@@ -330,7 +326,7 @@
 													{:else}
 														<Currency
 															value={row.marketValue}
-															maximumFractionDigits={2}
+															decimalScale={2}
 															sentiment={balanceSentiment(row)}
 														/>
 													{/if}
@@ -350,7 +346,7 @@
 												{@const total = totalsByFilter.get(option.key) ?? 0}
 												<Currency
 													value={total}
-													maximumFractionDigits={2}
+													decimalScale={2}
 													sentiment={total > 0 ? 'positive' : total < 0 ? 'negative' : 'neutral'}
 												/>
 											</Table.Cell>

--- a/src/routes/(app)/transactions/transaction-table.svelte
+++ b/src/routes/(app)/transactions/transaction-table.svelte
@@ -105,7 +105,7 @@
 									<Tooltip.Trigger
 										class="border-border inline-block border-b border-dashed hover:border-current"
 									>
-										<Currency value={row.value} maximumFractionDigits={2} />
+										<Currency value={row.value} decimalScale={2} />
 									</Tooltip.Trigger>
 									<Tooltip.Content sideOffset={6}>
 										<p class="text-xs leading-snug font-normal">
@@ -114,7 +114,7 @@
 									</Tooltip.Content>
 								</Tooltip.Root>
 							{:else}
-								<Currency value={row.value} maximumFractionDigits={2} />
+								<Currency value={row.value} decimalScale={2} />
 							{/if}
 						</Table.Cell>
 					</Table.Row>

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -309,13 +309,13 @@
 											<Tooltip.Content sideOffset={6}>
 												<p class="font-normal">
 													{m.trends_performance_tooltip_from()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.net.prev, { maximumFractionDigits: 2 })}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.net.prev, 2)}
+													</span>
 													{m.trends_performance_tooltip_to()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.net.cur, { maximumFractionDigits: 2 })}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.net.cur, 2)}
+													</span>
 												</p>
 											</Tooltip.Content>
 										</Tooltip.Root>
@@ -330,7 +330,7 @@
 									>
 									<Tooltip.Content sideOffset={6}>
 										<p class="font-normal">
-											{formatCurrency(table.current.net, { maximumFractionDigits: 2 })}
+											{formatCurrency(table.current.net, 2)}
 										</p>
 									</Tooltip.Content>
 								</Tooltip.Root>
@@ -354,15 +354,13 @@
 											<Tooltip.Content sideOffset={6}>
 												<p class="font-normal">
 													{m.trends_performance_tooltip_from()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.cash.prev, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.cash.prev, 2)}
+													</span>
 													to
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.cash.cur, { maximumFractionDigits: 2 })}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.cash.cur, 2)}
+													</span>
 												</p>
 											</Tooltip.Content>
 										</Tooltip.Root>
@@ -377,7 +375,7 @@
 									>
 									<Tooltip.Content sideOffset={6}>
 										<p class="font-normal">
-											{formatCurrency(table.current.cash, { maximumFractionDigits: 2 })}
+											{formatCurrency(table.current.cash, 2)}
 										</p>
 									</Tooltip.Content>
 								</Tooltip.Root>
@@ -401,15 +399,13 @@
 											<Tooltip.Content sideOffset={6}>
 												<p class="font-normal">
 													{m.trends_performance_tooltip_from()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.debt.prev, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.debt.prev, 2)}
+													</span>
 													to
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.debt.cur, { maximumFractionDigits: 2 })}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.debt.cur, 2)}
+													</span>
 												</p>
 											</Tooltip.Content>
 										</Tooltip.Root>
@@ -424,7 +420,7 @@
 									>
 									<Tooltip.Content sideOffset={6}>
 										<p class="font-normal">
-											{formatCurrency(table.current.debt, { maximumFractionDigits: 2 })}
+											{formatCurrency(table.current.debt, 2)}
 										</p>
 									</Tooltip.Content>
 								</Tooltip.Root>
@@ -448,17 +444,13 @@
 											<Tooltip.Content sideOffset={6}>
 												<p class="font-normal">
 													{m.trends_performance_tooltip_from()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.investment.prev, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.investment.prev, 2)}
+													</span>
 													to
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.investment.cur, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.investment.cur, 2)}
+													</span>
 												</p>
 											</Tooltip.Content>
 										</Tooltip.Root>
@@ -473,7 +465,7 @@
 									>
 									<Tooltip.Content sideOffset={6}>
 										<p class="font-normal">
-											{formatCurrency(table.current.investment, { maximumFractionDigits: 2 })}
+											{formatCurrency(table.current.investment, 2)}
 										</p>
 									</Tooltip.Content>
 								</Tooltip.Root>
@@ -497,17 +489,13 @@
 											<Tooltip.Content sideOffset={6}>
 												<p class="font-normal">
 													{m.trends_performance_tooltip_from()}
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.other.prev, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.other.prev, 2)}
+													</span>
 													to
-													<span class="font-jetbrains-mono tabular-nums"
-														>{formatCurrency(c.values.other.cur, {
-															maximumFractionDigits: 2
-														})}</span
-													>
+													<span class="font-jetbrains-mono tabular-nums">
+														{formatCurrency(c.values.other.cur, 2)}
+													</span>
 												</p>
 											</Tooltip.Content>
 										</Tooltip.Root>
@@ -522,7 +510,7 @@
 									>
 									<Tooltip.Content sideOffset={6}>
 										<p class="font-normal">
-											{formatCurrency(table.current.other, { maximumFractionDigits: 2 })}
+											{formatCurrency(table.current.other, 2)}
 										</p>
 									</Tooltip.Content>
 								</Tooltip.Root>


### PR DESCRIPTION
## Summary

- Replace custom `formatCurrency` implementation with `formatValue` from `@canutin/svelte-currency-input`
- Export shared `intlConfig` from `currency.ts` for consistent locale/currency settings
- Rename `maximumFractionDigits` prop to `decimalScale` across all components for consistency with the library

Closes #277