### PR TITLE
fix: copy all Go source files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /pocketbase
 COPY pocketbase/go.mod pocketbase/go.sum ./
 RUN go mod download
 
-COPY pocketbase/main.go ./
+COPY pocketbase/*.go ./
 RUN CGO_ENABLED=0 go build -o pocketbase-custom .
 
 FROM oven/bun:1 AS builder


### PR DESCRIPTION
## Summary
- Fixes Docker build failure from #318 — Dockerfile only copied `main.go` but the Go refactor split code into `main.go`, `balance.go`, and `import.go`
- Changes `COPY pocketbase/main.go ./` to `COPY pocketbase/*.go ./`
- Verified Docker Go build stage passes locally