### PR TITLE
fix: use correct date format for PocketBase filters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "layerchart": "2.0.0-next.27",
         "mode-watcher": "^1.0.8",
         "paneforge": "^1.0.0",
-        "pocketbase": "^0.26.2",
+        "pocketbase": "^0.26.5",
         "pocketbase-typegen": "^1.3.1",
         "prettier": "^3.4.2",
         "prettier-plugin-svelte": "^3.3.3",
@@ -1191,7 +1191,7 @@
 
     "playwright-core": ["playwright-core@1.55.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg=="],
 
-    "pocketbase": ["pocketbase@0.26.2", "", {}, "sha512-WA8EOBc3QnSJh8rJ3iYoi9DmmPOMFIgVfAmIGux7wwruUEIzXgvrO4u0W2htfQjGIcyezJkdZOy5Xmh7SxAftw=="],
+    "pocketbase": ["pocketbase@0.26.5", "", {}, "sha512-SXcq+sRvVpNxfLxPB1C+8eRatL7ZY4o3EVl/0OdE3MeR9fhPyZt0nmmxLqYmkLvXCN9qp3lXWV/0EUYb3MmMXQ=="],
 
     "pocketbase-typegen": ["pocketbase-typegen@1.3.1", "", { "dependencies": { "commander": "^9.4.1", "cross-fetch": "^3.1.5", "dotenv-flow": "^4.1.0", "form-data": "^4.0.1", "sqlite": "^4.1.2", "sqlite3": "^5.1.4" }, "bin": { "pocketbase-typegen": "dist/index.js" } }, "sha512-nwPkcZU/EFDdGfVJWiaEKstkHWFXvf8RrmE36xANCXPwDo4OI5OS70CN3N/Ruw1CVx87EaGCbquVs0yRD3IqpQ=="],
 

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -496,6 +496,8 @@ test('"Last year" filter correctly handles period boundaries', async ({ page }) 
 
 	// Calculate dates relative to now for time-independent testing
 	// "Last year" filter range: [Jan 1 of lastYear 00:00:00, Jan 1 of thisYear 00:00:00)
+	// NOTE: This test could theoretically fail if run exactly at midnight on Dec 31st,
+	// as the test's "thisYear" and the backend's "thisYear" could differ by one year.
 	const now = new UTCDate();
 	const thisYearStart = startOfYear(now);
 	const lastYearStart = startOfYear(subYears(now, 1));

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -1,6 +1,6 @@
 import { UTCDate } from '@date-fns/utc';
 import { expect, test, type Page } from '@playwright/test';
-import { addMonths, startOfMonth } from 'date-fns';
+import { addMonths, startOfMonth, startOfYear, subYears } from 'date-fns';
 
 import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
@@ -474,3 +474,98 @@ async function expectRowVisibility(page: Page, description: string, shouldBeVisi
 function escapeRegex(value: string) {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`);
 }
+
+// Regression test for https://github.com/fmaclen/canutin/issues/289
+// PocketBase stores dates with space separator but JS toISOString() uses 'T'.
+// This causes string comparison failures at period boundaries.
+test('"Last year" filter correctly handles period boundaries', async ({ page }) => {
+	const user = await seedUser('ivy');
+
+	const account = await seedAccount({
+		name: 'Date Filter Test Account',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 1000
+	});
+
+	// Calculate dates relative to now for time-independent testing
+	// "Last year" filter range: [Jan 1 of lastYear 00:00:00, Jan 1 of thisYear 00:00:00)
+	const now = new UTCDate();
+	const thisYearStart = startOfYear(now);
+	const lastYearStart = startOfYear(subYears(now, 1));
+
+	// BOUNDARY: 1 second BEFORE period start - should NOT be visible
+	const beforePeriod = new UTCDate(lastYearStart.getTime() - 1000);
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: beforePeriod.toISOString(),
+		description: 'Before Period Boundary',
+		value: 100
+	});
+
+	// BOUNDARY: Exactly at period start (Jan 1 00:00:00.000Z) - should be visible
+	// This is the edge case most likely to fail due to T vs space comparison
+	const atPeriodStart = new UTCDate(lastYearStart.getTime());
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: atPeriodStart.toISOString(),
+		description: 'At Period Start Boundary',
+		value: 200
+	});
+
+	// INSIDE: Mid-year transaction - should be visible
+	const midYear = new UTCDate(lastYearStart.getUTCFullYear(), 6, 15, 12, 0, 0, 0);
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: midYear.toISOString(),
+		description: 'Mid Year Payment',
+		value: 300
+	});
+
+	// BOUNDARY: 1 second BEFORE period end - should be visible
+	const beforePeriodEnd = new UTCDate(thisYearStart.getTime() - 1000);
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: beforePeriodEnd.toISOString(),
+		description: 'Before Period End Boundary',
+		value: 400
+	});
+
+	// BOUNDARY: Exactly at period end (Jan 1 of this year) - should NOT be visible (exclusive)
+	const atPeriodEnd = new UTCDate(thisYearStart.getTime());
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: atPeriodEnd.toISOString(),
+		description: 'At Period End Boundary',
+		value: 500
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	// Apply "Last year" filter
+	await page.getByLabel('Period').click();
+	await page.getByRole('option', { name: 'Last year' }).click();
+	await expect(page.getByLabel('Period')).toContainText('Last year');
+
+	// Transactions INSIDE the period (inclusive start, exclusive end)
+	await expect(page.getByText('At Period Start Boundary')).toBeVisible();
+	await expect(page.getByText('Mid Year Payment')).toBeVisible();
+	await expect(page.getByText('Before Period End Boundary')).toBeVisible();
+
+	// Transactions OUTSIDE the period
+	await expect(page.getByText('Before Period Boundary')).not.toBeVisible();
+	await expect(page.getByText('At Period End Boundary')).not.toBeVisible();
+});

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -560,12 +560,12 @@ test('"Last year" filter correctly handles period boundaries', async ({ page }) 
 	await page.getByRole('option', { name: 'Last year' }).click();
 	await expect(page.getByLabel('Period')).toContainText('Last year');
 
+	// Transactions OUTSIDE the period
+	await expect(page.getByText('Before Period Boundary')).not.toBeVisible();
+	await expect(page.getByText('At Period End Boundary')).not.toBeVisible();
+
 	// Transactions INSIDE the period (inclusive start, exclusive end)
 	await expect(page.getByText('At Period Start Boundary')).toBeVisible();
 	await expect(page.getByText('Mid Year Payment')).toBeVisible();
 	await expect(page.getByText('Before Period End Boundary')).toBeVisible();
-
-	// Transactions OUTSIDE the period
-	await expect(page.getByText('Before Period Boundary')).not.toBeVisible();
-	await expect(page.getByText('At Period End Boundary')).not.toBeVisible();
 });

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"layerchart": "2.0.0-next.27",
 		"mode-watcher": "^1.0.8",
 		"paneforge": "^1.0.0",
-		"pocketbase": "^0.26.2",
+		"pocketbase": "^0.26.5",
 		"pocketbase-typegen": "^1.3.1",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",

--- a/scripts/pb-server.ts
+++ b/scripts/pb-server.ts
@@ -7,7 +7,7 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 
-const POCKETBASE_VERSION = '0.30.0';
+const POCKETBASE_VERSION = '0.35.0';
 const POCKETBASE_TAG = `v${POCKETBASE_VERSION}`; // GitHub release tag
 
 const projectRoot = process.cwd();

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -5,6 +5,7 @@ import { getContext, setContext } from 'svelte';
 
 import type { TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { toPocketBaseDateString } from './utils';
 
 type CashflowAverages = { income: number; expenses: number; surplus: number };
 
@@ -72,14 +73,13 @@ class CashflowContext {
 		const startYtd = startOfYear(now);
 
 		// Fetch all needed transactions since the earliest required start (13 months for the chart)
-		// IMPORTANT: PocketBase date filters require space instead of 'T' separator
-		// See: https://github.com/fmaclen/canutin/issues/289
 		const earliest = start13m < startYtd ? start13m : startYtd;
-		const earliestIso = earliest.toISOString().replace('T', ' ');
 
 		const txns = await this._pb.authedClient
 			.collection('transactions')
-			.getFullList<TransactionsResponse>({ filter: `date >= '${earliestIso}'` });
+			.getFullList<TransactionsResponse>({
+				filter: `date >= '${toPocketBaseDateString(earliest)}'`
+			});
 
 		const compute = (from: Date) => {
 			let income = 0;

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -13,6 +13,7 @@ import type {
 	TransactionsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { toPocketBaseDateString } from './utils';
 
 export type PeriodOption =
 	| 'this-month'
@@ -198,10 +199,10 @@ class TransactionsContext {
 			}
 
 			if (from) {
-				filterParts.push(`date >= '${from.toISOString()}'`);
+				filterParts.push(`date >= '${toPocketBaseDateString(from)}'`);
 			}
 			if (to) {
-				filterParts.push(`date < '${to.toISOString()}'`);
+				filterParts.push(`date < '${toPocketBaseDateString(to)}'`);
 			}
 
 			if (this.kind === 'credits') {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,14 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
+// PocketBase stores dates with space separator (e.g. "2025-01-01 00:00:00.000Z")
+// but JavaScript's toISOString() uses 'T' (e.g. "2025-01-01T00:00:00.000Z").
+// This causes filter comparison failures due to lexicographic ordering.
+// See: https://github.com/fmaclen/canutin/issues/289
+export function toPocketBaseDateString(date: Date): string {
+	return date.toISOString().replace('T', ' ');
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type WithoutChild<T> = T extends { child?: any } ? Omit<T, 'child'> : T;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- Add `toPocketBaseDateString()` utility to format dates with space separator instead of 'T'
- Fix date filters in transactions and cashflow contexts that were failing at period boundaries
- Add regression test for "Last year" filter boundary conditions
- Bump PocketBase server to v0.35.0 and SDK to v0.26.5

Closes #289