### PR TITLE
fix: bump Dockerfile Go version to 1.25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS go-builder
+FROM golang:1.25-alpine AS go-builder
 
 WORKDIR /pocketbase
 


### PR DESCRIPTION
## Summary
- Fixes build failure from #319 — `go.mod` requires Go >= 1.25.0 but the Dockerfile was still using `golang:1.24-alpine`