### PR TITLE
fix: update breadcrumb after editing transaction description

### DIFF
--- a/e2e/accounts.test.ts
+++ b/e2e/accounts.test.ts
@@ -214,6 +214,7 @@ test('user can edit account details and update balance', async ({ page }) => {
 			'This account has been updated elsewhere and your changes may be based on outdated data'
 		)
 	).not.toBeVisible();
+	await expect(page.getByLabel('breadcrumb').getByText('Business Checking')).toBeVisible();
 
 	await page.getByLabel('Balance', { exact: true }).fill('4500');
 	await page.getByRole('button', { name: 'Update' }).click();

--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -260,6 +260,7 @@ test('user can add a new asset with type WHOLE or SHARES', async ({ page }) => {
 	await page.getByRole('button', { name: 'Add' }).click();
 	await expect(page.getByText('Asset added successfully')).toBeVisible();
 	await expect(page).toHaveURL('/assets');
+	await expect(page.getByText('Asset added successfully')).not.toBeVisible();
 
 	const wholeAssetRow = page.getByRole('row', { name: 'Gold Coins' });
 	await expect(wholeAssetRow).toBeVisible();

--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -374,6 +374,7 @@ test('user can edit asset details and update balance', async ({ page }) => {
 			'This asset has been updated elsewhere and your changes may be based on outdated data'
 		)
 	).not.toBeVisible();
+	await expect(page.getByLabel('breadcrumb').getByText('Rare Coin Collection')).toBeVisible();
 
 	await page.getByLabel('Market value').fill('12500');
 	await page.getByLabel('Book value').fill('10000');

--- a/e2e/transactions.crud.test.ts
+++ b/e2e/transactions.crud.test.ts
@@ -178,6 +178,9 @@ test('user can edit transaction details', async ({ page }) => {
 	await page.getByLabel('Labels').fill('Business Travel, Conference');
 	await page.getByRole('button', { name: 'Save' }).click();
 	await expect(page.getByText('Transaction updated')).toBeVisible();
+	await expect(
+		page.getByLabel('breadcrumb').getByText('Skyward Airlines Conference Trip')
+	).toBeVisible();
 
 	await page.getByLabel('breadcrumb').getByRole('link', { name: 'Transactions' }).click();
 	await expect(page.url()).toContain('/transactions');

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -230,9 +230,7 @@ test('transactions pagination navigates between pages', async ({ page }) => {
 	await signIn(page, user.email);
 	await goToPageViaSidebar(page, 'Transactions');
 
-	const rowsForBatch = page.getByRole('row', {
-		name: new RegExp(escapeRegex(prefix))
-	});
+	const rowsForBatch = page.getByRole('row', { name: prefix });
 	const previousButton = page.getByRole('button', { name: 'Previous' });
 	const nextButton = page.getByRole('button', { name: 'Next' });
 	await expect(previousButton).toBeDisabled();
@@ -240,25 +238,17 @@ test('transactions pagination navigates between pages', async ({ page }) => {
 	await expect(rowsForBatch).toHaveCount(50);
 
 	const lastDescription = seededDescriptions[seededDescriptions.length - 1] ?? '';
-	await expect(
-		page.getByRole('row', { name: new RegExp(escapeRegex(lastDescription)) })
-	).toHaveCount(0);
+	await expect(page.getByRole('row', { name: lastDescription })).toHaveCount(0);
 
 	await nextButton.click();
 	await expect(rowsForBatch).toHaveCount(5);
-	await expect(
-		page.getByRole('row', { name: new RegExp(escapeRegex(lastDescription)) })
-	).toBeVisible();
+	await expect(page.getByRole('row', { name: lastDescription })).toBeVisible();
 	await expect(nextButton).toBeDisabled();
 	await expect(previousButton).toBeEnabled();
 
 	await previousButton.click();
 	await expect(rowsForBatch).toHaveCount(50);
-	await expect(
-		page.getByRole('row', {
-			name: new RegExp(escapeRegex(`${prefix} 010`))
-		})
-	).toBeVisible();
+	await expect(page.getByRole('row', { name: `${prefix} 010` })).toBeVisible();
 	await expect(previousButton).toBeDisabled();
 	await expect(nextButton).toBeEnabled();
 
@@ -277,9 +267,7 @@ test('transactions pagination navigates between pages', async ({ page }) => {
 	await expect(page.getByRole('button', { name: 'Next' })).toHaveCount(0);
 
 	// Should be showing transactions now (not an empty page)
-	const creditRows = page.getByRole('row', {
-		name: new RegExp(escapeRegex(prefix))
-	});
+	const creditRows = page.getByRole('row', { name: prefix });
 	await expect(creditRows.first()).toBeVisible();
 });
 
@@ -482,18 +470,13 @@ function isWithinPeriod(date: Date, option: PeriodOption, reference: Date) {
 }
 
 async function expectRowVisibility(page: Page, description: string, shouldBeVisible: boolean) {
-	const pattern = new RegExp(escapeRegex(description));
-	const row = page.getByRole('row', { name: pattern });
+	const row = page.getByRole('row', { name: description });
 	if (shouldBeVisible) {
 		await expect(row).toHaveCount(1);
 		await expect(row).toBeVisible();
 	} else {
 		await expect(row).toHaveCount(0);
 	}
-}
-
-function escapeRegex(value: string) {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`);
 }
 
 // Regression test for https://github.com/fmaclen/canutin/issues/289

--- a/src/routes/(app)/transactions/[id]/+page.svelte
+++ b/src/routes/(app)/transactions/[id]/+page.svelte
@@ -132,6 +132,7 @@
 				.collection('transactions')
 				.update(currentTransactionId, transactionData);
 
+			transaction = { ...transaction!, description: formData.description.trim() };
 			toast.success(m.transactions_edit_success());
 		} catch (error) {
 			console.error('Failed to update transaction:', error);


### PR DESCRIPTION
## Summary
- Fixed bug where editing a transaction's description didn't update the breadcrumb
- Added test assertions to verify breadcrumb updates after editing (transactions, accounts, assets)

Closes #300