### PR TITLE
feat: add account filter dropdown to transactions page

### DIFF
--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -920,3 +920,239 @@ test('invalid date range params fall back to default period', async ({ page }) =
 		await expect(page.getByLabel('Period')).toContainText('Last 3 months');
 	}
 });
+
+test('transactions can be filtered by account', async ({ page }) => {
+	const user = await seedUser('morgan');
+
+	const checkingAccount = await seedAccount({
+		name: 'Everyday Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: checkingAccount.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 5000
+	});
+
+	const creditAccount = await seedAccount({
+		name: 'Rewards Credit Card',
+		balanceGroup: AccountsBalanceGroupOptions.DEBT,
+		owner: user.id,
+		balanceType: 'Credit card'
+	});
+	await seedAccountBalance({
+		account: creditAccount.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: -1500
+	});
+
+	const now = new UTCDate();
+
+	await seedTransaction({
+		account: checkingAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Paycheck Direct Deposit',
+		value: 3500
+	});
+	await seedTransaction({
+		account: checkingAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'ATM Withdrawal',
+		value: -200
+	});
+	await seedTransaction({
+		account: creditAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Restaurant Dinner',
+		value: -85
+	});
+	await seedTransaction({
+		account: creditAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Online Shopping',
+		value: -150
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	// All transactions should be visible initially
+	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
+	await expect(page.getByText('ATM Withdrawal')).toBeVisible();
+	await expect(page.getByText('Restaurant Dinner')).toBeVisible();
+	await expect(page.getByText('Online Shopping')).toBeVisible();
+
+	// Account filter should show "All accounts" by default
+	await expect(page.getByLabel('Account')).toContainText('All accounts');
+
+	// Open the account filter dropdown
+	await page.getByLabel('Account').click();
+
+	// Dropdown should show accounts grouped by balance type with colored indicators
+	await expect(page.getByText('Cash')).toBeVisible();
+	await expect(page.getByText('Debt')).toBeVisible();
+	await expect(page.getByRole('option', { name: 'Everyday Checking' })).toBeVisible();
+	await expect(page.getByRole('option', { name: 'Rewards Credit Card' })).toBeVisible();
+
+	// Select the checking account
+	await page.getByRole('option', { name: 'Everyday Checking' }).click();
+
+	// Only checking account transactions should be visible
+	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
+	await expect(page.getByText('ATM Withdrawal')).toBeVisible();
+	await expect(page.getByText('Restaurant Dinner')).not.toBeVisible();
+	await expect(page.getByText('Online Shopping')).not.toBeVisible();
+
+	// Filter trigger should show the selected account name
+	await expect(page.getByLabel('Account')).toContainText('Everyday Checking');
+
+	// URL should contain account parameter
+	await expect(page).toHaveURL(/account=/);
+
+	// Reload and verify filter persists
+	await page.reload();
+	await expect(page.getByLabel('Account')).toContainText('Everyday Checking');
+	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
+	await expect(page.getByText('Restaurant Dinner')).not.toBeVisible();
+
+	// Switch to credit card account
+	await page.getByLabel('Account').click();
+	await page.getByRole('option', { name: 'Rewards Credit Card' }).click();
+
+	// Only credit card transactions should be visible
+	await expect(page.getByText('Restaurant Dinner')).toBeVisible();
+	await expect(page.getByText('Online Shopping')).toBeVisible();
+	await expect(page.getByText('Paycheck Direct Deposit')).not.toBeVisible();
+	await expect(page.getByText('ATM Withdrawal')).not.toBeVisible();
+
+	// Clear the filter by selecting "All accounts"
+	await page.getByLabel('Account').click();
+	await page.getByRole('option', { name: 'All accounts' }).click();
+
+	// All transactions should be visible again
+	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
+	await expect(page.getByText('ATM Withdrawal')).toBeVisible();
+	await expect(page.getByText('Restaurant Dinner')).toBeVisible();
+	await expect(page.getByText('Online Shopping')).toBeVisible();
+
+	// URL should no longer contain account parameter
+	await expect(page).not.toHaveURL(/account=/);
+});
+
+test('account filter works with other filters combined', async ({ page }) => {
+	const user = await seedUser('casey');
+
+	const savingsAccount = await seedAccount({
+		name: 'High Yield Savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Savings'
+	});
+	await seedAccountBalance({
+		account: savingsAccount.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 10000
+	});
+
+	const brokerageAccount = await seedAccount({
+		name: 'Investment Brokerage',
+		balanceGroup: AccountsBalanceGroupOptions.INVESTMENT,
+		owner: user.id,
+		balanceType: 'Brokerage'
+	});
+	await seedAccountBalance({
+		account: brokerageAccount.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 25000
+	});
+
+	const now = new UTCDate();
+
+	// Savings account: one credit, one debit
+	await seedTransaction({
+		account: savingsAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Interest Payment',
+		value: 50
+	});
+	await seedTransaction({
+		account: savingsAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Transfer to Checking',
+		value: -500
+	});
+
+	// Brokerage account: one credit, one debit
+	await seedTransaction({
+		account: brokerageAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Dividend Income',
+		value: 125
+	});
+	await seedTransaction({
+		account: brokerageAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Stock Purchase',
+		value: -1000
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	// Filter by savings account
+	await page.getByLabel('Account').click();
+	await page.getByRole('option', { name: 'High Yield Savings' }).click();
+
+	// Both savings transactions visible
+	await expect(page.getByText('Interest Payment')).toBeVisible();
+	await expect(page.getByText('Transfer to Checking')).toBeVisible();
+	await expect(page.getByText('Dividend Income')).not.toBeVisible();
+	await expect(page.getByText('Stock Purchase')).not.toBeVisible();
+
+	// Add type filter for credits only
+	await page.getByLabel('Type').click();
+	await page.getByRole('option', { name: 'Credits only' }).click();
+
+	// Only savings credit should be visible
+	await expect(page.getByText('Interest Payment')).toBeVisible();
+	await expect(page.getByText('Transfer to Checking')).not.toBeVisible();
+	await expect(page.getByText('Dividend Income')).not.toBeVisible();
+	await expect(page.getByText('Stock Purchase')).not.toBeVisible();
+
+	// URL should contain both filters
+	await expect(page).toHaveURL(/account=/);
+	await expect(page).toHaveURL(/amount=credits/);
+
+	// Reload and verify both filters persist
+	await page.reload();
+	await expect(page.getByLabel('Account')).toContainText('High Yield Savings');
+	await expect(page.getByLabel('Type')).toContainText('Credits only');
+	await expect(page.getByText('Interest Payment')).toBeVisible();
+	await expect(page.getByText('Transfer to Checking')).not.toBeVisible();
+
+	// Clear account filter while keeping type filter
+	await page.getByLabel('Account').click();
+	await page.getByRole('option', { name: 'All accounts' }).click();
+
+	// Both credit transactions should now be visible
+	await expect(page.getByText('Interest Payment')).toBeVisible();
+	await expect(page.getByText('Dividend Income')).toBeVisible();
+	await expect(page.getByText('Transfer to Checking')).not.toBeVisible();
+	await expect(page.getByText('Stock Purchase')).not.toBeVisible();
+});

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -1134,6 +1134,28 @@ test('account filter works with other filters combined', async ({ page }) => {
 	await expect(page.getByText('Dividend Income')).not.toBeVisible();
 	await expect(page.getByText('Stock Purchase')).not.toBeVisible();
 
+	// Test that realtime updates respect BOTH filters (account + kind).
+	// Seed two transactions: one that matches both filters, one that only matches kind.
+	await seedTransaction({
+		account: brokerageAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Realtime Brokerage Dividend',
+		value: 75
+	});
+	await seedTransaction({
+		account: savingsAccount.id,
+		owner: user.id,
+		date: now.toISOString(),
+		description: 'Realtime Savings Bonus',
+		value: 25
+	});
+
+	// Wait for the savings credit to appear (confirms realtime is working)
+	await expect(page.getByText('Realtime Savings Bonus')).toBeVisible();
+	// The brokerage credit should NOT appear (matches kind but wrong account)
+	await expect(page.getByText('Realtime Brokerage Dividend')).not.toBeVisible();
+
 	// URL should contain both filters
 	await expect(page).toHaveURL(/account=/);
 	await expect(page).toHaveURL(/amount=credits/);

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -992,10 +992,10 @@ test('transactions can be filtered by account', async ({ page }) => {
 	await expect(page.getByText('Online Shopping')).toBeVisible();
 
 	// Account filter should show "All accounts" by default
-	await expect(page.getByLabel('Account')).toContainText('All accounts');
+	await expect(page.getByLabel('Account', { exact: true })).toContainText('All accounts');
 
 	// Open the account filter dropdown
-	await page.getByLabel('Account').click();
+	await page.getByLabel('Account', { exact: true }).click();
 
 	// Dropdown should show accounts grouped by balance type with colored indicators
 	await expect(page.getByText('Cash')).toBeVisible();
@@ -1013,19 +1013,19 @@ test('transactions can be filtered by account', async ({ page }) => {
 	await expect(page.getByText('Online Shopping')).not.toBeVisible();
 
 	// Filter trigger should show the selected account name
-	await expect(page.getByLabel('Account')).toContainText('Everyday Checking');
+	await expect(page.getByLabel('Account', { exact: true })).toContainText('Everyday Checking');
 
 	// URL should contain account parameter
 	await expect(page).toHaveURL(/account=/);
 
 	// Reload and verify filter persists
 	await page.reload();
-	await expect(page.getByLabel('Account')).toContainText('Everyday Checking');
+	await expect(page.getByLabel('Account', { exact: true })).toContainText('Everyday Checking');
 	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
 	await expect(page.getByText('Restaurant Dinner')).not.toBeVisible();
 
 	// Switch to credit card account
-	await page.getByLabel('Account').click();
+	await page.getByLabel('Account', { exact: true }).click();
 	await page.getByRole('option', { name: 'Rewards Credit Card' }).click();
 
 	// Only credit card transactions should be visible
@@ -1034,9 +1034,8 @@ test('transactions can be filtered by account', async ({ page }) => {
 	await expect(page.getByText('Paycheck Direct Deposit')).not.toBeVisible();
 	await expect(page.getByText('ATM Withdrawal')).not.toBeVisible();
 
-	// Clear the filter by selecting "All accounts"
-	await page.getByLabel('Account').click();
-	await page.getByRole('option', { name: 'All accounts' }).click();
+	// Clear the filter using the X button
+	await page.getByLabel('Clear account filter').click();
 
 	// All transactions should be visible again
 	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
@@ -1116,7 +1115,7 @@ test('account filter works with other filters combined', async ({ page }) => {
 	await goToPageViaSidebar(page, 'Transactions');
 
 	// Filter by savings account
-	await page.getByLabel('Account').click();
+	await page.getByLabel('Account', { exact: true }).click();
 	await page.getByRole('option', { name: 'High Yield Savings' }).click();
 
 	// Both savings transactions visible
@@ -1141,14 +1140,13 @@ test('account filter works with other filters combined', async ({ page }) => {
 
 	// Reload and verify both filters persist
 	await page.reload();
-	await expect(page.getByLabel('Account')).toContainText('High Yield Savings');
+	await expect(page.getByLabel('Account', { exact: true })).toContainText('High Yield Savings');
 	await expect(page.getByLabel('Type')).toContainText('Credits only');
 	await expect(page.getByText('Interest Payment')).toBeVisible();
 	await expect(page.getByText('Transfer to Checking')).not.toBeVisible();
 
 	// Clear account filter while keeping type filter
-	await page.getByLabel('Account').click();
-	await page.getByRole('option', { name: 'All accounts' }).click();
+	await page.getByLabel('Clear account filter').click();
 
 	// Both credit transactions should now be visible
 	await expect(page.getByText('Interest Payment')).toBeVisible();

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -1024,8 +1024,8 @@ test('transactions can be filtered by account', async ({ page }) => {
 	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
 	await expect(page.getByText('Restaurant Dinner')).not.toBeVisible();
 
-	// Switch to credit card account
-	await page.getByLabel('Account', { exact: true }).click();
+	// Switch to credit card account (click left side to avoid ClearButton on right)
+	await page.getByLabel('Account', { exact: true }).click({ position: { x: 10, y: 10 } });
 	await page.getByRole('option', { name: 'Rewards Credit Card' }).click();
 
 	// Only credit card transactions should be visible

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -1024,8 +1024,8 @@ test('transactions can be filtered by account', async ({ page }) => {
 	await expect(page.getByText('Paycheck Direct Deposit')).toBeVisible();
 	await expect(page.getByText('Restaurant Dinner')).not.toBeVisible();
 
-	// Switch to credit card account (click left side to avoid ClearButton on right)
-	await page.getByLabel('Account', { exact: true }).click({ position: { x: 10, y: 10 } });
+	// Switch to credit card account
+	await page.getByLabel('Account', { exact: true }).click();
 	await page.getByRole('option', { name: 'Rewards Credit Card' }).click();
 
 	// Only credit card transactions should be visible

--- a/e2e/transactions.sorting.test.ts
+++ b/e2e/transactions.sorting.test.ts
@@ -204,7 +204,7 @@ test.describe('transactions table sorting', () => {
 
 		const rows = page.locator('tbody tr');
 
-		const accountHeader = page.getByRole('button', { name: 'Account' });
+		const accountHeader = page.locator('thead').getByRole('button', { name: 'Account' });
 		await accountHeader.click();
 
 		await expect(page).toHaveURL(/sort=account/);

--- a/messages/en.json
+++ b/messages/en.json
@@ -200,6 +200,8 @@
 	"transactions_filter_kind_credits_only": "Credits only",
 	"transactions_filter_kind_debits_only": "Debits only",
 	"transactions_filter_kind_excluded_only": "Excluded only",
+	"transactions_filter_account_label": "Account",
+	"transactions_filter_account_all": "All accounts",
 	"transactions_table_header_date": "Date",
 	"transactions_table_header_description": "Description",
 	"transactions_table_header_labels": "Labels",

--- a/messages/en.json
+++ b/messages/en.json
@@ -202,6 +202,7 @@
 	"transactions_filter_kind_excluded_only": "Excluded only",
 	"transactions_filter_account_label": "Account",
 	"transactions_filter_account_all": "All accounts",
+	"transactions_filter_account_clear": "Clear account filter",
 	"transactions_table_header_date": "Date",
 	"transactions_table_header_description": "Description",
 	"transactions_table_header_labels": "Labels",

--- a/messages/es.json
+++ b/messages/es.json
@@ -202,6 +202,7 @@
 	"transactions_filter_kind_excluded_only": "Solo excluidos",
 	"transactions_filter_account_label": "Cuenta",
 	"transactions_filter_account_all": "Todas las cuentas",
+	"transactions_filter_account_clear": "Borrar filtro de cuenta",
 	"transactions_table_header_date": "Fecha",
 	"transactions_table_header_description": "Descripción",
 	"transactions_table_header_labels": "Etiquetas",

--- a/messages/es.json
+++ b/messages/es.json
@@ -200,6 +200,8 @@
 	"transactions_filter_kind_credits_only": "Solo abonos",
 	"transactions_filter_kind_debits_only": "Solo cargos",
 	"transactions_filter_kind_excluded_only": "Solo excluidos",
+	"transactions_filter_account_label": "Cuenta",
+	"transactions_filter_account_all": "Todas las cuentas",
 	"transactions_table_header_date": "Fecha",
 	"transactions_table_header_description": "Descripción",
 	"transactions_table_header_labels": "Etiquetas",

--- a/src/lib/components/clear-button.svelte
+++ b/src/lib/components/clear-button.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import XIcon from '@lucide/svelte/icons/x';
+
+	let {
+		onclick,
+		onpointerdown,
+		'aria-label': ariaLabel
+	}: {
+		onclick: (e: MouseEvent) => void;
+		onpointerdown?: (e: PointerEvent) => void;
+		'aria-label': string;
+	} = $props();
+</script>
+
+<button
+	type="button"
+	{onclick}
+	{onpointerdown}
+	aria-label={ariaLabel}
+	class="text-muted-foreground hover:text-foreground cursor-pointer"
+>
+	<XIcon class="size-4" />
+</button>

--- a/src/lib/components/clear-button.svelte
+++ b/src/lib/components/clear-button.svelte
@@ -4,10 +4,14 @@
 	let {
 		onclick,
 		onpointerdown,
+		onpointerup,
+		class: className,
 		'aria-label': ariaLabel
 	}: {
 		onclick: (e: MouseEvent) => void;
 		onpointerdown?: (e: PointerEvent) => void;
+		onpointerup?: (e: PointerEvent) => void;
+		class?: string;
 		'aria-label': string;
 	} = $props();
 </script>
@@ -16,8 +20,9 @@
 	type="button"
 	{onclick}
 	{onpointerdown}
+	{onpointerup}
 	aria-label={ariaLabel}
-	class="text-muted-foreground hover:text-foreground cursor-pointer"
+	class="text-muted-foreground hover:text-foreground cursor-pointer {className ?? ''}"
 >
 	<XIcon class="size-4" />
 </button>

--- a/src/lib/components/page.svelte
+++ b/src/lib/components/page.svelte
@@ -10,6 +10,6 @@
 	<title>{getPageTitle(pageTitle)}</title>
 </svelte:head>
 
-<div class="flex flex-col space-y-8 p-8">
+<div class="flex flex-col space-y-8 p-6 sm:p-8">
 	{@render children?.()}
 </div>

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -56,6 +56,7 @@ class TransactionsContext {
 	period: PeriodOption = $state('last-3-months');
 	kind: KindFilter = $state('all');
 	search: string = $state('');
+	accountFilter: string | null = $state(null);
 	page: number = $state(1);
 	isLoading: boolean = $state(true);
 	rawTransactions: TransactionsResponse<TransactionExpand>[] = $state([]);
@@ -113,6 +114,7 @@ class TransactionsContext {
 		this.period = 'last-3-months';
 		this.kind = 'all';
 		this.search = '';
+		this.accountFilter = null;
 
 		const sortParam = params.get('sort');
 		const dirParam = params.get('dir');
@@ -155,6 +157,11 @@ class TransactionsContext {
 		const searchParam = params.get('q');
 		if (searchParam) {
 			this.search = searchParam;
+		}
+
+		const accountParam = params.get('account');
+		if (accountParam) {
+			this.accountFilter = accountParam;
 		}
 
 		if (shouldRefresh) {
@@ -262,6 +269,10 @@ class TransactionsContext {
 			if (searchQuery) {
 				const escaped = searchQuery.replace(/'/g, "''");
 				filterParts.push(`description ~ '${escaped}'`);
+			}
+
+			if (this.accountFilter) {
+				filterParts.push(`account = '${this.accountFilter}'`);
 			}
 
 			const filter = filterParts.length > 0 ? filterParts.join(' && ') : undefined;
@@ -415,6 +426,7 @@ class TransactionsContext {
 			if (this.kind === 'credits') return row.value > 0;
 			if (this.kind === 'debits') return row.value < 0;
 			if (this.kind === 'excluded') return row.excluded;
+			if (this.accountFilter && row.accountId !== this.accountFilter) return false;
 			return true;
 		});
 
@@ -513,6 +525,11 @@ class TransactionsContext {
 		} else {
 			params.set('amount', this.kind);
 		}
+		if (this.accountFilter) {
+			params.set('account', this.accountFilter);
+		} else {
+			params.delete('account');
+		}
 
 		this.updateUrl(params);
 		this.refreshTransactions();
@@ -527,6 +544,32 @@ class TransactionsContext {
 			params.delete('amount');
 		} else {
 			params.set('amount', option);
+		}
+		if (this.accountFilter) {
+			params.set('account', this.accountFilter);
+		} else {
+			params.delete('account');
+		}
+
+		this.updateUrl(params);
+		this.refreshTransactions();
+	}
+
+	setAccountFilter(accountId: string | null) {
+		this.accountFilter = accountId;
+		this.page = 1;
+
+		const currentPage = get(page);
+		const params = new SvelteURLSearchParams(currentPage.url.searchParams);
+		if (accountId) {
+			params.set('account', accountId);
+		} else {
+			params.delete('account');
+		}
+		if (this.kind === 'all') {
+			params.delete('amount');
+		} else {
+			params.set('amount', this.kind);
 		}
 
 		this.updateUrl(params);

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -161,7 +161,11 @@ class TransactionsContext {
 
 		const accountParam = params.get('account');
 		if (accountParam) {
-			this.accountFilter = accountParam;
+			const accounts = this._accountsContext.accounts;
+			const isValid = accounts.length === 0 || accounts.some((a) => a.id === accountParam);
+			if (isValid) {
+				this.accountFilter = accountParam;
+			}
 		}
 
 		if (shouldRefresh) {
@@ -190,6 +194,19 @@ class TransactionsContext {
 			this._lastSyncedSearch = newUrl.search;
 			// eslint-disable-next-line svelte/no-navigation-without-resolve
 			replaceState(newUrl.href, {});
+		}
+	}
+
+	private syncFiltersToParams(params: SvelteURLSearchParams) {
+		if (this.kind === 'all') {
+			params.delete('amount');
+		} else {
+			params.set('amount', this.kind);
+		}
+		if (this.accountFilter) {
+			params.set('account', this.accountFilter);
+		} else {
+			params.delete('account');
 		}
 	}
 
@@ -423,10 +440,10 @@ class TransactionsContext {
 			const time = row.dateValue;
 			if (fromTime !== null && time < fromTime) return false;
 			if (toTime !== null && time >= toTime) return false;
+			if (this.accountFilter && row.accountId !== this.accountFilter) return false;
 			if (this.kind === 'credits') return row.value > 0;
 			if (this.kind === 'debits') return row.value < 0;
 			if (this.kind === 'excluded') return row.excluded;
-			if (this.accountFilter && row.accountId !== this.accountFilter) return false;
 			return true;
 		});
 
@@ -520,16 +537,7 @@ class TransactionsContext {
 		params.delete('periodTo');
 		params.delete('periodLabel');
 		params.set('period', option);
-		if (this.kind === 'all') {
-			params.delete('amount');
-		} else {
-			params.set('amount', this.kind);
-		}
-		if (this.accountFilter) {
-			params.set('account', this.accountFilter);
-		} else {
-			params.delete('account');
-		}
+		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
 		this.refreshTransactions();
@@ -540,16 +548,7 @@ class TransactionsContext {
 
 		const currentPage = get(page);
 		const params = new SvelteURLSearchParams(currentPage.url.searchParams);
-		if (option === 'all') {
-			params.delete('amount');
-		} else {
-			params.set('amount', option);
-		}
-		if (this.accountFilter) {
-			params.set('account', this.accountFilter);
-		} else {
-			params.delete('account');
-		}
+		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
 		this.refreshTransactions();
@@ -561,16 +560,7 @@ class TransactionsContext {
 
 		const currentPage = get(page);
 		const params = new SvelteURLSearchParams(currentPage.url.searchParams);
-		if (accountId) {
-			params.set('account', accountId);
-		} else {
-			params.delete('account');
-		}
-		if (this.kind === 'all') {
-			params.delete('amount');
-		} else {
-			params.set('amount', this.kind);
-		}
+		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
 		this.refreshTransactions();

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -2,7 +2,6 @@
 	import { CalendarDate, type DateValue } from '@internationalized/date';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import SearchIcon from '@lucide/svelte/icons/search';
-	import XIcon from '@lucide/svelte/icons/x';
 	import type { DateRange } from 'bits-ui';
 	import { addDays, format, subDays } from 'date-fns';
 
@@ -12,6 +11,7 @@
 		groupAccountsByBalanceGroup
 	} from '$lib/account-utils';
 	import { getAccountsContext } from '$lib/accounts.svelte';
+	import ClearButton from '$lib/components/clear-button.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
@@ -154,14 +154,9 @@
 			class="bg-background pr-9 pl-9"
 		/>
 		{#if txContext.search}
-			<button
-				type="button"
-				onclick={clearSearch}
-				aria-label={m.transactions_clear_search()}
-				class="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 cursor-pointer"
-			>
-				<XIcon class="size-4" />
-			</button>
+			<div class="absolute top-1/2 right-3 -translate-y-1/2">
+				<ClearButton onclick={clearSearch} aria-label={m.transactions_clear_search()} />
+			</div>
 		{/if}
 	</div>
 	<Popover.Root bind:open={periodPopoverOpen}>
@@ -231,13 +226,24 @@
 						].color}"
 					></div>
 					<span class="truncate">{selectedAccount.name}</span>
+					<ClearButton
+						onclick={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							txContext.setAccountFilter(null);
+						}}
+						onpointerdown={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						aria-label={m.transactions_filter_account_clear()}
+					/>
 				</div>
 			{:else}
 				{m.transactions_filter_account_all()}
 			{/if}
 		</Select.Trigger>
 		<Select.Content>
-			<Select.Item value="">{m.transactions_filter_account_all()}</Select.Item>
 			{#each BALANCE_GROUP_ORDER as group (group)}
 				{@const accountsInGroup = accountsByGroup.get(group) ?? []}
 				{#if accountsInGroup.length > 0}

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -6,12 +6,19 @@
 	import type { DateRange } from 'bits-ui';
 	import { addDays, format, subDays } from 'date-fns';
 
+	import {
+		BALANCE_GROUP_ORDER,
+		getBalanceGroupMeta,
+		groupAccountsByBalanceGroup
+	} from '$lib/account-utils';
+	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Popover from '$lib/components/ui/popover/index.js';
 	import { RangeCalendar } from '$lib/components/ui/range-calendar/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { m } from '$lib/paraglide/messages';
+	import { AccountsBalanceGroupOptions } from '$lib/pocketbase.schema';
 	import {
 		getTransactionsContext,
 		type KindFilter,
@@ -19,6 +26,15 @@
 	} from '$lib/transactions.svelte';
 
 	const txContext = getTransactionsContext();
+	const accountsContext = getAccountsContext();
+
+	const groupMeta = getBalanceGroupMeta();
+	let accountsByGroup = $derived(groupAccountsByBalanceGroup(accountsContext.accounts));
+	let selectedAccount = $derived(
+		txContext.accountFilter
+			? accountsContext.accounts.find((a) => a.id === txContext.accountFilter)
+			: null
+	);
 
 	let periodPopoverOpen = $state(false);
 
@@ -195,6 +211,48 @@
 		<Select.Content>
 			{#each txContext.kindOptions as option (option)}
 				<Select.Item value={option}>{kindLabel(option)}</Select.Item>
+			{/each}
+		</Select.Content>
+	</Select.Root>
+	<Select.Root
+		type="single"
+		value={txContext.accountFilter ?? ''}
+		onValueChange={(v) => txContext.setAccountFilter(v || null)}
+	>
+		<Select.Trigger
+			aria-label={m.transactions_filter_account_label()}
+			class="bg-background w-full sm:w-48"
+		>
+			{#if selectedAccount}
+				<div class="flex items-center gap-2">
+					<div
+						class="size-2 shrink-0 rounded-full {groupMeta[
+							selectedAccount.balanceGroup as AccountsBalanceGroupOptions
+						].color}"
+					></div>
+					<span class="truncate">{selectedAccount.name}</span>
+				</div>
+			{:else}
+				{m.transactions_filter_account_all()}
+			{/if}
+		</Select.Trigger>
+		<Select.Content>
+			<Select.Item value="">{m.transactions_filter_account_all()}</Select.Item>
+			{#each BALANCE_GROUP_ORDER as group (group)}
+				{@const accountsInGroup = accountsByGroup.get(group) ?? []}
+				{#if accountsInGroup.length > 0}
+					<Select.Group>
+						<Select.Label>
+							<div class="flex items-center gap-2">
+								<div class="size-2 rounded-full {groupMeta[group].color}"></div>
+								{groupMeta[group].label}
+							</div>
+						</Select.Label>
+						{#each accountsInGroup as account (account.id)}
+							<Select.Item value={account.id}>{account.name}</Select.Item>
+						{/each}
+					</Select.Group>
+				{/if}
 			{/each}
 		</Select.Content>
 	</Select.Root>

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -219,7 +219,7 @@
 			class="bg-background w-full sm:w-auto sm:max-w-64 sm:min-w-48"
 		>
 			{#if selectedAccount}
-				<div class="flex items-center gap-2">
+				<div class="flex w-full items-center gap-2">
 					<div
 						class="size-2 shrink-0 rounded-full {groupMeta[
 							selectedAccount.balanceGroup as AccountsBalanceGroupOptions
@@ -227,12 +227,17 @@
 					></div>
 					<span class="max-w-40 truncate">{selectedAccount.name}</span>
 					<ClearButton
+						class="ml-auto"
 						onclick={(e) => {
 							e.preventDefault();
 							e.stopPropagation();
 							txContext.setAccountFilter(null);
 						}}
 						onpointerdown={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+						}}
+						onpointerup={(e) => {
 							e.preventDefault();
 							e.stopPropagation();
 						}}

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -216,7 +216,7 @@
 	>
 		<Select.Trigger
 			aria-label={m.transactions_filter_account_label()}
-			class="bg-background w-full sm:w-48"
+			class="bg-background w-full sm:w-auto sm:max-w-64 sm:min-w-48"
 		>
 			{#if selectedAccount}
 				<div class="flex items-center gap-2">
@@ -225,7 +225,7 @@
 							selectedAccount.balanceGroup as AccountsBalanceGroupOptions
 						].color}"
 					></div>
-					<span class="truncate">{selectedAccount.name}</span>
+					<span class="max-w-40 truncate">{selectedAccount.name}</span>
 					<ClearButton
 						onclick={(e) => {
 							e.preventDefault();

--- a/src/routes/(app)/transactions/transaction-summary.svelte
+++ b/src/routes/(app)/transactions/transaction-summary.svelte
@@ -6,7 +6,11 @@
 	const txContext = getTransactionsContext();
 </script>
 
-<div role="region" aria-label={m.transactions_summary_aria_label()} class="grid grid-cols-2 gap-2">
+<div
+	role="region"
+	aria-label={m.transactions_summary_aria_label()}
+	class="grid grid-cols-1 gap-2 sm:grid-cols-2"
+>
 	<KeyValue
 		title={m.transactions_summary_count_label()}
 		value={txContext.filteredRows.length}


### PR DESCRIPTION
## Summary

- Adds account filter dropdown to the transactions page filters
- Accounts are grouped by balance type (Cash, Debt, Investment, Other) with colored indicators
- Filter persists in URL and combines with other filters (period, type, search)
- Includes X button to clear the filter (extracted to shared `ClearButton` component)

Closes #281