### PR TITLE
test: stabilize trends two-year boundary

### DIFF
--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { setHours, startOfYear, subDays, subMonths, subYears } from 'date-fns';
+import { endOfDay, setHours, startOfYear, subDays, subMonths, subYears } from 'date-fns';
 
 import {
 	AccountsBalanceGroupOptions,
@@ -43,9 +43,7 @@ test('trends performance table', async ({ page }) => {
 	const fiveYears = subYears(now, 5);
 	const earliest = subYears(now, 6);
 	const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-	const twoYearsStart = new Date(
-		Date.UTC(twoYears.getUTCFullYear(), twoYears.getUTCMonth(), twoYears.getUTCDate())
-	);
+	const twoYearsStart = endOfDay(twoYears);
 
 	// YTD balance should be on Jan 1st to match the app's YTD anchor calculation.
 	// The app uses `endOfDay(startOfYear(new Date()))` for YTD, so a balance at


### PR DESCRIPTION
## Summary
- Align the trends performance 2Y fixture with the app's end-of-day anchor calculation.
- Keep the seeded two-year balance available when the app computes `endOfDay(subYears(new Date(), 2))`.

Fixes #355

## Validation
- `npx prettier --check e2e/trends.performance.test.ts`
- `npx eslint e2e/trends.performance.test.ts`
- `npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide`
- `npx svelte-check --tsconfig ./tsconfig.json` (0 errors, 7 pre-existing warnings)

## Note
- `npx playwright test e2e/trends.performance.test.ts` could not start locally because the Playwright webServer commands require `bun`, and `bun` is not installed in this environment (`/bin/sh: 1: bun: not found`).