### PR TITLE
fix: include pb_hooks in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /app
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/pocketbase/pb_migrations ./pocketbase/pb_migrations
+COPY --from=builder /app/pocketbase/pb_hooks ./pocketbase/pb_hooks
 COPY --from=go-builder /pocketbase/pocketbase-custom ./pocketbase/pocketbase-custom
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

- Add missing `COPY` for `pocketbase/pb_hooks` in the Dockerfile
- Without this, the JSVM import/revert hooks at `/api/canutin/import` are unavailable in production containers

One-line fix from the import feature merged in #316.