### PR TITLE
fix: dark mode contrast, palette rebalance, and text wrap polish

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -78,19 +78,21 @@
 }
 
 .dark {
-	--background: oklch(0.33 0 0);
+	--brand-secondary: hsl(212, 40%, 20%);
+
+	--background: oklch(0.17 0 0);
 	--foreground: oklch(0.985 0 0);
-	--card: oklch(0.205 0 0);
+	--card: oklch(0.22 0 0);
 	--card-foreground: oklch(0.985 0 0);
-	--popover: oklch(0.205 0 0);
+	--popover: oklch(0.22 0 0);
 	--popover-foreground: oklch(0.985 0 0);
 	--primary: var(--brand);
 	--primary-foreground: oklch(0.985 0 0);
-	--secondary: oklch(0.269 0 0);
+	--secondary: oklch(0.27 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
-	--muted: oklch(0.269 0 0);
+	--muted: oklch(0.27 0 0);
 	--muted-foreground: oklch(0.708 0 0);
-	--accent: oklch(0.269 0 0);
+	--accent: oklch(0.27 0 0);
 	--accent-foreground: oklch(0.985 0 0);
 	--destructive: oklch(0.704 0.191 22.216);
 	--border: oklch(1 0 0 / 10%);
@@ -101,11 +103,11 @@
 	--chart-3: oklch(0.769 0.188 70.08);
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
-	--sidebar: oklch(0.205 0 0);
+	--sidebar: oklch(0.22 0 0);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.488 0.243 264.376);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.269 0 0);
+	--sidebar-accent: oklch(0.27 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
 	--sidebar-ring: oklch(0.556 0 0);

--- a/src/app.css
+++ b/src/app.css
@@ -165,6 +165,7 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+		text-wrap: pretty;
 	}
 }
 

--- a/src/lib/components/key-value.svelte
+++ b/src/lib/components/key-value.svelte
@@ -20,10 +20,10 @@
 	const variantClasses: Record<Variant, string> = {
 		filled: 'shadow-md bg-background',
 		outline: 'border border-border bg-transparent',
-		cash: 'shadow-md bg-cash text-background',
-		debt: 'shadow-md bg-debt text-background',
-		investment: 'shadow-md bg-investment text-background',
-		other: 'shadow-md bg-other-assets text-background'
+		cash: 'shadow-md bg-cash text-white',
+		debt: 'shadow-md bg-debt text-white',
+		investment: 'shadow-md bg-investment text-white',
+		other: 'shadow-md bg-other-assets text-white'
 	};
 </script>
 

--- a/src/lib/components/ui/badge/badge.svelte
+++ b/src/lib/components/ui/badge/badge.svelte
@@ -11,10 +11,10 @@
 				destructive:
 					'bg-destructive [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/70 border-transparent text-white',
 				outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-				cash: 'bg-cash text-background border-transparent',
-				debt: 'bg-debt text-background border-transparent',
-				investment: 'bg-investment text-background border-transparent',
-				other: 'bg-other-assets text-background border-transparent'
+				cash: 'bg-cash text-white border-transparent',
+				debt: 'bg-debt text-white border-transparent',
+				investment: 'bg-investment text-white border-transparent',
+				other: 'bg-other-assets text-white border-transparent'
 			}
 		},
 		defaultVariants: {

--- a/src/lib/components/ui/table/table-row.svelte
+++ b/src/lib/components/ui/table/table-row.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="table-row"
 	class={cn(
-		'hover:[&,&>svelte-css-wrapper]:[&>td]:bg-brand-secondary odd:[&>td]:bg-primary-foreground transition-colors [&>td]:h-11 [&>td]:border-b [&>td]:border-dashed last:[&>td]:border-b-0 last:[&>td:first-child]:rounded-bl-md last:[&>td:last-child]:rounded-br-md',
+		'hover:[&,&>svelte-css-wrapper]:[&>td]:bg-brand-secondary odd:[&>td]:bg-sidebar transition-colors [&>td]:h-11 [&>td]:border-b [&>td]:border-dashed last:[&>td]:border-b-0 last:[&>td:first-child]:rounded-bl-md last:[&>td:last-child]:rounded-br-md',
 		className
 	)}
 	{...restProps}

--- a/src/routes/(app)/big-picture/summary.svelte
+++ b/src/routes/(app)/big-picture/summary.svelte
@@ -19,7 +19,7 @@
 	});
 </script>
 
-<div class="text-background grid gap-2 lg:grid-cols-[1.3fr_1fr_1fr]">
+<div class="grid gap-2 text-white lg:grid-cols-[1.3fr_1fr_1fr]">
 	<div
 		class="flex flex-col justify-between rounded-sm bg-stone-700 p-4 shadow-md md:row-span-2"
 		role="region"


### PR DESCRIPTION
## Summary

- Swaps theme-unaware tokens (`primary-foreground`, `text-background`) that don't flip between light and dark for theme-aware or intentionally-constant ones across table zebra stripes, summary cards, and colored badges.
- Rebalances the dark palette so the page bg is the darkest surface (0.17 L) and cards / popover / sidebar sit slightly above it (0.22 L) — standard dark-mode elevation instead of the previous inverted "sunken surfaces" look.
- Adds a dark override for `--brand-secondary` so table row hover is a subtle blue tint, not a glaring white band.
- Applies `text-wrap: pretty` globally on `body` so long descriptions and account names wrap with balanced ragged endings.

## Files

- `src/app.css` — dark palette rebalance + `--brand-secondary` dark override + body `text-wrap: pretty`
- `src/lib/components/ui/table/table-row.svelte` — zebra stripe uses `bg-sidebar`
- `src/lib/components/ui/badge/badge.svelte` — `cash`/`debt`/`investment`/`other` variants use `text-white`
- `src/lib/components/key-value.svelte` — same `text-white` fix
- `src/routes/(app)/big-picture/summary.svelte` — wrapper uses `text-white`