### PR TITLE
feat: improve realtime financial loading

### DIFF
--- a/e2e/accounts.test.ts
+++ b/e2e/accounts.test.ts
@@ -23,7 +23,7 @@ test('accounts table reflects filters, transactions, and aggregate totals', asyn
 	await seedAccountBalance({
 		account: openAccount.id,
 		owner: user.id,
-		asOf: new Date().toISOString(),
+		asOf: '2025-01-01T00:00:00.000Z',
 		value: 2500
 	});
 	await seedTransaction({
@@ -112,6 +112,29 @@ test('accounts table reflects filters, transactions, and aggregate totals', asyn
 	await expect(closedRow).toContainText('-$400');
 	await expect(closedRow.getByText('Closed')).toBeVisible();
 	await expect(aggregateRow).toContainText('-$400');
+
+	await page.getByRole('tab', { name: 'Open' }).click();
+	const openBalanceCell = openRow.locator('td').nth(6);
+	await expect(openBalanceCell).toContainText('$2,500.00');
+	await expect(aggregateRow).toContainText('$2,500.00');
+
+	await seedAccountBalance({
+		account: openAccount.id,
+		owner: user.id,
+		asOf: '2025-02-01T00:00:00.000Z',
+		value: 7777
+	});
+	await expect(openBalanceCell).toContainText('$7,777.00');
+	await expect(aggregateRow).toContainText('$7,777.00');
+
+	await seedAccountBalance({
+		account: openAccount.id,
+		owner: user.id,
+		asOf: '2024-12-01T00:00:00.000Z',
+		value: 3333
+	});
+	await expect(openBalanceCell).toContainText('$7,777.00');
+	await expect(aggregateRow).toContainText('$7,777.00');
 });
 
 test('user can add a new account', async ({ page }) => {

--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -3,6 +3,7 @@ import { expect, test, type Locator } from '@playwright/test';
 import { AssetsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
+	deleteAssetBalance,
 	recordExists,
 	seedAsset,
 	seedAssetBalance,
@@ -475,7 +476,9 @@ test('user sees stale data warning and can refresh form', async ({ page }) => {
 	await expect(page.getByLabel('Name')).toHaveValue('Vanguard S&P 500 Index Fund');
 });
 
-test('user can delete asset and cascade deletes balances', async ({ page }) => {
+test('asset reverts to prior balance on balance delete, then cascade deletes on asset delete', async ({
+	page
+}) => {
 	const user = await seedUser('victor');
 
 	const asset = await seedAsset({
@@ -485,16 +488,27 @@ test('user can delete asset and cascade deletes balances', async ({ page }) => {
 		balanceType: 'ETF'
 	});
 
-	const balance = await seedAssetBalance({
+	const oldestBalance = await seedAssetBalance({
 		asset: asset.id,
 		owner: user.id,
-		asOf: new Date().toISOString(),
-		bookValue: 10000,
-		marketValue: 12000
+		asOf: '2023-01-01T00:00:00.000Z',
+		marketValue: 3000
+	});
+	const middleBalance = await seedAssetBalance({
+		asset: asset.id,
+		owner: user.id,
+		asOf: '2024-01-01T00:00:00.000Z',
+		marketValue: 7000
+	});
+	const newestBalance = await seedAssetBalance({
+		asset: asset.id,
+		owner: user.id,
+		asOf: '2025-01-01T00:00:00.000Z',
+		marketValue: 9000
 	});
 
 	expect(await recordExists('assets', asset.id)).toBe(true);
-	expect(await recordExists('assetBalances', balance.id)).toBe(true);
+	expect(await recordExists('assetBalances', newestBalance.id)).toBe(true);
 
 	await page.goto('/');
 	await signIn(page, user.email);
@@ -502,6 +516,15 @@ test('user can delete asset and cascade deletes balances', async ({ page }) => {
 
 	const assetRow = page.getByRole('row', { name: 'Old Investment' });
 	await expect(assetRow).toBeVisible();
+	await expectAssetRowCells(assetRow, [[7, '$9,000.00']]);
+
+	await deleteAssetBalance(oldestBalance.id);
+	await expectAssetRowCells(assetRow, [[7, '$9,000.00']]);
+
+	await deleteAssetBalance(newestBalance.id);
+	await expectAssetRowCells(assetRow, [[7, '$7,000.00']]);
+
+	expect(await recordExists('assetBalances', middleBalance.id)).toBe(true);
 
 	await assetRow.getByRole('link', { name: 'Old Investment' }).click();
 	await expect(page).toHaveURL(new RegExp(`/assets/${asset.id}(\\?|$)`));
@@ -517,5 +540,5 @@ test('user can delete asset and cascade deletes balances', async ({ page }) => {
 	await expect(page.getByRole('row', { name: 'Old Investment' })).not.toBeVisible();
 
 	expect(await recordExists('assets', asset.id)).toBe(false);
-	expect(await recordExists('assetBalances', balance.id)).toBe(false);
+	expect(await recordExists('assetBalances', middleBalance.id)).toBe(false);
 });

--- a/e2e/balance-sheet.test.ts
+++ b/e2e/balance-sheet.test.ts
@@ -37,6 +37,7 @@ test('balance sheet', async ({ page }) => {
 	await expect(investments).toContainText('$0');
 	await expect(debt).toContainText('$0');
 	await expect(other).toContainText('$0');
+	await expect(page.getByText('No accounts or assets for this balance group')).toHaveCount(4);
 
 	const creditCard = await seedAccount({
 		name: 'Crescent Classic',

--- a/e2e/big-picture.cashflow.test.ts
+++ b/e2e/big-picture.cashflow.test.ts
@@ -2,9 +2,13 @@ import { UTCDate } from '@date-fns/utc';
 import { expect, test } from '@playwright/test';
 import { addMonths, endOfMonth, format, setHours, startOfMonth, subHours } from 'date-fns';
 
-import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
+import {
+	AccountsBalanceGroupOptions,
+	AccountSharesAccessRoleOptions,
+	AccountSharesPerspectiveOptions
+} from '../src/lib/pocketbase.schema';
 import { signIn } from './playwright.helpers';
-import { seedAccount, seedTransaction, seedUser } from './pocketbase.helpers';
+import { seedAccount, seedAccountShare, seedTransaction, seedUser } from './pocketbase.helpers';
 
 type PeriodSeed = {
 	monthsAgo: number;
@@ -204,12 +208,12 @@ test.describe('big picture cashflow chart', () => {
 test('clicking cashflow chart bar navigates to transactions filtered by that month', async ({
 	page
 }) => {
-	const user = await seedUser('morgan');
+	const elena = await seedUser('elena');
 
 	const account = await seedAccount({
 		name: 'Cashflow Link Test Account',
 		balanceGroup: AccountsBalanceGroupOptions.CASH,
-		owner: user.id,
+		owner: elena.id,
 		balanceType: 'Checking',
 		autoCalculated: new Date().toISOString()
 	});
@@ -221,7 +225,7 @@ test('clicking cashflow chart bar navigates to transactions filtered by that mon
 
 	await seedTransaction({
 		account: account.id,
-		owner: user.id,
+		owner: elena.id,
 		date: new UTCDate(
 			targetMonth.getUTCFullYear(),
 			targetMonth.getUTCMonth(),
@@ -236,7 +240,7 @@ test('clicking cashflow chart bar navigates to transactions filtered by that mon
 	});
 	await seedTransaction({
 		account: account.id,
-		owner: user.id,
+		owner: elena.id,
 		date: new UTCDate(
 			targetMonth.getUTCFullYear(),
 			targetMonth.getUTCMonth(),
@@ -253,14 +257,14 @@ test('clicking cashflow chart bar navigates to transactions filtered by that mon
 	// Seed a transaction in the current month (should NOT be visible after filtering)
 	await seedTransaction({
 		account: account.id,
-		owner: user.id,
+		owner: elena.id,
 		date: new UTCDate(now.getUTCFullYear(), now.getUTCMonth(), 5, 12, 0, 0, 0).toISOString(),
 		description: 'Current Month Transaction',
 		value: 200
 	});
 
 	await page.goto('/');
-	await signIn(page, user.email);
+	await signIn(page, elena.email);
 
 	// Click on the target month's bar in the cashflow chart
 	// The bar has aria-label "{periodLabel}: {surplus}" format
@@ -294,4 +298,50 @@ test('clicking cashflow chart bar navigates to transactions filtered by that mon
 	await expect(page.getByText('Target Month Income')).toBeVisible();
 	await expect(page.getByText('Target Month Expense')).toBeVisible();
 	await expect(page.getByText('Current Month Transaction')).toBeVisible();
+});
+
+test('recipient sees inverse shared account cashflow in projected income and expense buckets', async ({
+	page
+}) => {
+	const marisol = await seedUser('marisol');
+	const quentin = await seedUser('quentin');
+
+	const sharedAccount = await seedAccount({
+		name: 'Shared reimbursement ledger',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: marisol.id,
+		balanceType: 'Shared cashflow',
+		autoCalculated: new Date().toISOString()
+	});
+
+	await seedTransaction({
+		account: sharedAccount.id,
+		owner: marisol.id,
+		date: isoFirstOfMonth(0),
+		description: 'Recipient-side income',
+		value: -1200
+	});
+	await seedTransaction({
+		account: sharedAccount.id,
+		owner: marisol.id,
+		date: isoFirstOfMonth(0),
+		description: 'Recipient-side expense',
+		value: 600
+	});
+	await seedAccountShare({
+		account: sharedAccount.id,
+		recipient: quentin.id,
+		recipientEmail: quentin.email,
+		grantedBy: marisol.id,
+		accessRole: AccountSharesAccessRoleOptions.VIEWER,
+		perspective: AccountSharesPerspectiveOptions.INVERSE,
+		includeInNetWorth: true
+	});
+
+	await page.goto('/');
+	await signIn(page, quentin.email);
+
+	await expect(page.getByRole('region', { name: 'Income per month' })).toContainText('$200');
+	await expect(page.getByRole('region', { name: 'Expenses per month' })).toContainText('$100');
+	await expect(page.getByRole('region', { name: 'Surplus per month' })).toContainText('$100');
 });

--- a/e2e/big-picture.cashflow.test.ts
+++ b/e2e/big-picture.cashflow.test.ts
@@ -300,7 +300,7 @@ test('clicking cashflow chart bar navigates to transactions filtered by that mon
 	await expect(page.getByText('Current Month Transaction')).toBeVisible();
 });
 
-test('recipient sees inverse shared account cashflow in projected income and expense buckets', async ({
+test('recipient sees inverse shared account cashflow in per-month income and expense averages', async ({
 	page
 }) => {
 	const marisol = await seedUser('marisol');

--- a/e2e/pocketbase.helpers.ts
+++ b/e2e/pocketbase.helpers.ts
@@ -264,6 +264,11 @@ export async function deleteUser(id: string) {
 	await pb.collection('users').delete(id);
 }
 
+export async function deleteAssetBalance(id: string) {
+	const pb = await getAdminPB();
+	await pb.collection('assetBalances').delete(id);
+}
+
 export async function getTransactionLabelsByName(owner: string, name: string) {
 	const pb = await getAdminPB();
 	return await pb.collection('transactionLabels').getFullList({

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -229,6 +229,89 @@ test('transactions pagination navigates between pages', async ({ page }) => {
 	await expect(creditRows.first()).toBeVisible();
 });
 
+test('credits filter paginates across pages client-side', async ({ page }) => {
+	const user = await seedUser('dakota');
+
+	const account = await seedAccount({
+		name: 'Primary Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 5000
+	});
+
+	const prefix = 'Credit Batch Tx';
+	const baseDate = new Date();
+	const seededDescriptions: string[] = [];
+	for (let i = 0; i < 51; i++) {
+		const date = new Date(
+			Date.UTC(
+				baseDate.getUTCFullYear(),
+				baseDate.getUTCMonth(),
+				baseDate.getUTCDate(),
+				12,
+				0,
+				0,
+				0
+			)
+		);
+		date.setUTCDate(date.getUTCDate() - i);
+		const description = `${prefix} ${String(i + 1).padStart(3, '0')}`;
+		await seedTransaction({
+			account: account.id,
+			owner: user.id,
+			date: date.toISOString(),
+			description,
+			value: 100 + i
+		});
+		seededDescriptions.push(description);
+	}
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Transactions');
+
+	// Use "Lifetime" so every seeded credit is in range regardless of month boundaries
+	await page.getByLabel('Period').click();
+	await page.getByRole('button', { name: 'Lifetime' }).click();
+	await expect(page.getByLabel('Period')).toContainText('Lifetime');
+
+	await page.getByLabel('Type').click();
+	await page.getByRole('option', { name: 'Credits only' }).click();
+	await expect(page.getByLabel('Type')).toContainText('Credits only');
+
+	const rowsForBatch = page.getByRole('row', { name: prefix });
+	const previousButton = page.getByRole('button', { name: 'Previous' });
+	const nextButton = page.getByRole('button', { name: 'Next' });
+	await expect(rowsForBatch).toHaveCount(50);
+	await expect(previousButton).toBeDisabled();
+	await expect(nextButton).toBeEnabled();
+
+	// Newest transaction is on page 1; the oldest is on page 2 (client-side slice)
+	const firstDescription = seededDescriptions[0] ?? '';
+	const lastDescription = seededDescriptions[seededDescriptions.length - 1] ?? '';
+	await expect(page.getByRole('row', { name: firstDescription })).toBeVisible();
+	await expect(page.getByRole('row', { name: lastDescription })).toHaveCount(0);
+
+	await nextButton.click();
+	await expect(rowsForBatch).toHaveCount(1);
+	await expect(page.getByRole('row', { name: lastDescription })).toBeVisible();
+	await expect(page.getByRole('row', { name: firstDescription })).toHaveCount(0);
+	await expect(nextButton).toBeDisabled();
+	await expect(previousButton).toBeEnabled();
+
+	await previousButton.click();
+	await expect(rowsForBatch).toHaveCount(50);
+	await expect(page.getByRole('row', { name: firstDescription })).toBeVisible();
+	await expect(previousButton).toBeDisabled();
+	await expect(nextButton).toBeEnabled();
+});
+
 test('transactions can be searched by description', async ({ page }) => {
 	const user = await seedUser('grace');
 

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -217,6 +217,17 @@ test('trends performance table', async ({ page }) => {
 	await expect(growthChart).toHaveAttribute('data-growth-start-net', '22500');
 	await expect(growthChart).toHaveAttribute('data-growth-end-net', '5000');
 
+	// The performance table is bounded to 5 years, but the MAX growth chart receives the
+	// full-history balances, so its range start reaches the earliest seeded balance (6 years
+	// back) rather than the 2Y window start.
+	await page.getByRole('tab', { name: 'MAX' }).click();
+	const maxChart = page.locator('[data-growth-period="max"]');
+	await expect(maxChart).toHaveAttribute('data-growth-start', earliest.toISOString().slice(0, 10));
+	await expect(maxChart).not.toHaveAttribute(
+		'data-growth-start',
+		twoYearsStart.toISOString().slice(0, 10)
+	);
+
 	// Table columns: Group | 1W | 1M | 6M | YTD | 1Y | 2Y | 5Y | MAX | Allocation
 	// Columns 1-5 (1W, 1M, 6M, YTD, 1Y) can have date collisions depending on
 	// when the test runs (e.g., 1W and YTD collide in early January).

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,7 @@
 	"sidebar_data_sources": "Data sources",
 	"sidebar_big_picture": "The big picture",
 	"sidebar_balance_sheet": "Balance sheet",
+	"balance_sheet_group_empty": "No accounts or assets for this balance group",
 	"sidebar_trends": "Trends",
 	"sidebar_assets": "Assets",
 	"portfolio_page_title": "Portfolio",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,6 +31,7 @@
 	"sidebar_data_sources": "Fuentes de datos",
 	"sidebar_big_picture": "Panorama",
 	"sidebar_balance_sheet": "Balances",
+	"balance_sheet_group_empty": "No hay cuentas ni activos para este grupo de balance",
 	"sidebar_trends": "Tendencias",
 	"sidebar_assets": "Activos",
 	"portfolio_page_title": "Portafolio",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"build": "bun run vite build",
 		"preview": "bun run vite preview",
 		"prepare": "svelte-kit sync || echo ''",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "bun run prettier --write .",
 		"lint": "bun run prettier --check . && bun run eslint .",

--- a/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
+++ b/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
@@ -43,8 +43,7 @@ migrate((app) => {
   unmarshal({
     "indexes": [
       "CREATE INDEX idx_securityBalances_importSession ON securityBalances (importSession, owner)",
-      "CREATE INDEX idx_securityBalances_lookup ON securityBalances (account, security, asOf)",
-      "CREATE INDEX idx_securityBalances_account_asOf ON securityBalances (account, asOf)"
+      "CREATE INDEX idx_securityBalances_lookup ON securityBalances (account, security, asOf)"
     ]
   }, securityBalances)
 

--- a/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
+++ b/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
@@ -1,0 +1,123 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const transactions = app.findCollectionByNameOrId("pbc_3174063690")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_transactions_importSession ON transactions (importSession, owner)",
+      "CREATE INDEX idx_transactions_externalId ON transactions (account, externalId, owner) WHERE externalId != ''",
+      "CREATE INDEX idx_transactions_account_date ON transactions (account, date)"
+    ]
+  }, transactions)
+
+  app.save(transactions)
+
+  const accountBalances = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_accountBalances_importSession ON accountBalances (importSession, owner)",
+      "CREATE INDEX idx_accountBalances_account_asOf ON accountBalances (account, asOf)"
+    ]
+  }, accountBalances)
+
+  app.save(accountBalances)
+
+  const assetBalances = app.findCollectionByNameOrId("pbc_1178802947")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_assetBalances_importSession ON assetBalances (importSession, owner)",
+      "CREATE INDEX idx_assetBalances_asset_asOf ON assetBalances (asset, asOf)"
+    ]
+  }, assetBalances)
+
+  app.save(assetBalances)
+
+  const securityBalances = app.findCollectionByNameOrId("pbc_3206402748")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_securityBalances_importSession ON securityBalances (importSession, owner)",
+      "CREATE INDEX idx_securityBalances_lookup ON securityBalances (account, security, asOf)",
+      "CREATE INDEX idx_securityBalances_account_asOf ON securityBalances (account, asOf)"
+    ]
+  }, securityBalances)
+
+  app.save(securityBalances)
+
+  const securityTransactions = app.findCollectionByNameOrId("pbc_2175204147")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_securityTransactions_importSession ON securityTransactions (importSession, owner)",
+      "CREATE INDEX idx_securityTransactions_lookup ON securityTransactions (account, security, date)",
+      "CREATE INDEX idx_securityTransactions_account_date ON securityTransactions (account, date)"
+    ]
+  }, securityTransactions)
+
+  return app.save(securityTransactions)
+}, (app) => {
+  const transactions = app.findCollectionByNameOrId("pbc_3174063690")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_transactions_importSession ON transactions (importSession, owner)",
+      "CREATE INDEX idx_transactions_externalId ON transactions (account, externalId, owner) WHERE externalId != ''"
+    ]
+  }, transactions)
+
+  app.save(transactions)
+
+  const accountBalances = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_accountBalances_importSession ON accountBalances (importSession, owner)"
+    ]
+  }, accountBalances)
+
+  app.save(accountBalances)
+
+  const assetBalances = app.findCollectionByNameOrId("pbc_1178802947")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_assetBalances_importSession ON assetBalances (importSession, owner)"
+    ]
+  }, assetBalances)
+
+  app.save(assetBalances)
+
+  const securityBalances = app.findCollectionByNameOrId("pbc_3206402748")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_securityBalances_importSession ON securityBalances (importSession, owner)",
+      "CREATE INDEX idx_securityBalances_lookup ON securityBalances (account, security, asOf)"
+    ]
+  }, securityBalances)
+
+  app.save(securityBalances)
+
+  const securityTransactions = app.findCollectionByNameOrId("pbc_2175204147")
+
+  // update collection data
+  unmarshal({
+    "indexes": [
+      "CREATE INDEX idx_securityTransactions_importSession ON securityTransactions (importSession, owner)",
+      "CREATE INDEX idx_securityTransactions_lookup ON securityTransactions (account, security, date)"
+    ]
+  }, securityTransactions)
+
+  return app.save(securityTransactions)
+})

--- a/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
+++ b/pocketbase/pb_migrations/1781654400_add_collection_performance_indexes.js
@@ -7,7 +7,8 @@ migrate((app) => {
     "indexes": [
       "CREATE INDEX idx_transactions_importSession ON transactions (importSession, owner)",
       "CREATE INDEX idx_transactions_externalId ON transactions (account, externalId, owner) WHERE externalId != ''",
-      "CREATE INDEX idx_transactions_account_date ON transactions (account, date)"
+      "CREATE INDEX idx_transactions_account_date ON transactions (account, date)",
+      "CREATE INDEX idx_transactions_excluded_date ON transactions (excluded, date)"
     ]
   }, transactions)
 

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -33,31 +33,42 @@ type PositionsSource = {
 	positionsLoaded: boolean;
 };
 
-const DEBOUNCE_MS = 200;
+type LatestAccountBalance = {
+	id: string;
+	account: string;
+	value: number;
+	asOf: string;
+	created: string;
+};
 
 class AccountsContext {
 	accounts: AccountWithBalance[] = $derived.by(() =>
-		this.rawAccounts.map(({ record, cashBalance, balanceAsOf }) => {
+		this.rawAccounts.map((record) => {
+			const cash = this.latestCashByAccount.get(record.id);
 			const positions = this.positionsSource?.positionsValueByAccount;
 			const positionsValue = positions && positions.has(record.id) ? positions.get(record.id)! : 0;
-			return this.toAccountWithBalance(record, cashBalance, positionsValue, balanceAsOf);
+			return this.toAccountWithBalance(
+				record,
+				cash?.value ?? 0,
+				positionsValue,
+				cash?.asOf ?? ''
+			);
 		})
 	);
 	get accountRecords(): AccountsResponse[] {
-		return this.rawAccounts.map(({ record }) => record);
+		return this.rawAccounts;
 	}
 	shares: AccountSharesResponse[] = $state([]);
 	lastBalanceEvent: number = $state(0);
 	isLoading: boolean = $state(true);
 
-	private rawAccounts: { record: AccountsResponse; cashBalance: number; balanceAsOf: string }[] =
-		$state([]);
+	private rawAccounts: AccountsResponse[] = $state([]);
+	private latestCashByAccount = new SvelteMap<string, LatestAccountBalance>();
 	private positionsSource: PositionsSource | null = $state(null);
 	private accountsLoaded = false;
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
-	private refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private refreshSequence = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
@@ -125,16 +136,24 @@ class AccountsContext {
 			perspective
 		});
 		await this.refreshShares();
+		if (await this.refreshAccount(accountId, this.currentUserId)) this.notifyBalancesChanged();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
-		await this._pb.authedClient.collection('accountShares').update(shareId, { includeInNetWorth });
+		const share = await this._pb.authedClient
+			.collection('accountShares')
+			.update<AccountSharesResponse>(shareId, { includeInNetWorth });
 		await this.refreshShares();
+		if (await this.refreshAccount(share.account, this.currentUserId)) this.notifyBalancesChanged();
 	}
 
 	async revokeShare(shareId: string) {
+		const accountId = this.shares.find((share) => share.id === shareId)?.account;
 		await this._pb.authedClient.collection('accountShares').delete(shareId);
 		await this.refreshShares();
+		if (accountId && (await this.refreshAccount(accountId, this.currentUserId))) {
+			this.notifyBalancesChanged();
+		}
 	}
 
 	private init() {
@@ -145,9 +164,8 @@ class AccountsContext {
 			this._activeUserId = userId;
 			if (!userId) {
 				this.refreshSequence++;
-				if (this.refreshTimer) clearTimeout(this.refreshTimer);
-				this.refreshTimer = null;
 				this.rawAccounts = [];
+				this.latestCashByAccount.clear();
 				this.shares = [];
 				this.accountsLoaded = false;
 				this.lastBalanceEvent = 0;
@@ -190,31 +208,23 @@ class AccountsContext {
 
 	private async refreshAccounts(userId = this.currentUserId, token = this.refreshSequence) {
 		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const [accounts, accountBalances] = await Promise.all([
-			this._pb.authedClient.collection('accounts').getFullList<AccountsResponse>({
-				filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
-				requestKey: null
-			}),
-			this._pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
-				sort: 'account,-asOf,-created,-id',
-				requestKey: null
-			})
-		]);
+		const accounts = await this._pb.authedClient.collection('accounts').getFullList<AccountsResponse>({
+			filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
+			requestKey: null
+		});
 		for (const account of accounts) {
 			await this.balanceTypesContext.ensureLoaded(account.balanceType);
 		}
+		const latestBalances = await Promise.all(
+			accounts.map((account) => this.getLatestAccountBalance(account.id))
+		);
 		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 
-		const latestCashByAccount = new SvelteMap<string, AccountBalancesResponse>();
-		for (const balance of accountBalances) {
-			if (!latestCashByAccount.has(balance.account)) {
-				latestCashByAccount.set(balance.account, balance);
-			}
+		this.latestCashByAccount.clear();
+		for (const balance of latestBalances) {
+			if (balance) this.latestCashByAccount.set(balance.account, balance);
 		}
-		this.rawAccounts = accounts.map((record) => {
-			const cash = latestCashByAccount.get(record.id);
-			return { record, cashBalance: cash?.value ?? 0, balanceAsOf: cash?.asOf ?? '' };
-		});
+		this.rawAccounts = accounts;
 		this.accountsLoaded = true;
 	}
 
@@ -223,7 +233,13 @@ class AccountsContext {
 
 		this._pb.authedClient
 			.collection('accounts')
-			.subscribe<AccountsResponse>('*', (event) => this.onCollectionEvent(event, userId))
+			.subscribe<AccountsResponse>('*', (event) => {
+				void this.onCollectionEvent(event, userId).catch((error) => {
+					if (userId === this._activeUserId) {
+						this._pb.handleConnectionError(error, 'accounts', 'account_event');
+					}
+				});
+			})
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_accounts');
@@ -233,7 +249,13 @@ class AccountsContext {
 			});
 		this._pb.authedClient
 			.collection('accountBalances')
-			.subscribe<AccountBalancesResponse>('*', (event) => this.onCollectionEvent(event, userId))
+			.subscribe<AccountBalancesResponse>('*', (event) => {
+				void this.onCollectionEvent(event, userId).catch((error) => {
+					if (userId === this._activeUserId) {
+						this._pb.handleConnectionError(error, 'accounts', 'balance_event');
+					}
+				});
+			})
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_balances');
@@ -262,13 +284,17 @@ class AccountsContext {
 		this._pb.authedClient.collection('accountShares').unsubscribe('*');
 	}
 
-	private onCollectionEvent(
+	private async onCollectionEvent(
 		e: RecordSubscription<AccountsResponse> | RecordSubscription<AccountBalancesResponse>,
 		userId: string
 	) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!e.action) return;
-		this.scheduleRefresh();
+		if ('account' in e.record) {
+			await this.onAccountBalanceEvent(e.action, e.record, userId);
+			return;
+		}
+		await this.onAccountEvent(e.action, e.record, userId);
 	}
 
 	private onAccountShareEvent(e: RecordSubscription<AccountSharesResponse>, userId: string) {
@@ -283,25 +309,141 @@ class AccountsContext {
 			this.shares = this.shares.filter((share) => share.id !== e.record.id);
 		}
 
-		this.scheduleRefresh();
+		void this.refreshAccount(e.record.account, userId)
+			.then(() => this.notifyBalancesChanged())
+			.catch((error) => {
+				if (userId === this.currentUserId) this._pb.handleConnectionError(error, 'accounts', 'share');
+			});
 	}
 
-	private scheduleRefresh() {
-		if (this.refreshTimer) clearTimeout(this.refreshTimer);
-		const userId = this.currentUserId;
-		if (!userId) return;
-		const token = ++this.refreshSequence;
-		this.refreshTimer = setTimeout(async () => {
-			this.refreshTimer = null;
-			try {
-				await this.refreshShares(userId, token);
-				await this.refreshAccounts(userId, token);
-				this.notifyBalancesChanged();
-			} catch (error) {
-				if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-				this._pb.handleConnectionError(error, 'accounts', 'refresh');
+	private async onAccountEvent(action: string, account: AccountsResponse, userId: string) {
+		if (action === 'delete') {
+			this.rawAccounts = this.rawAccounts.filter((record) => record.id !== account.id);
+			this.latestCashByAccount.delete(account.id);
+			this.notifyBalancesChanged();
+			return;
+		}
+
+		await this.balanceTypesContext.ensureLoaded(account.balanceType);
+		if (userId !== this.currentUserId) return;
+		const exists = this.rawAccounts.some((record) => record.id === account.id);
+		this.rawAccounts = exists
+			? this.rawAccounts.map((record) => (record.id === account.id ? account : record))
+			: [...this.rawAccounts, account];
+		if (!this.latestCashByAccount.has(account.id)) {
+			await this.refreshAccountBalance(account.id, userId);
+		}
+		this.notifyBalancesChanged();
+	}
+
+	private async onAccountBalanceEvent(
+		action: string,
+		balance: AccountBalancesResponse,
+		userId: string
+	) {
+		const accountId = balance.account;
+		let previousAccountId: string | null = null;
+		for (const [key, currentBalance] of this.latestCashByAccount) {
+			if (currentBalance.id === balance.id) {
+				previousAccountId = key;
+				break;
 			}
-		}, DEBOUNCE_MS);
+		}
+		if (previousAccountId && previousAccountId !== accountId) {
+			await this.refreshAccountBalance(previousAccountId, userId);
+		}
+
+		if (!this.rawAccounts.some((account) => account.id === accountId)) {
+			await this.refreshAccount(accountId, userId);
+			this.notifyBalancesChanged();
+			return;
+		}
+
+		const current = this.latestCashByAccount.get(accountId);
+		if (action === 'delete' || current?.id === balance.id) {
+			await this.refreshAccountBalance(accountId, userId);
+			this.notifyBalancesChanged();
+			return;
+		}
+
+		if (!current || this.isAtLeastAsRecent(balance, current)) {
+			this.latestCashByAccount.set(accountId, this.toLatestAccountBalance(balance));
+			this.notifyBalancesChanged();
+		}
+	}
+
+	private async refreshAccount(accountId: string, userId: string) {
+		if (!userId || userId !== this.currentUserId) return false;
+		try {
+			const account = await this._pb.authedClient
+				.collection('accounts')
+				.getOne<AccountsResponse>(accountId, { requestKey: null });
+			await this.balanceTypesContext.ensureLoaded(account.balanceType);
+			const balance = await this.getLatestAccountBalance(accountId);
+			if (userId !== this.currentUserId) return false;
+			const exists = this.rawAccounts.some((record) => record.id === account.id);
+			this.rawAccounts = exists
+				? this.rawAccounts.map((record) => (record.id === account.id ? account : record))
+				: [...this.rawAccounts, account];
+			if (balance) this.latestCashByAccount.set(accountId, balance);
+			else this.latestCashByAccount.delete(accountId);
+			return true;
+		} catch (error) {
+			if (this.isUnavailableRecordError(error)) {
+				this.rawAccounts = this.rawAccounts.filter((account) => account.id !== accountId);
+				this.latestCashByAccount.delete(accountId);
+				return true;
+			}
+			throw error;
+		}
+	}
+
+	private async refreshAccountBalance(accountId: string, userId: string) {
+		const balance = await this.getLatestAccountBalance(accountId);
+		if (userId !== this.currentUserId) return false;
+		if (balance) this.latestCashByAccount.set(accountId, balance);
+		else this.latestCashByAccount.delete(accountId);
+		return true;
+	}
+
+	private async getLatestAccountBalance(accountId: string) {
+		const res = await this._pb.authedClient
+			.collection('accountBalances')
+			.getList<AccountBalancesResponse>(1, 1, {
+				filter: `account='${accountId}'`,
+				sort: '-asOf,-created,-id',
+				requestKey: null
+			});
+		const balance = res.items[0];
+		return balance ? this.toLatestAccountBalance(balance) : null;
+	}
+
+	private toLatestAccountBalance(balance: AccountBalancesResponse) {
+		return {
+			id: balance.id,
+			account: balance.account,
+			value: balance.value ?? 0,
+			asOf: balance.asOf,
+			created: balance.created
+		};
+	}
+
+	private isAtLeastAsRecent(
+		balance: Pick<AccountBalancesResponse, 'asOf' | 'created' | 'id'>,
+		current: Pick<LatestAccountBalance, 'asOf' | 'created' | 'id'>
+	) {
+		if (balance.asOf !== current.asOf) return balance.asOf > current.asOf;
+		if (balance.created !== current.created) return balance.created > current.created;
+		return balance.id >= current.id;
+	}
+
+	private isUnavailableRecordError(error: unknown) {
+		return (
+			typeof error === 'object' &&
+			error !== null &&
+			'status' in error &&
+			(error.status === 403 || error.status === 404)
+		);
 	}
 
 	private toAccountWithBalance(
@@ -342,7 +484,6 @@ class AccountsContext {
 	}
 
 	dispose() {
-		if (this.refreshTimer) clearTimeout(this.refreshTimer);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -47,12 +47,7 @@ class AccountsContext {
 			const cash = this.latestCashByAccount.get(record.id);
 			const positions = this.positionsSource?.positionsValueByAccount;
 			const positionsValue = positions && positions.has(record.id) ? positions.get(record.id)! : 0;
-			return this.toAccountWithBalance(
-				record,
-				cash?.value ?? 0,
-				positionsValue,
-				cash?.asOf ?? ''
-			);
+			return this.toAccountWithBalance(record, cash?.value ?? 0, positionsValue, cash?.asOf ?? '');
 		})
 	);
 	get accountRecords(): AccountsResponse[] {
@@ -208,10 +203,12 @@ class AccountsContext {
 
 	private async refreshAccounts(userId = this.currentUserId, token = this.refreshSequence) {
 		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const accounts = await this._pb.authedClient.collection('accounts').getFullList<AccountsResponse>({
-			filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
-			requestKey: null
-		});
+		const accounts = await this._pb.authedClient
+			.collection('accounts')
+			.getFullList<AccountsResponse>({
+				filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
+				requestKey: null
+			});
 		for (const account of accounts) {
 			await this.balanceTypesContext.ensureLoaded(account.balanceType);
 		}
@@ -312,7 +309,8 @@ class AccountsContext {
 		void this.refreshAccount(e.record.account, userId)
 			.then(() => this.notifyBalancesChanged())
 			.catch((error) => {
-				if (userId === this.currentUserId) this._pb.handleConnectionError(error, 'accounts', 'share');
+				if (userId === this.currentUserId)
+					this._pb.handleConnectionError(error, 'accounts', 'share');
 			});
 	}
 

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -370,7 +370,7 @@ class AccountsContext {
 		}
 	}
 
-	private async refreshAccount(accountId: string, userId: string) {
+	async refreshAccount(accountId: string, userId: string) {
 		if (!userId || userId !== this.currentUserId) return false;
 		try {
 			const account = await this._pb.authedClient
@@ -397,10 +397,16 @@ class AccountsContext {
 	}
 
 	private async refreshAccountBalance(accountId: string, userId: string) {
+		const balanceBeforeRefresh = this.latestCashByAccount.get(accountId);
 		const balance = await this.getLatestAccountBalance(accountId);
 		if (userId !== this.currentUserId) return false;
 		if (balance) this.latestCashByAccount.set(accountId, balance);
-		else this.latestCashByAccount.delete(accountId);
+		else if (
+			balanceBeforeRefresh &&
+			this.latestCashByAccount.get(accountId)?.id === balanceBeforeRefresh.id
+		) {
+			this.latestCashByAccount.delete(accountId);
+		}
 		return true;
 	}
 

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -106,34 +106,40 @@ class AssetsContext {
 		recipientEmail: string,
 		perspective: AssetSharesPerspectiveOptions
 	) {
+		const userId = this.currentUserId;
 		await this._pb.postJson('/api/shares/assets', {
 			assetId,
 			recipientEmail,
 			perspective
 		});
-		await this.refreshShares();
-		if (await this.refreshAsset(assetId)) this.lastBalanceEvent = Date.now();
+		await this.refreshShares(userId);
+		if (await this.refreshAsset(assetId, userId)) this.lastBalanceEvent = Date.now();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
+		const userId = this.currentUserId;
 		const share = await this._pb.authedClient
 			.collection('assetShares')
 			.update<AssetSharesResponse>(shareId, { includeInNetWorth });
-		await this.refreshShares();
-		if (await this.refreshAsset(share.asset)) this.lastBalanceEvent = Date.now();
+		await this.refreshShares(userId);
+		if (await this.refreshAsset(share.asset, userId)) this.lastBalanceEvent = Date.now();
 	}
 
 	async revokeShare(shareId: string) {
+		const userId = this.currentUserId;
 		const assetId = this.shares.find((share) => share.id === shareId)?.asset;
 		await this._pb.authedClient.collection('assetShares').delete(shareId);
-		await this.refreshShares();
-		if (assetId && (await this.refreshAsset(assetId))) this.lastBalanceEvent = Date.now();
+		await this.refreshShares(userId);
+		if (assetId && (await this.refreshAsset(assetId, userId))) {
+			this.lastBalanceEvent = Date.now();
+		}
 	}
 
 	private async init() {
 		try {
+			const userId = this.currentUserId;
 			this.realtimeSubscribe();
-			await this.refreshShares();
+			await this.refreshShares(userId);
 			await this.refreshAssets();
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
@@ -143,11 +149,16 @@ class AssetsContext {
 		}
 	}
 
-	private async refreshShares() {
-		this.shares = await this._pb.authedClient.collection('assetShares').getFullList({
+	private async refreshShares(userId: string) {
+		if (userId !== this.currentUserId) return false;
+
+		const shares = await this._pb.authedClient.collection('assetShares').getFullList({
 			sort: 'recipientEmail',
 			requestKey: null
 		});
+		if (userId !== this.currentUserId) return false;
+		this.shares = shares;
+		return true;
 	}
 
 	private async refreshAssets() {
@@ -173,38 +184,68 @@ class AssetsContext {
 	}
 
 	private realtimeSubscribe() {
+		const userId = this.currentUserId;
+		if (!userId) return;
+
 		this._pb.authedClient
 			.collection('assets')
 			.subscribe<AssetsResponse>('*', (event) => {
-				void this.onAssetEvent(event).catch((error) =>
-					this._pb.handleConnectionError(error, 'assets', 'asset_event')
-				);
+				void this.onAssetEvent(event, userId).catch((error) => {
+					if (userId === this.currentUserId) {
+						this._pb.handleConnectionError(error, 'assets', 'asset_event');
+					} else {
+						console.error('[assetsStore] Stale event failed:', error);
+					}
+				});
 			})
-			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets'));
+			.catch((error) => {
+				if (userId === this.currentUserId) {
+					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets');
+				} else {
+					console.error('[assetsStore] Stale subscription failed:', error);
+				}
+			});
 		this._pb.authedClient
 			.collection('assetBalances')
-			.subscribe<AssetBalancesResponse>('*', this.onAssetBalanceEvent.bind(this))
-			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances'));
+			.subscribe<AssetBalancesResponse>('*', (event) => this.onAssetBalanceEvent(event, userId))
+			.catch((error) => {
+				if (userId === this.currentUserId) {
+					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances');
+				} else {
+					console.error('[assetsStore] Stale subscription failed:', error);
+				}
+			});
 		this._pb.authedClient
 			.collection('assetShares')
-			.subscribe<AssetSharesResponse>('*', this.onAssetShareEvent.bind(this))
-			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares'));
+			.subscribe<AssetSharesResponse>('*', (event) => this.onAssetShareEvent(event, userId))
+			.catch((error) => {
+				if (userId === this.currentUserId) {
+					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares');
+				} else {
+					console.error('[assetsStore] Stale subscription failed:', error);
+				}
+			});
 	}
 
-	private async onAssetEvent(e: RecordSubscription<AssetsResponse>) {
+	private async onAssetEvent(e: RecordSubscription<AssetsResponse>, userId: string) {
+		if (userId !== this.currentUserId) return;
+
 		if (e.action === 'create') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			const balanceData = await this.getLatestAssetBalance(e.record.id);
+			if (userId !== this.currentUserId) return;
 			this.rawAssets = [...this.rawAssets, e.record];
 			if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
 		} else if (e.action === 'update') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
+			if (userId !== this.currentUserId) return;
 			const exists = this.rawAssets.some((asset) => asset.id === e.record.id);
 			this.rawAssets = exists
 				? this.rawAssets.map((asset) => (asset.id === e.record.id ? e.record : asset))
 				: [...this.rawAssets, e.record];
 			if (!this.latestBalanceByAsset.has(e.record.id)) {
 				const balanceData = await this.getLatestAssetBalance(e.record.id);
+				if (userId !== this.currentUserId) return;
 				if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
 			}
 		} else if (e.action === 'delete') {
@@ -213,34 +254,42 @@ class AssetsContext {
 		}
 	}
 
-	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>) {
+	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>, userId: string) {
+		if (userId !== this.currentUserId) return;
 		if (!e.action) return;
 		const assetId = e.record.asset;
-		let previousAssetId: string | null = null;
+		let displayedAssetId: string | null = null;
 		for (const [key, currentBalance] of this.latestBalanceByAsset) {
 			if (currentBalance.id === e.record.id) {
-				previousAssetId = key;
+				displayedAssetId = key;
 				break;
 			}
 		}
-		if (previousAssetId && previousAssetId !== assetId) {
-			void this.refetchAssetBalance(previousAssetId);
+		if (displayedAssetId && displayedAssetId !== assetId) {
+			void this.refetchAssetBalance(displayedAssetId, userId);
 		}
 
 		if (e.action === 'create' || e.action === 'update') {
 			const asset = this.rawAssets.find((x) => x.id === assetId);
 			if (!asset) {
-				void this.refreshAsset(assetId)
+				void this.refreshAsset(assetId, userId)
 					.then((refreshed) => {
+						if (userId !== this.currentUserId) return;
 						if (refreshed) this.lastBalanceEvent = Date.now();
 					})
-					.catch((error) => this._pb.handleConnectionError(error, 'assets', 'balance'));
+					.catch((error) => {
+						if (userId === this.currentUserId) {
+							this._pb.handleConnectionError(error, 'assets', 'balance');
+						} else {
+							console.error('[assetsStore] Stale event failed:', error);
+						}
+					});
 				return;
 			}
 
 			const current = this.latestBalanceByAsset.get(assetId);
 			if (current?.id === e.record.id) {
-				void this.refetchAssetBalance(assetId);
+				void this.refetchAssetBalance(assetId, userId);
 				return;
 			}
 
@@ -248,12 +297,14 @@ class AssetsContext {
 				this.latestBalanceByAsset.set(assetId, this.toLatestAssetBalance(e.record));
 				this.lastBalanceEvent = Date.now();
 			}
-		} else if (e.action === 'delete') {
-			void this.refetchAssetBalance(assetId);
+		} else if (e.action === 'delete' && displayedAssetId === assetId) {
+			void this.refetchAssetBalance(assetId, userId);
 		}
 	}
 
-	private onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>) {
+	private onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>, userId: string) {
+		if (userId !== this.currentUserId) return;
+
 		if (e.action === 'create') {
 			this.shares = [...this.shares, e.record];
 		} else if (e.action === 'update') {
@@ -262,11 +313,18 @@ class AssetsContext {
 			this.shares = this.shares.filter((share) => share.id !== e.record.id);
 		}
 
-		void this.refreshAsset(e.record.asset)
+		void this.refreshAsset(e.record.asset, userId)
 			.then((refreshed) => {
+				if (userId !== this.currentUserId) return;
 				if (refreshed) this.lastBalanceEvent = Date.now();
 			})
-			.catch((error) => this._pb.handleConnectionError(error, 'assets', 'share'));
+			.catch((error) => {
+				if (userId === this.currentUserId) {
+					this._pb.handleConnectionError(error, 'assets', 'share');
+				} else {
+					console.error('[assetsStore] Stale event failed:', error);
+				}
+			});
 	}
 
 	private computeBalanceData(
@@ -316,24 +374,36 @@ class AssetsContext {
 		};
 	}
 
-	private async refetchAssetBalance(assetId: string) {
+	private async refetchAssetBalance(assetId: string, userId: string) {
+		if (userId !== this.currentUserId) return;
+
 		try {
 			const balanceData = await this.getLatestAssetBalance(assetId);
+			if (userId !== this.currentUserId) return;
 			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
 			else this.latestBalanceByAsset.delete(assetId);
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
-			console.error('[assets:refetch_balance]', error);
+			if (userId === this.currentUserId) {
+				console.error('[assets:refetch_balance]', error);
+			} else {
+				console.error('[assetsStore] Stale event failed:', error);
+			}
 		}
 	}
 
-	private async refreshAsset(assetId: string) {
+	private async refreshAsset(assetId: string, userId: string) {
+		if (userId !== this.currentUserId) return false;
+
 		try {
 			const asset = await this._pb.authedClient
 				.collection('assets')
 				.getOne<AssetsResponse>(assetId, { requestKey: null });
+			if (userId !== this.currentUserId) return false;
 			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
+			if (userId !== this.currentUserId) return false;
 			const balanceData = await this.getLatestAssetBalance(assetId);
+			if (userId !== this.currentUserId) return false;
 			const exists = this.rawAssets.some((record) => record.id === asset.id);
 			this.rawAssets = exists
 				? this.rawAssets.map((record) => (record.id === asset.id ? asset : record))
@@ -342,6 +412,7 @@ class AssetsContext {
 			else this.latestBalanceByAsset.delete(assetId);
 			return true;
 		} catch (error) {
+			if (userId !== this.currentUserId) return false;
 			if (this.isUnavailableRecordError(error)) {
 				this.rawAssets = this.rawAssets.filter((asset) => asset.id !== assetId);
 				this.latestBalanceByAsset.delete(assetId);

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -48,7 +48,10 @@ export type AssetWithBalance = AssetsResponse &
 class AssetsContext {
 	assets: AssetWithBalance[] = $derived.by(() =>
 		this.rawAssets.map((asset) =>
-			this.toAssetWithBalance(asset, this.latestBalanceByAsset.get(asset.id) ?? DEFAULT_BALANCE_DATA)
+			this.toAssetWithBalance(
+				asset,
+				this.latestBalanceByAsset.get(asset.id) ?? DEFAULT_BALANCE_DATA
+			)
 		)
 	);
 	shares: AssetSharesResponse[] = $state([]);

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -1,5 +1,6 @@
 import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 
 import { setBalanceTypesContext } from './balance-types.svelte';
 import {
@@ -18,6 +19,11 @@ type AssetBalanceData = {
 	gain: number;
 	gainPercent: number;
 	balanceAsOf: string;
+};
+
+type LatestAssetBalance = AssetBalanceData & {
+	id: string;
+	created: string;
 };
 
 const DEFAULT_BALANCE_DATA: AssetBalanceData = {
@@ -40,13 +46,20 @@ export type AssetWithBalance = AssetsResponse &
 	};
 
 class AssetsContext {
-	assets: AssetWithBalance[] = $state([]);
+	assets: AssetWithBalance[] = $derived.by(() =>
+		this.rawAssets.map((asset) =>
+			this.toAssetWithBalance(asset, this.latestBalanceByAsset.get(asset.id) ?? DEFAULT_BALANCE_DATA)
+		)
+	);
 	shares: AssetSharesResponse[] = $state([]);
 	lastBalanceEvent: number = $state(0);
 	isLoading: boolean = $state(true);
 
+	private rawAssets: AssetsResponse[] = $state([]);
+	private latestBalanceByAsset = new SvelteMap<string, LatestAssetBalance>();
 	private _pb: PocketBaseContext;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
+	private _refreshAssetsSequence = 0;
 
 	constructor(
 		pb: PocketBaseContext,
@@ -96,17 +109,22 @@ class AssetsContext {
 			perspective
 		});
 		await this.refreshShares();
+		if (await this.refreshAsset(assetId)) this.lastBalanceEvent = Date.now();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
-		await this._pb.authedClient.collection('assetShares').update(shareId, { includeInNetWorth });
+		const share = await this._pb.authedClient
+			.collection('assetShares')
+			.update<AssetSharesResponse>(shareId, { includeInNetWorth });
 		await this.refreshShares();
-		await this.refreshAssets();
+		if (await this.refreshAsset(share.asset)) this.lastBalanceEvent = Date.now();
 	}
 
 	async revokeShare(shareId: string) {
+		const assetId = this.shares.find((share) => share.id === shareId)?.asset;
 		await this._pb.authedClient.collection('assetShares').delete(shareId);
 		await this.refreshShares();
+		if (assetId && (await this.refreshAsset(assetId))) this.lastBalanceEvent = Date.now();
 	}
 
 	private async init() {
@@ -130,30 +148,43 @@ class AssetsContext {
 	}
 
 	private async refreshAssets() {
+		const refreshId = ++this._refreshAssetsSequence;
 		const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
 			requestKey: null
 		});
-		const next: AssetWithBalance[] = [];
+		const latestBalances = new SvelteMap<string, LatestAssetBalance>();
 		for (const asset of list) {
 			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
+			if (refreshId !== this._refreshAssetsSequence) return false;
 			const balanceData = await this.getLatestAssetBalance(asset.id);
-			next.push(this.toAssetWithBalance(asset, balanceData));
+			if (refreshId !== this._refreshAssetsSequence) return false;
+			if (balanceData) latestBalances.set(asset.id, balanceData);
 		}
-		this.assets = next;
+		if (refreshId !== this._refreshAssetsSequence) return false;
+		this.latestBalanceByAsset.clear();
+		for (const [assetId, balance] of latestBalances) {
+			this.latestBalanceByAsset.set(assetId, balance);
+		}
+		this.rawAssets = list;
+		return true;
 	}
 
 	private realtimeSubscribe() {
 		this._pb.authedClient
 			.collection('assets')
-			.subscribe('*', this.onAssetEvent.bind(this))
+			.subscribe<AssetsResponse>('*', (event) => {
+				void this.onAssetEvent(event).catch((error) =>
+					this._pb.handleConnectionError(error, 'assets', 'asset_event')
+				);
+			})
 			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets'));
 		this._pb.authedClient
 			.collection('assetBalances')
-			.subscribe('*', this.onAssetBalanceEvent.bind(this))
+			.subscribe<AssetBalancesResponse>('*', this.onAssetBalanceEvent.bind(this))
 			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances'));
 		this._pb.authedClient
 			.collection('assetShares')
-			.subscribe('*', this.onAssetShareEvent.bind(this))
+			.subscribe<AssetSharesResponse>('*', this.onAssetShareEvent.bind(this))
 			.catch((error) => this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares'));
 	}
 
@@ -161,44 +192,57 @@ class AssetsContext {
 		if (e.action === 'create') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			const balanceData = await this.getLatestAssetBalance(e.record.id);
-			this.assets = [...this.assets, this.toAssetWithBalance(e.record, balanceData)];
+			this.rawAssets = [...this.rawAssets, e.record];
+			if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
 		} else if (e.action === 'update') {
-			const existing = this.assets.find((a) => a.id === e.record.id);
-			const balanceData = existing
-				? this.toRawBalanceData(existing)
-				: await this.getLatestAssetBalance(e.record.id);
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
-			this.assets = this.assets.map((x) =>
-				x.id === e.record.id ? this.toAssetWithBalance(e.record, balanceData) : x
-			);
+			const exists = this.rawAssets.some((asset) => asset.id === e.record.id);
+			this.rawAssets = exists
+				? this.rawAssets.map((asset) => (asset.id === e.record.id ? e.record : asset))
+				: [...this.rawAssets, e.record];
+			if (!this.latestBalanceByAsset.has(e.record.id)) {
+				const balanceData = await this.getLatestAssetBalance(e.record.id);
+				if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
+			}
 		} else if (e.action === 'delete') {
-			this.assets = this.assets.filter((x) => x.id !== e.record.id);
+			this.rawAssets = this.rawAssets.filter((x) => x.id !== e.record.id);
+			this.latestBalanceByAsset.delete(e.record.id);
 		}
 	}
 
 	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>) {
 		if (!e.action) return;
 		const assetId = e.record.asset;
-		const newAsOf = e.record.asOf;
+		let previousAssetId: string | null = null;
+		for (const [key, currentBalance] of this.latestBalanceByAsset) {
+			if (currentBalance.id === e.record.id) {
+				previousAssetId = key;
+				break;
+			}
+		}
+		if (previousAssetId && previousAssetId !== assetId) {
+			void this.refetchAssetBalance(previousAssetId);
+		}
 
 		if (e.action === 'create' || e.action === 'update') {
-			const asset = this.assets.find((x) => x.id === assetId);
+			const asset = this.rawAssets.find((x) => x.id === assetId);
 			if (!asset) {
-				void this.refreshAssets().then(() => {
-					this.lastBalanceEvent = Date.now();
-				});
+				void this.refreshAsset(assetId)
+					.then((refreshed) => {
+						if (refreshed) this.lastBalanceEvent = Date.now();
+					})
+					.catch((error) => this._pb.handleConnectionError(error, 'assets', 'balance'));
 				return;
 			}
 
-			if (!asset.balanceAsOf || newAsOf >= asset.balanceAsOf) {
-				this.assets = this.assets.map((x) =>
-					x.id === assetId
-						? {
-								...x,
-								...this.computeBalanceData(e.record, x.perspective)
-							}
-						: x
-				);
+			const current = this.latestBalanceByAsset.get(assetId);
+			if (current?.id === e.record.id) {
+				void this.refetchAssetBalance(assetId);
+				return;
+			}
+
+			if (!current || this.isAtLeastAsRecent(e.record, current)) {
+				this.latestBalanceByAsset.set(assetId, this.toLatestAssetBalance(e.record));
 				this.lastBalanceEvent = Date.now();
 			}
 		} else if (e.action === 'delete') {
@@ -206,7 +250,7 @@ class AssetsContext {
 		}
 	}
 
-	private async onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>) {
+	private onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>) {
 		if (e.action === 'create') {
 			this.shares = [...this.shares, e.record];
 		} else if (e.action === 'update') {
@@ -215,8 +259,11 @@ class AssetsContext {
 			this.shares = this.shares.filter((share) => share.id !== e.record.id);
 		}
 
-		await this.refreshAssets();
-		this.lastBalanceEvent = Date.now();
+		void this.refreshAsset(e.record.asset)
+			.then((refreshed) => {
+				if (refreshed) this.lastBalanceEvent = Date.now();
+			})
+			.catch((error) => this._pb.handleConnectionError(error, 'assets', 'share'));
 	}
 
 	private computeBalanceData(
@@ -227,21 +274,6 @@ class AssetsContext {
 		return {
 			...projected,
 			balanceAsOf: balance.asOf
-		};
-	}
-
-	private toRawBalanceData(asset: AssetWithBalance) {
-		const rawBookValue =
-			asset.perspective === 'INVERSE' ? -(asset.bookValue ?? 0) : (asset.bookValue ?? 0);
-		const rawMarketValue =
-			asset.perspective === 'INVERSE' ? -(asset.marketValue ?? 0) : (asset.marketValue ?? 0);
-		return {
-			marketValue: rawMarketValue,
-			bookValue: rawBookValue,
-			gain: rawMarketValue - rawBookValue,
-			gainPercent:
-				rawBookValue !== 0 ? ((rawMarketValue - rawBookValue) / Math.abs(rawBookValue)) * 100 : 0,
-			balanceAsOf: asset.balanceAsOf
 		};
 	}
 
@@ -284,24 +316,35 @@ class AssetsContext {
 	private async refetchAssetBalance(assetId: string) {
 		try {
 			const balanceData = await this.getLatestAssetBalance(assetId);
-			this.assets = this.assets.map((x) =>
-				x.id === assetId
-					? {
-							...x,
-							...this.computeBalanceData(
-								{
-									asOf: balanceData.balanceAsOf,
-									bookValue: balanceData.bookValue,
-									marketValue: balanceData.marketValue
-								},
-								x.perspective
-							)
-						}
-					: x
-			);
+			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
+			else this.latestBalanceByAsset.delete(assetId);
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
 			console.error('[assets:refetch_balance]', error);
+		}
+	}
+
+	private async refreshAsset(assetId: string) {
+		try {
+			const asset = await this._pb.authedClient
+				.collection('assets')
+				.getOne<AssetsResponse>(assetId, { requestKey: null });
+			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
+			const balanceData = await this.getLatestAssetBalance(assetId);
+			const exists = this.rawAssets.some((record) => record.id === asset.id);
+			this.rawAssets = exists
+				? this.rawAssets.map((record) => (record.id === asset.id ? asset : record))
+				: [...this.rawAssets, asset];
+			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
+			else this.latestBalanceByAsset.delete(assetId);
+			return true;
+		} catch (error) {
+			if (this.isUnavailableRecordError(error)) {
+				this.rawAssets = this.rawAssets.filter((asset) => asset.id !== assetId);
+				this.latestBalanceByAsset.delete(assetId);
+				return true;
+			}
+			throw error;
 		}
 	}
 
@@ -310,11 +353,16 @@ class AssetsContext {
 			.collection('assetBalances')
 			.getList<AssetBalancesResponse>(1, 1, {
 				filter: `asset='${assetId}'`,
-				sort: '-asOf,-created,-id'
+				sort: '-asOf,-created,-id',
+				requestKey: null
 			});
 		const balance = res.items[0];
-		if (!balance) return DEFAULT_BALANCE_DATA;
+		return balance ? this.toLatestAssetBalance(balance) : null;
+	}
+
+	private toLatestAssetBalance(balance: AssetBalancesResponse) {
 		return {
+			id: balance.id,
 			marketValue: balance.marketValue ?? 0,
 			bookValue: balance.bookValue ?? 0,
 			gain: (balance.marketValue ?? 0) - (balance.bookValue ?? 0),
@@ -324,14 +372,34 @@ class AssetsContext {
 							Math.abs(balance.bookValue ?? 0)) *
 						100
 					: 0,
-			balanceAsOf: balance.asOf
+			balanceAsOf: balance.asOf,
+			created: balance.created
 		};
 	}
 
+	private isAtLeastAsRecent(
+		balance: Pick<AssetBalancesResponse, 'asOf' | 'created' | 'id'>,
+		current: Pick<LatestAssetBalance, 'balanceAsOf' | 'created' | 'id'>
+	) {
+		if (balance.asOf !== current.balanceAsOf) return balance.asOf > current.balanceAsOf;
+		if (balance.created !== current.created) return balance.created > current.created;
+		return balance.id >= current.id;
+	}
+
+	private isUnavailableRecordError(error: unknown) {
+		return (
+			typeof error === 'object' &&
+			error !== null &&
+			'status' in error &&
+			(error.status === 403 || error.status === 404)
+		);
+	}
+
 	dispose() {
-		this._pb.authedClient.collection('assets').unsubscribe();
-		this._pb.authedClient.collection('assetBalances').unsubscribe();
-		this._pb.authedClient.collection('assetShares').unsubscribe();
+		this._refreshAssetsSequence++;
+		this._pb.authedClient.collection('assets').unsubscribe('*');
+		this._pb.authedClient.collection('assetBalances').unsubscribe('*');
+		this._pb.authedClient.collection('assetShares').unsubscribe('*');
 	}
 }
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -1,7 +1,7 @@
 import { UTCDate } from '@date-fns/utc';
 import { addMonths, format, startOfMonth, startOfYear } from 'date-fns';
 import { type RecordSubscription } from 'pocketbase';
-import { getContext, setContext } from 'svelte';
+import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 import { getAccountsContext, type AccountWithBalance } from './accounts.svelte';
@@ -57,6 +57,7 @@ class CashflowContext {
 	private _transactionsById = new SvelteMap<string, TransactionsResponse>();
 	private _activeWindow: CashflowWindow | null = null;
 	private _hasTransactionSnapshot = false;
+	private _watchedAccountsKey: string | null = null;
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
@@ -67,10 +68,41 @@ class CashflowContext {
 	private init() {
 		this.realtimeSubscribe();
 		$effect(() => {
-			void this.recomputeAll(this._accountsContext.accounts).catch((error) => {
+			const accounts = this._accountsContext.accounts;
+			const watchedAccountsKey = this.getWatchedAccountsKey(accounts);
+			const activeWindow = this._activeWindow;
+			const cashflowWindow = this.getCashflowWindow();
+
+			if (watchedAccountsKey === this._watchedAccountsKey) {
+				if (!activeWindow) {
+					if (this._recomputeAllInFlight > 0) return;
+				} else if (
+					activeWindow.earliestKey === cashflowWindow.earliestKey &&
+					activeWindow.startNextMonthKey === cashflowWindow.startNextMonthKey &&
+					this._hasTransactionSnapshot
+				) {
+					untrack(() => {
+						if (this._recomputeAllInFlight === 0) {
+							this.recomputeFromTransactionMap(accounts, activeWindow);
+						}
+					});
+					return;
+				}
+			}
+
+			this._watchedAccountsKey = watchedAccountsKey;
+			void this.recomputeAll(accounts).catch((error) => {
+				if (this._watchedAccountsKey === watchedAccountsKey) this._watchedAccountsKey = null;
 				this._pb.handleConnectionError(error, 'cashflow', 'init');
 			});
 		});
+	}
+
+	private getWatchedAccountsKey(accounts: AccountWithBalance[]) {
+		return accounts
+			.map((account) => `${account.id}:${account.perspective}`)
+			.sort()
+			.join('|');
 	}
 
 	private realtimeSubscribe() {
@@ -175,6 +207,7 @@ class CashflowContext {
 			);
 			this._activeWindow = cashflowWindow;
 			this._hasTransactionSnapshot = true;
+			this._watchedAccountsKey = this.getWatchedAccountsKey(accounts);
 			this.recomputeFromTransactionMap(accounts, cashflowWindow);
 		} finally {
 			this._recomputeAllInFlight--;

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -171,7 +171,9 @@ class CashflowContext {
 
 			if (recomputeSequence !== this._recomputeSequence) return;
 
-			this._transactionsById = new SvelteMap(txns.map((transaction) => [transaction.id, transaction]));
+			this._transactionsById = new SvelteMap(
+				txns.map((transaction) => [transaction.id, transaction])
+			);
 			this._activeWindow = window;
 			this._hasTransactionSnapshot = true;
 			this.recomputeFromTransactionMap(accounts, window);

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -2,12 +2,27 @@ import { UTCDate } from '@date-fns/utc';
 import { addMonths, format, startOfMonth, startOfYear } from 'date-fns';
 import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 
-import type { TransactionsResponse } from './pocketbase.schema';
+import { getAccountsContext, type AccountWithBalance } from './accounts.svelte';
+import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { projectSignedValue } from './sharing';
 import { toPocketBaseDateString } from './utils';
 
 type CashflowAverages = { income: number; expenses: number; surplus: number };
+
+type CashflowWindow = {
+	startOfThisMonth: Date;
+	start12m: Date;
+	start6m: Date;
+	start3m: Date;
+	startYtd: Date;
+	earliest: Date;
+	startNextMonth: Date;
+	earliestKey: string;
+	startNextMonthKey: string;
+};
 
 export const CASHFLOW_PERIODS = 13;
 
@@ -32,32 +47,99 @@ class CashflowContext {
 	periods: CashflowPeriod[] = $state([]);
 
 	private _pb: PocketBaseContext;
+	private _accountsContext: ReturnType<typeof getAccountsContext>;
 	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private _unsubscribe: (() => void) | null = null;
+	private _disposed = false;
+	private _recomputeSequence = 0;
+	private _recomputeAllInFlight = 0;
+	private _transactionsById = new SvelteMap<string, TransactionsResponse>();
+	private _activeWindow: CashflowWindow | null = null;
+	private _hasTransactionSnapshot = false;
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
+		this._accountsContext = getAccountsContext();
 		this.init();
 	}
 
-	private async init() {
-		try {
-			// Subscribe FIRST to avoid missing events during initial fetch
-			this.realtimeSubscribe();
-			await this.recomputeAll();
-		} catch (error) {
-			this._pb.handleConnectionError(error, 'cashflow', 'init');
-		}
+	private init() {
+		this.realtimeSubscribe();
+		$effect(() => {
+			void this.recomputeAll(this._accountsContext.accounts).catch((error) => {
+				this._pb.handleConnectionError(error, 'cashflow', 'init');
+			});
+		});
 	}
 
 	private realtimeSubscribe() {
 		this._pb.authedClient
 			.collection('transactions')
 			.subscribe('*', this.onTransactionEvent.bind(this))
-			.catch((error) => this._pb.handleSubscriptionError(error, 'cashflow', 'subscribe'));
+			.then((unsubscribe) => {
+				if (this._disposed) {
+					unsubscribe();
+					return;
+				}
+
+				this._unsubscribe = unsubscribe;
+			})
+			.catch((error) => {
+				if (!this._disposed) this._pb.handleSubscriptionError(error, 'cashflow', 'subscribe');
+			});
 	}
 
 	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
 		if (!e.action) return;
+
+		const window = this.getCashflowWindow();
+		const activeWindow = this._activeWindow;
+		let shouldRecomputeAll = false;
+		let shouldRecomputeFromMap = false;
+
+		if (
+			!this._hasTransactionSnapshot ||
+			!activeWindow ||
+			activeWindow.earliestKey !== window.earliestKey ||
+			activeWindow.startNextMonthKey !== window.startNextMonthKey
+		) {
+			shouldRecomputeAll = true;
+		} else {
+			if (e.action === 'delete') {
+				if (this._transactionsById.delete(e.record.id)) {
+					shouldRecomputeFromMap = true;
+				} else {
+					const membership = this.transactionWindowMembership(e.record, activeWindow);
+					shouldRecomputeAll = membership !== false;
+				}
+			} else if (e.action === 'create' || e.action === 'update') {
+				const membership = this.transactionWindowMembership(e.record, activeWindow);
+
+				if (membership === null) {
+					shouldRecomputeAll = true;
+				} else if (membership) {
+					if (!this._accountsContext.accounts.some((account) => account.id === e.record.account)) {
+						shouldRecomputeAll = true;
+					} else {
+						this._transactionsById.set(e.record.id, e.record);
+						shouldRecomputeFromMap = true;
+					}
+				} else if (this._transactionsById.delete(e.record.id)) {
+					shouldRecomputeFromMap = true;
+				}
+			} else {
+				shouldRecomputeAll = true;
+			}
+
+			if (shouldRecomputeFromMap) {
+				shouldRecomputeAll = this._recomputeAllInFlight > 0;
+				this._recomputeSequence++;
+				this.recomputeFromTransactionMap(this._accountsContext.accounts, activeWindow);
+				if (!shouldRecomputeAll) return;
+			}
+		}
+
+		if (!shouldRecomputeAll) return;
 
 		if (this._debounceTimer) {
 			clearTimeout(this._debounceTimer);
@@ -66,53 +148,107 @@ class CashflowContext {
 		this._debounceTimer = setTimeout(async () => {
 			this._debounceTimer = null;
 			try {
-				await this.recomputeAll();
+				await this.recomputeAll(this._accountsContext.accounts);
 			} catch (error) {
 				console.error('[cashflow:recompute_on_event]', error);
 			}
 		}, DEBOUNCE_MS);
 	}
 
-	private async recomputeAll() {
+	private async recomputeAll(accounts: AccountWithBalance[]) {
+		const recomputeSequence = ++this._recomputeSequence;
+		const window = this.getCashflowWindow();
+
+		this._recomputeAllInFlight++;
+		try {
+			const txns = await this._pb.authedClient
+				.collection('transactions')
+				.getFullList<TransactionsResponse>({
+					filter: `date >= '${window.earliestKey}' && date < '${window.startNextMonthKey}' && excluded = ''`,
+					fields: 'id,date,account,value',
+					requestKey: null
+				});
+
+			if (recomputeSequence !== this._recomputeSequence) return;
+
+			this._transactionsById = new SvelteMap(txns.map((transaction) => [transaction.id, transaction]));
+			this._activeWindow = window;
+			this._hasTransactionSnapshot = true;
+			this.recomputeFromTransactionMap(accounts, window);
+		} finally {
+			this._recomputeAllInFlight--;
+		}
+	}
+
+	private getCashflowWindow() {
 		const now = new UTCDate();
 		const startOfThisMonth = startOfMonth(now);
 		const start13m = addMonths(startOfThisMonth, -(CASHFLOW_PERIODS - 1));
-		const start12m = addMonths(startOfThisMonth, -11);
-		const start6m = addMonths(startOfThisMonth, -5);
-		const start3m = addMonths(startOfThisMonth, -2);
 		const startYtd = startOfYear(now);
-
-		// Fetch all needed transactions since the earliest required start (13 months for the chart)
 		const earliest = start13m < startYtd ? start13m : startYtd;
+		const startNextMonth = addMonths(startOfThisMonth, 1);
 
-		const txns = await this._pb.authedClient
-			.collection('transactions')
-			.getFullList<TransactionsResponse>({
-				filter: `date >= '${toPocketBaseDateString(earliest)}'`,
-				requestKey: null // Disable auto-cancellation to prevent glitches during bulk operations
-			});
-
-		const compute = (from: Date) => {
-			let income = 0;
-			let expenses = 0;
-			for (const t of txns) {
-				if (t.excluded) continue;
-				const td = t.date ? new Date(t.date) : null;
-				if (!td || td < from) continue;
-				const v = t.value ?? 0;
-				if (v >= 0) income += v;
-				else expenses += v; // negative values accumulate
-			}
-			const surplus = income + expenses;
-			return { income, expenses, surplus } as const;
+		return {
+			startOfThisMonth,
+			start12m: addMonths(startOfThisMonth, -11),
+			start6m: addMonths(startOfThisMonth, -5),
+			start3m: addMonths(startOfThisMonth, -2),
+			startYtd,
+			earliest,
+			startNextMonth,
+			earliestKey: toPocketBaseDateString(earliest),
+			startNextMonthKey: toPocketBaseDateString(startNextMonth)
 		};
+	}
 
-		const sums3m = compute(start3m);
-		const sums6m = compute(start6m);
-		const sumsYtd = compute(startYtd);
-		const sums1y = compute(start12m);
+	private transactionWindowMembership(transaction: TransactionsResponse, window: CashflowWindow) {
+		if (!transaction.date || !('excluded' in transaction)) return null;
 
-		const monthsYtd = startOfThisMonth.getUTCMonth() + 1; // Jan=0 -> count inclusive
+		const date = new Date(transaction.date);
+		if (Number.isNaN(date.valueOf())) return null;
+
+		return date >= window.earliest && date < window.startNextMonth && !transaction.excluded;
+	}
+
+	private recomputeFromTransactionMap(accounts: AccountWithBalance[], window: CashflowWindow) {
+		const accountPerspectiveById = new SvelteMap(
+			accounts.map((account) => [account.id, account.perspective])
+		);
+		const sums3m = { income: 0, expenses: 0, surplus: 0 };
+		const sums6m = { income: 0, expenses: 0, surplus: 0 };
+		const sumsYtd = { income: 0, expenses: 0, surplus: 0 };
+		const sums1y = { income: 0, expenses: 0, surplus: 0 };
+		const sumsByMonth = new SvelteMap<string, { income: number; expenses: number }>();
+
+		for (let i = 0; i < CASHFLOW_PERIODS; i++) {
+			const month = addMonths(window.startOfThisMonth, -(CASHFLOW_PERIODS - 1 - i));
+			sumsByMonth.set(format(month, 'yyyy-MM'), { income: 0, expenses: 0 });
+		}
+
+		for (const t of this._transactionsById.values()) {
+			if (!t.date) continue;
+			const date = new Date(t.date);
+			const value = projectSignedValue(
+				t.value ?? 0,
+				accountPerspectiveById.get(t.account) ?? AccountSharesPerspectiveOptions.NORMAL
+			);
+			const bucket = value >= 0 ? 'income' : 'expenses';
+
+			if (date >= window.start3m) sums3m[bucket] += value;
+			if (date >= window.start6m) sums6m[bucket] += value;
+			if (date >= window.startYtd) sumsYtd[bucket] += value;
+			if (date >= window.start12m) sums1y[bucket] += value;
+
+			const monthSums = sumsByMonth.get(t.date.slice(0, 7));
+			if (monthSums) monthSums[bucket] += value;
+		}
+
+		sums3m.surplus = sums3m.income + sums3m.expenses;
+		sums6m.surplus = sums6m.income + sums6m.expenses;
+		sumsYtd.surplus = sumsYtd.income + sumsYtd.expenses;
+		sums1y.surplus = sums1y.income + sums1y.expenses;
+
+		const monthsYtd = window.startOfThisMonth.getUTCMonth() + 1;
 
 		this.avg3m = {
 			income: sums3m.income / 3,
@@ -139,33 +275,18 @@ class CashflowContext {
 
 		for (let i = 0; i < CASHFLOW_PERIODS; i++) {
 			const monthOffset = CASHFLOW_PERIODS - 1 - i;
-			const month = addMonths(startOfThisMonth, -monthOffset);
+			const month = addMonths(window.startOfThisMonth, -monthOffset);
 			const isCurrentPeriod = monthOffset === 0;
 
-			// Use YYYY-MM for simpler comparison (avoid timezone issues)
 			const periodKey = format(month, 'yyyy-MM');
-
-			let income = 0;
-			let expenses = 0;
-
-			for (const t of txns) {
-				if (t.excluded) continue;
-				if (!t.date) continue;
-				// Compare by YYYY-MM to avoid timezone edge cases
-				const txMonth = t.date.slice(0, 7);
-				if (txMonth === periodKey) {
-					const v = t.value ?? 0;
-					if (v >= 0) income += v;
-					else expenses += v;
-				}
-			}
+			const monthSums = sumsByMonth.get(periodKey) ?? { income: 0, expenses: 0 };
 
 			periods.push({
 				id: i,
 				month,
-				income,
-				expenses,
-				surplus: income + expenses,
+				income: monthSums.income,
+				expenses: monthSums.expenses,
+				surplus: monthSums.income + monthSums.expenses,
 				isCurrentPeriod,
 				periodLabel: format(month, 'MMMM yyyy')
 			});
@@ -175,10 +296,14 @@ class CashflowContext {
 	}
 
 	dispose() {
+		this._disposed = true;
+		this._recomputeSequence++;
 		if (this._debounceTimer) {
 			clearTimeout(this._debounceTimer);
+			this._debounceTimer = null;
 		}
-		this._pb.authedClient.collection('transactions').unsubscribe();
+		this._unsubscribe?.();
+		this._unsubscribe = null;
 	}
 }
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -45,6 +45,7 @@ class CashflowContext {
 	avg1y: CashflowAverages = $state({ income: 0, expenses: 0, surplus: 0 });
 
 	periods: CashflowPeriod[] = $state([]);
+	isLoading: boolean = $state(true);
 
 	private _pb: PocketBaseContext;
 	private _accountsContext: ReturnType<typeof getAccountsContext>;
@@ -92,7 +93,7 @@ class CashflowContext {
 	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
 		if (!e.action) return;
 
-		const window = this.getCashflowWindow();
+		const cashflowWindow = this.getCashflowWindow();
 		const activeWindow = this._activeWindow;
 		let shouldRecomputeAll = false;
 		let shouldRecomputeFromMap = false;
@@ -100,8 +101,8 @@ class CashflowContext {
 		if (
 			!this._hasTransactionSnapshot ||
 			!activeWindow ||
-			activeWindow.earliestKey !== window.earliestKey ||
-			activeWindow.startNextMonthKey !== window.startNextMonthKey
+			activeWindow.earliestKey !== cashflowWindow.earliestKey ||
+			activeWindow.startNextMonthKey !== cashflowWindow.startNextMonthKey
 		) {
 			shouldRecomputeAll = true;
 		} else {
@@ -145,26 +146,24 @@ class CashflowContext {
 			clearTimeout(this._debounceTimer);
 		}
 
-		this._debounceTimer = setTimeout(async () => {
+		this._debounceTimer = setTimeout(() => {
 			this._debounceTimer = null;
-			try {
-				await this.recomputeAll(this._accountsContext.accounts);
-			} catch (error) {
+			void this.recomputeAll(this._accountsContext.accounts).catch((error) => {
 				console.error('[cashflow:recompute_on_event]', error);
-			}
+			});
 		}, DEBOUNCE_MS);
 	}
 
 	private async recomputeAll(accounts: AccountWithBalance[]) {
 		const recomputeSequence = ++this._recomputeSequence;
-		const window = this.getCashflowWindow();
+		const cashflowWindow = this.getCashflowWindow();
 
 		this._recomputeAllInFlight++;
 		try {
 			const txns = await this._pb.authedClient
 				.collection('transactions')
 				.getFullList<TransactionsResponse>({
-					filter: `date >= '${window.earliestKey}' && date < '${window.startNextMonthKey}' && excluded = ''`,
+					filter: `date >= '${cashflowWindow.earliestKey}' && date < '${cashflowWindow.startNextMonthKey}' && excluded = ''`,
 					fields: 'id,date,account,value',
 					requestKey: null
 				});
@@ -174,11 +173,12 @@ class CashflowContext {
 			this._transactionsById = new SvelteMap(
 				txns.map((transaction) => [transaction.id, transaction])
 			);
-			this._activeWindow = window;
+			this._activeWindow = cashflowWindow;
 			this._hasTransactionSnapshot = true;
-			this.recomputeFromTransactionMap(accounts, window);
+			this.recomputeFromTransactionMap(accounts, cashflowWindow);
 		} finally {
 			this._recomputeAllInFlight--;
+			if (!this._disposed && recomputeSequence === this._recomputeSequence) this.isLoading = false;
 		}
 	}
 
@@ -203,16 +203,26 @@ class CashflowContext {
 		};
 	}
 
-	private transactionWindowMembership(transaction: TransactionsResponse, window: CashflowWindow) {
+	private transactionWindowMembership(
+		transaction: TransactionsResponse,
+		cashflowWindow: CashflowWindow
+	) {
 		if (!transaction.date || !('excluded' in transaction)) return null;
 
 		const date = new Date(transaction.date);
 		if (Number.isNaN(date.valueOf())) return null;
 
-		return date >= window.earliest && date < window.startNextMonth && !transaction.excluded;
+		return (
+			date >= cashflowWindow.earliest &&
+			date < cashflowWindow.startNextMonth &&
+			!transaction.excluded
+		);
 	}
 
-	private recomputeFromTransactionMap(accounts: AccountWithBalance[], window: CashflowWindow) {
+	private recomputeFromTransactionMap(
+		accounts: AccountWithBalance[],
+		cashflowWindow: CashflowWindow
+	) {
 		const accountPerspectiveById = new SvelteMap(
 			accounts.map((account) => [account.id, account.perspective])
 		);
@@ -223,7 +233,7 @@ class CashflowContext {
 		const sumsByMonth = new SvelteMap<string, { income: number; expenses: number }>();
 
 		for (let i = 0; i < CASHFLOW_PERIODS; i++) {
-			const month = addMonths(window.startOfThisMonth, -(CASHFLOW_PERIODS - 1 - i));
+			const month = addMonths(cashflowWindow.startOfThisMonth, -(CASHFLOW_PERIODS - 1 - i));
 			sumsByMonth.set(format(month, 'yyyy-MM'), { income: 0, expenses: 0 });
 		}
 
@@ -236,10 +246,10 @@ class CashflowContext {
 			);
 			const bucket = value >= 0 ? 'income' : 'expenses';
 
-			if (date >= window.start3m) sums3m[bucket] += value;
-			if (date >= window.start6m) sums6m[bucket] += value;
-			if (date >= window.startYtd) sumsYtd[bucket] += value;
-			if (date >= window.start12m) sums1y[bucket] += value;
+			if (date >= cashflowWindow.start3m) sums3m[bucket] += value;
+			if (date >= cashflowWindow.start6m) sums6m[bucket] += value;
+			if (date >= cashflowWindow.startYtd) sumsYtd[bucket] += value;
+			if (date >= cashflowWindow.start12m) sums1y[bucket] += value;
 
 			const monthSums = sumsByMonth.get(t.date.slice(0, 7));
 			if (monthSums) monthSums[bucket] += value;
@@ -250,7 +260,7 @@ class CashflowContext {
 		sumsYtd.surplus = sumsYtd.income + sumsYtd.expenses;
 		sums1y.surplus = sums1y.income + sums1y.expenses;
 
-		const monthsYtd = window.startOfThisMonth.getUTCMonth() + 1;
+		const monthsYtd = cashflowWindow.startOfThisMonth.getUTCMonth() + 1;
 
 		this.avg3m = {
 			income: sums3m.income / 3,
@@ -277,7 +287,7 @@ class CashflowContext {
 
 		for (let i = 0; i < CASHFLOW_PERIODS; i++) {
 			const monthOffset = CASHFLOW_PERIODS - 1 - i;
-			const month = addMonths(window.startOfThisMonth, -monthOffset);
+			const month = addMonths(cashflowWindow.startOfThisMonth, -monthOffset);
 			const isCurrentPeriod = monthOffset === 0;
 
 			const periodKey = format(month, 'yyyy-MM');

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -67,6 +67,14 @@ class CashflowContext {
 
 	private init() {
 		this.realtimeSubscribe();
+		// Perf-critical: `accounts` is a $derived that gets a new identity on every
+		// balance tick, so this effect re-runs constantly. It must NOT refetch all
+		// transactions each time. We gate on `watchedAccountsKey` (account ids +
+		// perspectives): a balance-only change recomputes from the in-memory
+		// transaction map (no network); only a change to the watched accounts or a
+		// roll-over of the cashflow window triggers a full recomputeAll() fetch.
+		// Reverting this to recomputeAll(accounts) on every run reintroduces a full
+		// transactions getFullList on every balance event (the regression this fixes).
 		$effect(() => {
 			const accounts = this._accountsContext.accounts;
 			const watchedAccountsKey = this.getWatchedAccountsKey(accounts);

--- a/src/lib/components/ui/skeleton/skeleton.svelte
+++ b/src/lib/components/ui/skeleton/skeleton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import type { HTMLAttributes } from 'svelte/elements';
 
 	import { cn, type WithElementRef, type WithoutChildren } from '$lib/utils.js';
@@ -13,6 +14,11 @@
 <div
 	bind:this={ref}
 	data-slot="skeleton"
-	class={cn('bg-border animate-pulse rounded', className)}
+	class={cn('bg-border relative overflow-hidden rounded', className)}
 	{...restProps}
-></div>
+>
+	<LoaderCircleIcon
+		aria-hidden="true"
+		class="text-muted-foreground/70 absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 animate-spin"
+	/>
+</div>

--- a/src/lib/components/ui/skeleton/skeleton.svelte
+++ b/src/lib/components/ui/skeleton/skeleton.svelte
@@ -17,7 +17,7 @@
 <div
 	bind:this={ref}
 	data-slot="skeleton"
-	class={cn('bg-border relative overflow-hidden rounded', className)}
+	class={cn('bg-border relative animate-pulse overflow-hidden rounded', className)}
 	{...restProps}
 >
 	{#if showSpinner}

--- a/src/lib/components/ui/skeleton/skeleton.svelte
+++ b/src/lib/components/ui/skeleton/skeleton.svelte
@@ -7,8 +7,11 @@
 	let {
 		ref = $bindable(null),
 		class: className,
+		showSpinner = false,
 		...restProps
-	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> & {
+		showSpinner?: boolean;
+	} = $props();
 </script>
 
 <div
@@ -17,8 +20,10 @@
 	class={cn('bg-border relative overflow-hidden rounded', className)}
 	{...restProps}
 >
-	<LoaderCircleIcon
-		aria-hidden="true"
-		class="text-muted-foreground/70 absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 animate-spin"
-	/>
+	{#if showSpinner}
+		<LoaderCircleIcon
+			aria-hidden="true"
+			class="text-muted-foreground/70 absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 animate-spin"
+		/>
+	{/if}
 </div>

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -9,8 +9,8 @@ import type { PocketBaseContext } from './pocketbase.svelte';
 import {
 	compareByValueDescThenName,
 	resolveSecurityBalanceValues,
-	type SecurityBalanceResolvedValue,
-	sumOrUnknown
+	sumOrUnknown,
+	type SecurityBalanceResolvedValue
 } from './security-balance-values';
 import { projectSignedValue } from './sharing';
 import { toNumber } from './utils';
@@ -315,11 +315,13 @@ class SecuritiesContext {
 	) {
 		if (!userId || userId !== this._auth.currentUserId || token !== this.refreshSequence)
 			return false;
-		const balances = await this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
-			filter: `account='${accountId}' && security='${securityId}'`,
-			sort: '-asOf,-created,-id',
-			requestKey: null
-		});
+		const balances = await this._pb.authedClient
+			.collection('securityBalances')
+			.getFullList<SecurityBalance>({
+				filter: `account='${accountId}' && security='${securityId}'`,
+				sort: '-asOf,-created,-id',
+				requestKey: null
+			});
 		if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return false;
 
 		const key = this.positionKey(accountId, securityId);
@@ -335,9 +337,10 @@ class SecuritiesContext {
 
 	private upsertSecurity(security: SecuritiesResponse) {
 		const exists = this.securities.some((record) => record.id === security.id);
-		this.securities = (exists
-			? this.securities.map((record) => (record.id === security.id ? security : record))
-			: [...this.securities, security]
+		this.securities = (
+			exists
+				? this.securities.map((record) => (record.id === security.id ? security : record))
+				: [...this.securities, security]
 		).toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 	}
 

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -9,6 +9,7 @@ import type { PocketBaseContext } from './pocketbase.svelte';
 import {
 	compareByValueDescThenName,
 	resolveSecurityBalanceValues,
+	type SecurityBalanceResolvedValue,
 	sumOrUnknown
 } from './security-balance-values';
 import { projectSignedValue } from './sharing';
@@ -64,7 +65,7 @@ class SecuritiesContext {
 				.map((account) => account.id)
 		);
 		const valuesByAccount = new SvelteMap<string, Array<number | null>>();
-		for (const resolved of resolveSecurityBalanceValues(this.securityBalances).values()) {
+		for (const resolved of this.currentPositions.values()) {
 			const accountId = resolved.balance.account;
 			if (!eligibleAccountIds.has(accountId)) continue;
 			const values = valuesByAccount.get(accountId) ?? [];
@@ -76,11 +77,11 @@ class SecuritiesContext {
 		);
 	});
 
-	private securityBalances: SecurityBalance[] = $state([]);
+	private currentPositions = new SvelteMap<string, SecurityBalanceResolvedValue>();
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _accounts: ReturnType<typeof getAccountsContext>;
-	private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+	private positionRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	private refreshSequence = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
@@ -126,7 +127,17 @@ class SecuritiesContext {
 				balance: balanceData
 			}
 		);
-		await this.refreshAll();
+		this.upsertSecurity(security);
+		if (
+			await this.refreshPosition(
+				balanceData.account,
+				security.id,
+				this._auth.currentUserId,
+				this.refreshSequence
+			)
+		) {
+			this._accounts.notifyBalancesChanged();
+		}
 		return security;
 	}
 
@@ -135,7 +146,16 @@ class SecuritiesContext {
 			...balanceData,
 			security: securityId
 		});
-		await this.refreshAll();
+		if (
+			await this.refreshPosition(
+				balanceData.account,
+				securityId,
+				this._auth.currentUserId,
+				this.refreshSequence
+			)
+		) {
+			this._accounts.notifyBalancesChanged();
+		}
 	}
 
 	private init() {
@@ -146,10 +166,9 @@ class SecuritiesContext {
 			this._activeUserId = userId;
 			if (!userId) {
 				this.refreshSequence++;
-				if (this.refreshTimer) clearTimeout(this.refreshTimer);
-				this.refreshTimer = null;
+				this.clearPositionRefreshTimers();
 				this.securities = [];
-				this.securityBalances = [];
+				this.currentPositions.clear();
 				this.positionsLoaded = false;
 				this.isLoading = false;
 				return;
@@ -194,7 +213,10 @@ class SecuritiesContext {
 		]);
 		if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
 		this.securities = securities;
-		this.securityBalances = securityBalances;
+		this.currentPositions.clear();
+		for (const [key, position] of resolveSecurityBalanceValues(securityBalances)) {
+			this.currentPositions.set(key, position);
+		}
 		this.resolvePositionsLoaded();
 	}
 
@@ -203,7 +225,7 @@ class SecuritiesContext {
 
 		this._pb.authedClient
 			.collection('securities')
-			.subscribe<SecuritiesResponse>('*', (event) => this.onRealtimeEvent(event, userId))
+			.subscribe<SecuritiesResponse>('*', (event) => this.onSecurityEvent(event, userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe');
@@ -213,7 +235,7 @@ class SecuritiesContext {
 			});
 		this._pb.authedClient
 			.collection('securityBalances')
-			.subscribe<SecurityBalance>('*', (event) => this.onRealtimeEvent(event, userId))
+			.subscribe<SecurityBalance>('*', (event) => this.onSecurityBalanceEvent(event, userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe_balances');
@@ -231,23 +253,99 @@ class SecuritiesContext {
 		this._pb.authedClient.collection('securityBalances').unsubscribe('*');
 	}
 
-	private onRealtimeEvent(
-		event: RecordSubscription<SecuritiesResponse> | RecordSubscription<SecurityBalance>,
-		userId: string
-	) {
+	private onSecurityEvent(event: RecordSubscription<SecuritiesResponse>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!event.action) return;
-		if (this.refreshTimer) clearTimeout(this.refreshTimer);
-		this.refreshTimer = setTimeout(() => {
-			this.refreshTimer = null;
-			const userId = this._auth.currentUserId;
-			const token = ++this.refreshSequence;
-			this.refreshAll(userId, token).catch((error) => {
-				if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
-				this._pb.handleConnectionError(error, 'securities', 'refresh');
-				this.resolvePositionsLoaded();
-			});
-		}, DEBOUNCE_MS);
+		if (event.action === 'delete') {
+			this.securities = this.securities.filter((security) => security.id !== event.record.id);
+			for (const [key, position] of this.currentPositions) {
+				if (position.balance.security === event.record.id) this.currentPositions.delete(key);
+			}
+			if (this.positionsLoaded) this._accounts.notifyBalancesChanged();
+			return;
+		}
+
+		this.upsertSecurity(event.record);
+	}
+
+	private onSecurityBalanceEvent(event: RecordSubscription<SecurityBalance>, userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		if (!event.action) return;
+
+		const key = this.positionKey(event.record.account, event.record.security);
+		if (event.action === 'update') {
+			for (const [currentKey, position] of this.currentPositions) {
+				if (position.balance.id === event.record.id && currentKey !== key) {
+					const [accountId, securityId] = currentKey.split(':');
+					if (accountId && securityId) this.schedulePositionRefresh(accountId, securityId, userId);
+				}
+			}
+		}
+
+		this.schedulePositionRefresh(event.record.account, event.record.security, userId);
+	}
+
+	private schedulePositionRefresh(accountId: string, securityId: string, userId: string) {
+		const key = this.positionKey(accountId, securityId);
+		const existing = this.positionRefreshTimers.get(key);
+		if (existing) clearTimeout(existing);
+
+		this.positionRefreshTimers.set(
+			key,
+			setTimeout(() => {
+				this.positionRefreshTimers.delete(key);
+				const token = this.refreshSequence;
+				void this.refreshPosition(accountId, securityId, userId, token)
+					.then((refreshed) => {
+						if (refreshed && this.positionsLoaded) this._accounts.notifyBalancesChanged();
+					})
+					.catch((error) => {
+						if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
+						this._pb.handleConnectionError(error, 'securities', 'position_refresh');
+					});
+			}, DEBOUNCE_MS)
+		);
+	}
+
+	private async refreshPosition(
+		accountId: string,
+		securityId: string,
+		userId: string,
+		token: number
+	) {
+		if (!userId || userId !== this._auth.currentUserId || token !== this.refreshSequence)
+			return false;
+		const balances = await this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
+			filter: `account='${accountId}' && security='${securityId}'`,
+			sort: '-asOf,-created,-id',
+			requestKey: null
+		});
+		if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return false;
+
+		const key = this.positionKey(accountId, securityId);
+		const position = resolveSecurityBalanceValues(balances).get(key);
+		if (position) this.currentPositions.set(key, position);
+		else this.currentPositions.delete(key);
+		return true;
+	}
+
+	private positionKey(accountId: string, securityId: string) {
+		return `${accountId}:${securityId}`;
+	}
+
+	private upsertSecurity(security: SecuritiesResponse) {
+		const exists = this.securities.some((record) => record.id === security.id);
+		this.securities = (exists
+			? this.securities.map((record) => (record.id === security.id ? security : record))
+			: [...this.securities, security]
+		).toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+	}
+
+	private clearPositionRefreshTimers() {
+		for (const timer of this.positionRefreshTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.positionRefreshTimers.clear();
 	}
 
 	private getLatestAccountBalanceRows() {
@@ -256,10 +354,8 @@ class SecuritiesContext {
 				.filter((account) => !account.closed)
 				.map((account) => [account.id, account])
 		);
-		const resolvedValues = resolveSecurityBalanceValues(this.securityBalances);
-
 		const rows: SecurityAccountBalance[] = [];
-		for (const resolved of resolvedValues.values()) {
+		for (const resolved of this.currentPositions.values()) {
 			const balance = resolved.balance;
 			const account = accounts.get(balance.account);
 			if (!account) continue;
@@ -330,7 +426,7 @@ class SecuritiesContext {
 	}
 
 	dispose() {
-		if (this.refreshTimer) clearTimeout(this.refreshTimer);
+		this.clearPositionRefreshTimers();
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -314,17 +314,9 @@ class TradesContext {
 			const fields =
 				'id,date,security,type,subtype,description,name,account,quantity,price,amount,fees,expand.account.id,expand.account.name,expand.security.id,expand.security.name,expand.security.symbol';
 			const filter = this.activeFilter;
-			const pageRequest = this._pb.authedClient
-				.collection('securityTransactions')
-				.getList<Trade>(this.page, this.pageSize, {
-					sort: '-date,-created,-id',
-					expand: 'account,security',
-					fields,
-					filter,
-					requestKey: null
-				});
 			if (includeSummary) {
-				const summaryRequest = this._pb.authedClient
+				const requestedPage = this.page;
+				const summaryList = await this._pb.authedClient
 					.collection('securityTransactions')
 					.getFullList<Trade>({
 						sort: '-date,-created,-id',
@@ -334,7 +326,6 @@ class TradesContext {
 						batch: 200,
 						requestKey: null
 					});
-				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
 				if (
 					userId !== this._activeUserId ||
 					refreshId !== this._refreshSequence ||
@@ -342,12 +333,22 @@ class TradesContext {
 				)
 					return;
 				if (pageRefreshId === this._pageRefreshSequence) {
-					this.rawTransactions = pageList.items;
-					this.totalItems = pageList.totalItems;
+					const start = (requestedPage - 1) * this.pageSize;
+					this.rawTransactions = summaryList.slice(start, start + this.pageSize);
+					this.totalItems = summaryList.length;
 				}
 				this.summaryTransactions = summaryList;
 				return;
 			}
+			const pageRequest = this._pb.authedClient
+				.collection('securityTransactions')
+				.getList<Trade>(this.page, this.pageSize, {
+					sort: '-date,-created,-id',
+					expand: 'account,security',
+					fields,
+					filter,
+					requestKey: null
+				});
 			const pageList = await pageRequest;
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
 			if (pageRefreshId === this._pageRefreshSequence) {
@@ -520,8 +521,7 @@ class TradesContext {
 
 		switch (option) {
 			case 'this-month': {
-				const adjusted = new Date(startOfThisMonth.getTime() - 1);
-				return { from: adjusted, to: null } as const;
+				return { from: startOfThisMonth, to: null } as const;
 			}
 			case 'last-month': {
 				const lastMonth = currentMonth === 0 ? 11 : currentMonth - 1;

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -57,6 +57,8 @@ class TradesContext {
 	page: number = $state(1);
 	isLoading: boolean = $state(true);
 	rawTransactions: Trade[] = $state([]);
+	summaryTransactions: Trade[] = $state([]);
+	totalItems: number = $state(0);
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
@@ -65,13 +67,17 @@ class TradesContext {
 	private _customFromDate: Date | null = $state(null);
 	private _customToDate: Date | null = $state(null);
 	private _customLabel: string | null = $state(null);
+	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
 	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _refreshSequence = 0;
+	private _pageRefreshSequence = 0;
+	private _summaryRefreshSequence = 0;
 
 	private static readonly LOADING_DELAY_MS = 150;
+	private static readonly SEARCH_DEBOUNCE_MS = 300;
 	private static readonly REFRESH_DEBOUNCE_MS = 200;
 
 	readonly periodOptions: PeriodOption[] = [
@@ -154,7 +160,10 @@ class TradesContext {
 			this.typeFilter = typeParam as SecurityTransactionsTypeOptions;
 		}
 
-		if (shouldRefresh) this.refreshTransactions();
+		if (shouldRefresh) {
+			this.page = 1;
+			this.refreshTransactions();
+		}
 	}
 
 	private parseDate(dateString: string) {
@@ -169,6 +178,14 @@ class TradesContext {
 		this.search = query;
 		this.page = 1;
 		this.syncFiltersToUrl();
+
+		if (this._searchDebounceTimer) {
+			clearTimeout(this._searchDebounceTimer);
+		}
+
+		this._searchDebounceTimer = setTimeout(() => {
+			this.refreshTransactions();
+		}, TradesContext.SEARCH_DEBOUNCE_MS);
 	}
 
 	setPresetPeriod(option: PeriodOption) {
@@ -185,6 +202,7 @@ class TradesContext {
 		params.set('period', option);
 
 		this.updateUrl(params);
+		this.page = 1;
 		this.refreshTransactions();
 	}
 
@@ -201,6 +219,7 @@ class TradesContext {
 		params.delete('periodLabel');
 
 		this.updateUrl(params);
+		this.page = 1;
 		this.refreshTransactions();
 	}
 
@@ -220,18 +239,61 @@ class TradesContext {
 
 	setTypeFilter(type: TradeTypeFilter) {
 		this.typeFilter = type;
+		this.page = 1;
 		this.syncFiltersToUrl();
 		this.refreshTransactions();
 	}
 
-	async refreshTransactions(userId = this._activeUserId) {
+	private escapeFilterValue(value: string) {
+		return value.replace(/'/g, "''");
+	}
+
+	private get activeFilter() {
+		const filterParts: string[] = [];
+
+		const { from, to } = this.activeDateRange;
+		if (from) {
+			filterParts.push(`date >= '${toPocketBaseDateString(from)}'`);
+		}
+		if (to) {
+			filterParts.push(`date < '${toPocketBaseDateString(to)}'`);
+		}
+
+		if (this.accountFilter) {
+			filterParts.push(`account = '${this.escapeFilterValue(this.accountFilter)}'`);
+		}
+		if (this.securityFilter) {
+			filterParts.push(`security = '${this.escapeFilterValue(this.securityFilter)}'`);
+		}
+		if (this.typeFilter !== 'all') {
+			filterParts.push(`type = '${this.escapeFilterValue(this.typeFilter)}'`);
+		}
+
+		const searchQuery = this.search.trim();
+		if (searchQuery) {
+			const escaped = this.escapeFilterValue(searchQuery);
+			filterParts.push(
+				`(description ~ '${escaped}' || name ~ '${escaped}' || subtype ~ '${escaped}' || type ~ '${escaped}' || security.name ~ '${escaped}' || security.symbol ~ '${escaped}' || account.name ~ '${escaped}')`
+			);
+		}
+
+		return filterParts.length > 0 ? filterParts.join(' && ') : undefined;
+	}
+
+	async refreshTransactions(userId = this._activeUserId, includeSummary = true) {
 		if (userId && userId !== this._activeUserId) return;
 		if (!userId) {
 			this.rawTransactions = [];
+			this.summaryTransactions = [];
+			this.totalItems = 0;
 			this.isLoading = false;
 			return;
 		}
-		const refreshId = ++this._refreshSequence;
+		const refreshId = this._refreshSequence;
+		const pageRefreshId = ++this._pageRefreshSequence;
+		const summaryRefreshId = includeSummary
+			? ++this._summaryRefreshSequence
+			: this._summaryRefreshSequence;
 
 		if (this._loadingDelayTimer) {
 			clearTimeout(this._loadingDelayTimer);
@@ -239,60 +301,77 @@ class TradesContext {
 		}
 
 		this._loadingDelayTimer = setTimeout(() => {
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
+			if (
+				userId !== this._activeUserId ||
+				refreshId !== this._refreshSequence ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
 			this.isLoading = true;
 		}, TradesContext.LOADING_DELAY_MS);
 
 		try {
-			const filterParts: string[] = [];
-
-			const { from, to } = this.activeDateRange;
-			if (from) {
-				filterParts.push(`date >= '${toPocketBaseDateString(from)}'`);
-			}
-			if (to) {
-				filterParts.push(`date < '${toPocketBaseDateString(to)}'`);
-			}
-
-			if (this.accountFilter) {
-				filterParts.push(`account = '${this.accountFilter}'`);
-			}
-			if (this.securityFilter) {
-				filterParts.push(`security = '${this.securityFilter}'`);
-			}
-			if (this.typeFilter !== 'all') {
-				filterParts.push(`type = '${this.typeFilter}'`);
-			}
-
-			const searchQuery = this.search.trim();
-			if (searchQuery) {
-				const escaped = searchQuery.replace(/'/g, "''");
-				filterParts.push(
-					`(description ~ '${escaped}' || subtype ~ '${escaped}' || type ~ '${escaped}' || security.name ~ '${escaped}' || security.symbol ~ '${escaped}' || account.name ~ '${escaped}')`
-				);
-			}
-
-			const filter = filterParts.length > 0 ? filterParts.join(' && ') : undefined;
-			const transactions = await this._pb.authedClient
+			const fields =
+				'id,date,security,type,subtype,description,name,account,quantity,price,amount,fees,expand.account.id,expand.account.name,expand.security.id,expand.security.name,expand.security.symbol';
+			const filter = this.activeFilter;
+			const pageRequest = this._pb.authedClient
 				.collection('securityTransactions')
-				.getFullList<Trade>({
+				.getList<Trade>(this.page, this.pageSize, {
 					sort: '-date,-created,-id',
 					expand: 'account,security',
-					batch: 200,
+					fields,
 					filter,
 					requestKey: null
 				});
+			if (includeSummary) {
+				const summaryRequest = this._pb.authedClient
+					.collection('securityTransactions')
+					.getFullList<Trade>({
+						sort: '-date,-created,-id',
+						expand: 'account,security',
+						fields,
+						filter,
+						batch: 200,
+						requestKey: null
+					});
+				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
+				if (
+					userId !== this._activeUserId ||
+					refreshId !== this._refreshSequence ||
+					summaryRefreshId !== this._summaryRefreshSequence
+				)
+					return;
+				if (pageRefreshId === this._pageRefreshSequence) {
+					this.rawTransactions = pageList.items;
+					this.totalItems = pageList.totalItems;
+				}
+				this.summaryTransactions = summaryList;
+				return;
+			}
+			const pageList = await pageRequest;
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
-			this.rawTransactions = transactions;
+			if (pageRefreshId === this._pageRefreshSequence) {
+				this.rawTransactions = pageList.items;
+				this.totalItems = pageList.totalItems;
+			}
 		} catch (error) {
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
+			if (
+				pageRefreshId !== this._pageRefreshSequence &&
+				(!includeSummary || summaryRefreshId !== this._summaryRefreshSequence)
+			)
+				return;
 			this._pb.handleConnectionError(error, 'securityTransactions', 'refresh');
 		} finally {
 			if (this._loadingDelayTimer) {
 				clearTimeout(this._loadingDelayTimer);
 				this._loadingDelayTimer = null;
 			}
-			if (userId === this._activeUserId && refreshId === this._refreshSequence)
+			if (
+				userId === this._activeUserId &&
+				refreshId === this._refreshSequence &&
+				pageRefreshId === this._pageRefreshSequence
+			)
 				this.isLoading = false;
 		}
 	}
@@ -315,6 +394,8 @@ class TradesContext {
 
 			if (!userId) {
 				this.rawTransactions = [];
+				this.summaryTransactions = [];
+				this.totalItems = 0;
 				this.isLoading = false;
 				return;
 			}
@@ -476,7 +557,11 @@ class TradesContext {
 	}
 
 	get allRows() {
-		return this.rawTransactions.map((transaction) => {
+		return this.mapTransactions(this.summaryTransactions);
+	}
+
+	private mapTransactions(transactions: Trade[]) {
+		return transactions.map((transaction) => {
 			const date = new Date(transaction.date);
 			const dateValue = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 			const account = this._accountsContext.getAccount(transaction.account);
@@ -538,17 +623,24 @@ class TradesContext {
 	}
 
 	get totalPages() {
-		const total = this.filteredRows.length;
+		const total = this.totalItems;
 		if (total === 0) return 1;
 		return Math.ceil(total / this.pageSize);
 	}
 
 	get paginatedRows() {
-		const start = (this.page - 1) * this.pageSize;
-		return this.filteredRows.slice(start, start + this.pageSize);
+		return this.mapTransactions(this.rawTransactions);
+	}
+
+	setPage(page: number) {
+		const nextPage = Math.min(Math.max(1, page), this.totalPages);
+		if (nextPage === this.page) return;
+		this.page = nextPage;
+		this.refreshTransactions(this._activeUserId, false);
 	}
 
 	dispose() {
+		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
 		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
 		if (this._refreshTimer) clearTimeout(this._refreshTimer);
 		this.unsubscribeRealtime();

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -25,7 +25,9 @@ import {
 export type TransactionSortColumn = 'date' | 'description' | 'account' | 'amount';
 
 function isTransactionSortColumn(column: string): column is TransactionSortColumn {
-	return column === 'date' || column === 'description' || column === 'account' || column === 'amount';
+	return (
+		column === 'date' || column === 'description' || column === 'account' || column === 'amount'
+	);
 }
 
 export type PeriodOption =
@@ -447,16 +449,16 @@ class TransactionsContext {
 					requestKey: null
 				});
 			if (includeSummary) {
-				const summaryRequest = this._pb.authedClient.collection('transactions').getFullList<
-					TransactionsResponse<TransactionExpand>
-				>({
-					sort,
-					expand: 'account,labels',
-					fields,
-					filter,
-					batch: 200,
-					requestKey: null
-				});
+				const summaryRequest = this._pb.authedClient
+					.collection('transactions')
+					.getFullList<TransactionsResponse<TransactionExpand>>({
+						sort,
+						expand: 'account,labels',
+						fields,
+						filter,
+						batch: 200,
+						requestKey: null
+					});
 				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
 				if (
 					userId !== this._activeUserId ||

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -375,7 +375,7 @@ class TransactionsContext {
 			filterParts.push(`account = '${this.escapeFilterValue(this.accountFilter)}'`);
 		}
 		if (this.labelFilter) {
-			filterParts.push(`labels ?= '${this.escapeFilterValue(this.labelFilter)}'`);
+			filterParts.push(`labels.id ?= '${this.escapeFilterValue(this.labelFilter)}'`);
 		}
 
 		return filterParts.length > 0 ? filterParts.join(' && ') : undefined;
@@ -439,15 +439,7 @@ class TransactionsContext {
 				'id,date,description,value,excluded,account,labels,expand.account.id,expand.account.name,expand.labels.id,expand.labels.name';
 			const filter = this.activeFilter;
 			const sort = this.activeSort;
-			const pageRequest = this._pb.authedClient
-				.collection('transactions')
-				.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
-					sort,
-					expand: 'account,labels',
-					fields,
-					filter,
-					requestKey: null
-				});
+			const usesClientPagination = this.usesClientPagination;
 			if (includeSummary) {
 				const summaryRequest = this._pb.authedClient
 					.collection('transactions')
@@ -457,6 +449,26 @@ class TransactionsContext {
 						fields,
 						filter,
 						batch: 200,
+						requestKey: null
+					});
+				if (usesClientPagination) {
+					const summaryList = await summaryRequest;
+					if (
+						userId !== this._activeUserId ||
+						refreshId !== this._refreshSequence ||
+						summaryRefreshId !== this._summaryRefreshSequence
+					)
+						return;
+					this.summaryTransactions = summaryList;
+					return;
+				}
+				const pageRequest = this._pb.authedClient
+					.collection('transactions')
+					.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
+						sort,
+						expand: 'account,labels',
+						fields,
+						filter,
 						requestKey: null
 					});
 				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
@@ -473,6 +485,16 @@ class TransactionsContext {
 				this.summaryTransactions = summaryList;
 				return;
 			}
+			if (usesClientPagination) return;
+			const pageRequest = this._pb.authedClient
+				.collection('transactions')
+				.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
+					sort,
+					expand: 'account,labels',
+					fields,
+					filter,
+					requestKey: null
+				});
 			const pageList = await pageRequest;
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
 			if (pageRefreshId === this._pageRefreshSequence) {
@@ -566,8 +588,7 @@ class TransactionsContext {
 
 		switch (option) {
 			case 'this-month': {
-				const adjusted = new Date(startOfThisMonth.getTime() - 1);
-				return { from: adjusted, to: null } as const;
+				return { from: startOfThisMonth, to: null } as const;
 			}
 			case 'last-month': {
 				const lastMonth = currentMonth === 0 ? 11 : currentMonth - 1;

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -24,6 +24,10 @@ import {
 
 export type TransactionSortColumn = 'date' | 'description' | 'account' | 'amount';
 
+function isTransactionSortColumn(column: string): column is TransactionSortColumn {
+	return column === 'date' || column === 'description' || column === 'account' || column === 'amount';
+}
+
 export type PeriodOption =
 	| 'this-month'
 	| 'last-month'
@@ -52,6 +56,7 @@ export type TransactionRow = {
 	accountId: string | null;
 	accountIsShared: boolean;
 	value: number;
+	hasProjectedValue: boolean;
 	excluded: boolean;
 };
 
@@ -65,6 +70,8 @@ class TransactionsContext {
 	page: number = $state(1);
 	isLoading: boolean = $state(true);
 	rawTransactions: TransactionsResponse<TransactionExpand>[] = $state([]);
+	summaryTransactions: TransactionsResponse<TransactionExpand>[] = $state([]);
+	serverTotalItems: number = $state(0);
 	transactionLabels: TransactionLabelsResponse[] = $state([]);
 	sortColumn: TransactionSortColumn | null = $state('date');
 	sortDirection: SortDirection | null = $state('desc');
@@ -75,12 +82,16 @@ class TransactionsContext {
 	private _customLabel: string | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
+	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _refreshSequence = 0;
+	private _pageRefreshSequence = 0;
+	private _summaryRefreshSequence = 0;
 
 	private static readonly LOADING_DELAY_MS = 150;
 	private static readonly SEARCH_DEBOUNCE_MS = 300;
+	private static readonly REFRESH_DEBOUNCE_MS = 200;
 
 	readonly periodOptions: PeriodOption[] = [
 		'this-month',
@@ -122,9 +133,8 @@ class TransactionsContext {
 
 		const sortParam = params.get('sort');
 		const dirParam = params.get('dir');
-		const validSortColumns: TransactionSortColumn[] = ['date', 'description', 'account', 'amount'];
-		if (sortParam && validSortColumns.includes(sortParam as TransactionSortColumn)) {
-			this.sortColumn = sortParam as TransactionSortColumn;
+		if (sortParam && isTransactionSortColumn(sortParam)) {
+			this.sortColumn = sortParam;
 			this.sortDirection = dirParam === 'asc' || dirParam === 'desc' ? dirParam : 'desc';
 		} else {
 			this.sortColumn = 'date';
@@ -183,6 +193,7 @@ class TransactionsContext {
 		}
 
 		if (shouldRefresh) {
+			this.page = 1;
 			this.refreshTransactions();
 		}
 	}
@@ -241,6 +252,10 @@ class TransactionsContext {
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
 			this._refreshSequence++;
+			if (this._refreshTimer) {
+				clearTimeout(this._refreshTimer);
+				this._refreshTimer = null;
+			}
 			if (this._loadingDelayTimer) {
 				clearTimeout(this._loadingDelayTimer);
 				this._loadingDelayTimer = null;
@@ -249,6 +264,8 @@ class TransactionsContext {
 
 			if (!userId) {
 				this.rawTransactions = [];
+				this.summaryTransactions = [];
+				this.serverTotalItems = 0;
 				this.transactionLabels = [];
 				this.isLoading = false;
 				return;
@@ -314,14 +331,91 @@ class TransactionsContext {
 		this.updateUrl(params);
 	}
 
-	async refreshTransactions(userId = this._activeUserId) {
+	private escapeFilterValue(value: string) {
+		return value.replace(/'/g, "''");
+	}
+
+	private get activeFilter() {
+		const filterParts: string[] = [];
+
+		let from: Date | null;
+		let to: Date | null;
+		if (this._customFromDate !== null || this._customToDate !== null) {
+			from = this._customFromDate;
+			to = this._customToDate;
+		} else {
+			const range = this.getPeriodRange(this.period);
+			from = range.from;
+			to = range.to;
+		}
+
+		if (from) {
+			filterParts.push(`date >= '${toPocketBaseDateString(from)}'`);
+		}
+		if (to) {
+			filterParts.push(`date < '${toPocketBaseDateString(to)}'`);
+		}
+
+		if (this.kind === 'excluded') {
+			filterParts.push('excluded != ""');
+		} else if (this.kind === 'credits') {
+			filterParts.push('excluded = ""');
+		} else if (this.kind === 'debits') {
+			filterParts.push('excluded = ""');
+		}
+
+		const searchQuery = this.search.trim();
+		if (searchQuery) {
+			filterParts.push(`description ~ '${this.escapeFilterValue(searchQuery)}'`);
+		}
+
+		if (this.accountFilter) {
+			filterParts.push(`account = '${this.escapeFilterValue(this.accountFilter)}'`);
+		}
+		if (this.labelFilter) {
+			filterParts.push(`labels ?= '${this.escapeFilterValue(this.labelFilter)}'`);
+		}
+
+		return filterParts.length > 0 ? filterParts.join(' && ') : undefined;
+	}
+
+	private get activeSort() {
+		if (!this.sortColumn || !this.sortDirection) return '-date,-created,-id';
+
+		const direction = this.sortDirection === 'desc' ? '-' : '';
+		switch (this.sortColumn) {
+			case 'amount':
+				// NOTE: Displayed amounts are projected from frontend share perspective, so raw
+				// `value` cannot be sorted server-side safely.
+				return '-date,-created,-id';
+			case 'description':
+				return `${direction}description,${direction}date,${direction}id`;
+			case 'account':
+				return `${direction}account.name,${direction}date,${direction}id`;
+			case 'date':
+			default:
+				return `${direction}date,${direction}created,${direction}id`;
+		}
+	}
+
+	private get usesClientPagination() {
+		return this.sortColumn === 'amount' || this.kind === 'credits' || this.kind === 'debits';
+	}
+
+	async refreshTransactions(userId = this._activeUserId, includeSummary = true) {
 		if (userId && userId !== this._activeUserId) return;
 		if (!userId) {
 			this.rawTransactions = [];
+			this.summaryTransactions = [];
+			this.serverTotalItems = 0;
 			this.isLoading = false;
 			return;
 		}
-		const refreshId = ++this._refreshSequence;
+		const refreshId = this._refreshSequence;
+		const pageRefreshId = ++this._pageRefreshSequence;
+		const summaryRefreshId = includeSummary
+			? ++this._summaryRefreshSequence
+			: this._summaryRefreshSequence;
 
 		if (this._loadingDelayTimer) {
 			clearTimeout(this._loadingDelayTimer);
@@ -329,67 +423,78 @@ class TransactionsContext {
 		}
 
 		this._loadingDelayTimer = setTimeout(() => {
-			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
+			if (
+				userId !== this._activeUserId ||
+				refreshId !== this._refreshSequence ||
+				pageRefreshId !== this._pageRefreshSequence
+			)
+				return;
 			this.isLoading = true;
 		}, TransactionsContext.LOADING_DELAY_MS);
 
 		try {
-			const filterParts: string[] = [];
-
-			let from: Date | null;
-			let to: Date | null;
-			if (this._customFromDate !== null || this._customToDate !== null) {
-				from = this._customFromDate;
-				to = this._customToDate;
-			} else {
-				const range = this.getPeriodRange(this.period);
-				from = range.from;
-				to = range.to;
-			}
-
-			if (from) {
-				filterParts.push(`date >= '${toPocketBaseDateString(from)}'`);
-			}
-			if (to) {
-				filterParts.push(`date < '${toPocketBaseDateString(to)}'`);
-			}
-
-			if (this.kind === 'excluded') {
-				filterParts.push('excluded != ""');
-			}
-
-			const searchQuery = this.search.trim();
-			if (searchQuery) {
-				const escaped = searchQuery.replace(/'/g, "''");
-				filterParts.push(`description ~ '${escaped}'`);
-			}
-
-			if (this.accountFilter) {
-				filterParts.push(`account = '${this.accountFilter}'`);
-			}
-
-			const filter = filterParts.length > 0 ? filterParts.join(' && ') : undefined;
-
-			const list = await this._pb.authedClient
+			const fields =
+				'id,date,description,value,excluded,account,labels,expand.account.id,expand.account.name,expand.labels.id,expand.labels.name';
+			const filter = this.activeFilter;
+			const sort = this.activeSort;
+			const pageRequest = this._pb.authedClient
 				.collection('transactions')
-				.getFullList<TransactionsResponse<TransactionExpand>>({
-					sort: '-date,-created,-id',
+				.getList<TransactionsResponse<TransactionExpand>>(this.page, this.pageSize, {
+					sort,
 					expand: 'account,labels',
-					batch: 200,
+					fields,
 					filter,
 					requestKey: null
 				});
+			if (includeSummary) {
+				const summaryRequest = this._pb.authedClient.collection('transactions').getFullList<
+					TransactionsResponse<TransactionExpand>
+				>({
+					sort,
+					expand: 'account,labels',
+					fields,
+					filter,
+					batch: 200,
+					requestKey: null
+				});
+				const [pageList, summaryList] = await Promise.all([pageRequest, summaryRequest]);
+				if (
+					userId !== this._activeUserId ||
+					refreshId !== this._refreshSequence ||
+					summaryRefreshId !== this._summaryRefreshSequence
+				)
+					return;
+				if (pageRefreshId === this._pageRefreshSequence) {
+					this.rawTransactions = pageList.items;
+					this.serverTotalItems = pageList.totalItems;
+				}
+				this.summaryTransactions = summaryList;
+				return;
+			}
+			const pageList = await pageRequest;
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
-			this.rawTransactions = list;
+			if (pageRefreshId === this._pageRefreshSequence) {
+				this.rawTransactions = pageList.items;
+				this.serverTotalItems = pageList.totalItems;
+			}
 		} catch (error) {
 			if (userId !== this._activeUserId || refreshId !== this._refreshSequence) return;
+			if (
+				pageRefreshId !== this._pageRefreshSequence &&
+				(!includeSummary || summaryRefreshId !== this._summaryRefreshSequence)
+			)
+				return;
 			this._pb.handleConnectionError(error, 'transactions', 'refresh');
 		} finally {
 			if (this._loadingDelayTimer) {
 				clearTimeout(this._loadingDelayTimer);
 				this._loadingDelayTimer = null;
 			}
-			if (userId === this._activeUserId && refreshId === this._refreshSequence)
+			if (
+				userId === this._activeUserId &&
+				refreshId === this._refreshSequence &&
+				pageRefreshId === this._pageRefreshSequence
+			)
 				this.isLoading = false;
 		}
 	}
@@ -434,31 +539,21 @@ class TransactionsContext {
 		this._pb.authedClient.collection('transactionLabels').unsubscribe('*');
 	}
 
-	private async onTransactionEvent(
+	private onTransactionEvent(
 		e: RecordSubscription<TransactionsResponse<TransactionExpand>>,
 		userId: string
 	) {
 		if (!userId || userId !== this._activeUserId) return;
 
-		if (e.action === 'create') {
-			const txn = await this._pb.authedClient
-				.collection('transactions')
-				.getOne<TransactionsResponse<TransactionExpand>>(e.record.id, {
-					expand: 'account,labels'
-				});
+		if (!e.action) return;
+		if (this._refreshTimer) clearTimeout(this._refreshTimer);
+		this._refreshTimer = setTimeout(() => {
+			this._refreshTimer = null;
 			if (userId !== this._activeUserId) return;
-			this.rawTransactions = [...this.rawTransactions, txn];
-		} else if (e.action === 'update') {
-			const txn = await this._pb.authedClient
-				.collection('transactions')
-				.getOne<TransactionsResponse<TransactionExpand>>(e.record.id, {
-					expand: 'account,labels'
-				});
-			if (userId !== this._activeUserId) return;
-			this.rawTransactions = this.rawTransactions.map((x) => (x.id === e.record.id ? txn : x));
-		} else if (e.action === 'delete') {
-			this.rawTransactions = this.rawTransactions.filter((x) => x.id !== e.record.id);
-		}
+			this.refreshTransactions(userId).catch((error) =>
+				this._pb.handleConnectionError(error, 'transactions', 'realtime_refresh')
+			);
+		}, TransactionsContext.REFRESH_DEBOUNCE_MS);
 	}
 
 	private getPeriodRange(option: PeriodOption) {
@@ -511,8 +606,8 @@ class TransactionsContext {
 		return map;
 	}
 
-	get allRows() {
-		return this.rawTransactions.map((txn) => {
+	private mapTransactions(transactions: TransactionsResponse<TransactionExpand>[]) {
+		return transactions.map((txn) => {
 			const dateIso = txn.date;
 			const date = new Date(dateIso);
 			const expandedAccount = txn.expand?.account;
@@ -543,9 +638,14 @@ class TransactionsContext {
 				accountId: txn.account ?? null,
 				accountIsShared: Boolean(contextAccount?.isShared),
 				value,
+				hasProjectedValue: Boolean(contextAccount),
 				excluded: Boolean(txn.excluded)
 			};
 		});
+	}
+
+	get allRows() {
+		return this.mapTransactions(this.summaryTransactions);
 	}
 
 	get filteredRows() {
@@ -569,8 +669,8 @@ class TransactionsContext {
 			if (toTime !== null && time >= toTime) return false;
 			if (this.accountFilter && row.accountId !== this.accountFilter) return false;
 			if (this.labelFilter && !row.labelIds.includes(this.labelFilter)) return false;
-			if (this.kind === 'credits') return row.value > 0 && !row.excluded;
-			if (this.kind === 'debits') return row.value < 0 && !row.excluded;
+			if (this.kind === 'credits') return row.hasProjectedValue && row.value > 0 && !row.excluded;
+			if (this.kind === 'debits') return row.hasProjectedValue && row.value < 0 && !row.excluded;
 			if (this.kind === 'excluded') return row.excluded;
 			return true;
 		});
@@ -596,14 +696,21 @@ class TransactionsContext {
 	}
 
 	get totalPages() {
-		const total = this.filteredRows.length;
+		const total = this.totalItems;
 		if (total === 0) return 1;
 		return Math.ceil(total / this.pageSize);
 	}
 
+	get totalItems() {
+		return this.usesClientPagination ? this.filteredRows.length : this.serverTotalItems;
+	}
+
 	get paginatedRows() {
-		const start = (this.page - 1) * this.pageSize;
-		return this.filteredRows.slice(start, start + this.pageSize);
+		if (this.usesClientPagination) {
+			const start = (this.page - 1) * this.pageSize;
+			return this.filteredRows.slice(start, start + this.pageSize);
+		}
+		return this.mapTransactions(this.rawTransactions);
 	}
 
 	get netBalance() {
@@ -648,6 +755,7 @@ class TransactionsContext {
 		params.delete('periodLabel');
 
 		this.updateUrl(params);
+		this.page = 1;
 		this.refreshTransactions();
 	}
 
@@ -666,11 +774,13 @@ class TransactionsContext {
 		this.syncFiltersToParams(params);
 
 		this.updateUrl(params);
+		this.page = 1;
 		this.refreshTransactions();
 	}
 
 	setKind(option: KindFilter) {
 		this.kind = option;
+		this.page = 1;
 
 		const params = new SvelteURLSearchParams(this.currentUrl.searchParams);
 		this.syncFiltersToParams(params);
@@ -705,7 +815,8 @@ class TransactionsContext {
 		return { column: this.sortColumn, direction: this.sortDirection };
 	}
 
-	setSort(column: TransactionSortColumn) {
+	setSort(column: string) {
+		if (!isTransactionSortColumn(column)) return;
 		if (this.sortColumn !== column) {
 			this.sortColumn = column;
 			this.sortDirection = 'desc';
@@ -721,6 +832,15 @@ class TransactionsContext {
 		params.set('dir', this.sortDirection);
 
 		this.updateUrl(params);
+		this.refreshTransactions();
+	}
+
+	setPage(page: number) {
+		const nextPage = Math.min(Math.max(1, page), this.totalPages);
+		if (nextPage === this.page) return;
+		this.page = nextPage;
+		if (this.usesClientPagination) return;
+		this.refreshTransactions(this._activeUserId, false);
 	}
 
 	get selectedIds() {
@@ -786,6 +906,9 @@ class TransactionsContext {
 	}
 
 	dispose() {
+		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
+		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
+		if (this._refreshTimer) clearTimeout(this._refreshTimer);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -241,7 +241,7 @@
 	<Section>
 		{#if !isLoaded}
 			<div class="bg-background overflow-hidden rounded-sm shadow-md">
-				<Skeleton class="h-64" />
+				<Skeleton class="h-64" showSpinner />
 			</div>
 		{:else}
 			<Tabs.Root bind:value={filter}>

--- a/src/routes/(app)/accounts/add/+page.svelte
+++ b/src/routes/(app)/accounts/add/+page.svelte
@@ -3,6 +3,7 @@
 
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAuthContext } from '$lib/auth.svelte';
 	import { getBalanceTypesContext } from '$lib/balance-types.svelte';
 	import CurrencyField from '$lib/components/currency-field.svelte';
@@ -26,6 +27,7 @@
 
 	const pb = getPocketBaseContext();
 	const auth = getAuthContext();
+	const accountsContext = getAccountsContext();
 	const balanceTypesContext = getBalanceTypesContext();
 
 	const ownerId = $derived(auth.currentUser?.record?.id);
@@ -69,6 +71,9 @@
 			};
 
 			await pb.authedClient.collection('accountBalances').create(balanceData);
+			if (await accountsContext.refreshAccount(account.id, currentOwnerId)) {
+				accountsContext.notifyBalancesChanged();
+			}
 
 			toast.success(m.accounts_add_success());
 			await goto(resolve('/accounts'));

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -219,7 +219,7 @@
 	<Section>
 		{#if !isLoaded}
 			<div class="bg-background overflow-hidden rounded-sm shadow-md">
-				<Skeleton class="h-64" />
+				<Skeleton class="h-64" showSpinner />
 			</div>
 		{:else}
 			<Tabs.Root bind:value={filter}>

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -2,6 +2,7 @@
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAssetsContext } from '$lib/assets.svelte';
 	import Currency from '$lib/components/currency.svelte';
+	import Empty from '$lib/components/empty.svelte';
 	import KeyValue from '$lib/components/key-value.svelte';
 	import Page from '$lib/components/page.svelte';
 	import RecordLink from '$lib/components/record-link.svelte';
@@ -10,6 +11,7 @@
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb/index.js';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { Skeleton } from '$lib/components/ui/skeleton';
 	import { m } from '$lib/paraglide/messages';
 	import { sumOrUnknown } from '$lib/security-balance-values';
 
@@ -19,6 +21,7 @@
 	const assetsContext = getAssetsContext();
 
 	const balanceGroups: BalanceGroup[] = ['CASH', 'DEBT', 'INVESTMENT', 'OTHER'];
+	const isLoading = $derived(accountsContext.isLoading || assetsContext.isLoading);
 
 	function groupTitle(group: BalanceGroup) {
 		return group === 'CASH'
@@ -152,50 +155,56 @@
 						value={grouped[balanceGroup].total}
 						variant={groupVariant(balanceGroup)}
 					/>
-					{#each grouped[balanceGroup].types as balanceType (balanceType.id)}
-						<div
-							class="bg-background overflow-hidden rounded-sm shadow-md"
-							role="region"
-							aria-label={balanceType.name}
-						>
-							<div class="flex items-center justify-between border-b px-4 py-3.5">
-								<div class="text-sm font-medium">{balanceType.name}</div>
-								<div class="font-mono tabular-nums">
-									{#if balanceType.total === null}
-										<span class="text-muted-foreground">~</span>
-									{:else}
-										<Currency value={balanceType.total} />
-									{/if}
+					{#if isLoading}
+						<Skeleton class="min-h-32" />
+					{:else if grouped[balanceGroup].types.length === 0}
+						<Empty>No accounts or assets for this balance group</Empty>
+					{:else}
+						{#each grouped[balanceGroup].types as balanceType (balanceType.id)}
+							<div
+								class="bg-background overflow-hidden rounded-sm shadow-md"
+								role="region"
+								aria-label={balanceType.name}
+							>
+								<div class="flex items-center justify-between border-b px-4 py-3.5">
+									<div class="text-sm font-medium">{balanceType.name}</div>
+									<div class="font-mono tabular-nums">
+										{#if balanceType.total === null}
+											<span class="text-muted-foreground">~</span>
+										{:else}
+											<Currency value={balanceType.total} />
+										{/if}
+									</div>
 								</div>
-							</div>
-							<ul>
-								{#each balanceType.items as item (item.id)}
-									<li
-										class="odd:bg-sidebar flex items-center justify-between gap-2 border-b border-dashed px-4 py-3 text-balance last:border-b-0"
-									>
-										<RecordLink
-											type={item.type}
-											id={item.id}
-											name={item.name}
-											isShared={item.isShared}
-											class={'text-sm ' +
-												(item.excluded ? 'text-muted-foreground' : 'text-foreground/90')}
-										/>
-										<span
-											class={'font-mono tabular-nums ' +
-												(item.excluded ? 'text-muted-foreground' : '')}
+								<ul>
+									{#each balanceType.items as item (item.id)}
+										<li
+											class="odd:bg-sidebar flex items-center justify-between gap-2 border-b border-dashed px-4 py-3 text-balance last:border-b-0"
 										>
-											{#if item.balance === null}
-												<span class="text-muted-foreground">~</span>
-											{:else}
-												<Currency value={item.balance} />
-											{/if}
-										</span>
-									</li>
-								{/each}
-							</ul>
-						</div>
-					{/each}
+											<RecordLink
+												type={item.type}
+												id={item.id}
+												name={item.name}
+												isShared={item.isShared}
+												class={'text-sm ' +
+													(item.excluded ? 'text-muted-foreground' : 'text-foreground/90')}
+											/>
+											<span
+												class={'font-mono tabular-nums ' +
+													(item.excluded ? 'text-muted-foreground' : '')}
+											>
+												{#if item.balance === null}
+													<span class="text-muted-foreground">~</span>
+												{:else}
+													<Currency value={item.balance} />
+												{/if}
+											</span>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						{/each}
+					{/if}
 				</div>
 			{/each}
 		</div>

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -158,7 +158,7 @@
 					{#if isLoading}
 						<Skeleton class="min-h-32" />
 					{:else if grouped[balanceGroup].types.length === 0}
-						<Empty>No accounts or assets for this balance group</Empty>
+						<Empty>{m.balance_sheet_group_empty()}</Empty>
 					{:else}
 						{#each grouped[balanceGroup].types as balanceType (balanceType.id)}
 							<div

--- a/src/routes/(app)/big-picture/+page.svelte
+++ b/src/routes/(app)/big-picture/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
+
 	import { setCashflowContext } from '$lib/cashflow.svelte';
 	import Page from '$lib/components/page.svelte';
 	import SectionTitle from '$lib/components/section-title.svelte';
@@ -14,7 +16,11 @@
 	import TrailingCashflow from './trailing-cashflow.svelte';
 
 	const pb = getPocketBaseContext();
-	setCashflowContext(pb);
+	const cashflowContext = setCashflowContext(pb);
+
+	onDestroy(() => {
+		cashflowContext.dispose();
+	});
 </script>
 
 <header class="bg-background flex h-16 shrink-0 items-center gap-2 border-b">

--- a/src/routes/(app)/big-picture/cashflow.svelte
+++ b/src/routes/(app)/big-picture/cashflow.svelte
@@ -5,6 +5,7 @@
 	import { formatCurrency } from '$lib/components/currency';
 	import Currency from '$lib/components/currency.svelte';
 	import SectionTitle from '$lib/components/section-title.svelte';
+	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/paraglide/messages';
 
@@ -108,8 +109,8 @@
 
 <SectionTitle title={m.cashflow_section_title()} />
 
-<div class="bg-background overflow-hidden rounded shadow-md">
-	{#if chartData.length > 0}
+{#if chartData.length > 0}
+	<div class="bg-background overflow-hidden rounded shadow-md">
 		<Tooltip.Provider>
 			<!-- Outer grid: one column per period -->
 			<div class="grid" style="grid-template-columns: repeat({chartData.length}, minmax(0, 1fr));">
@@ -245,5 +246,7 @@
 				{/each}
 			</div>
 		</Tooltip.Provider>
-	{/if}
-</div>
+	</div>
+{:else}
+	<Skeleton class="h-[calc(50vh+2rem)] max-h-[22rem] min-h-72" />
+{/if}

--- a/src/routes/(app)/big-picture/cashflow.svelte
+++ b/src/routes/(app)/big-picture/cashflow.svelte
@@ -248,5 +248,5 @@
 		</Tooltip.Provider>
 	</div>
 {:else if cashflow.isLoading}
-	<Skeleton class="h-[calc(50vh+2rem)] max-h-[22rem] min-h-72" />
+	<Skeleton class="h-[calc(50vh+2rem)] max-h-[22rem] min-h-72" showSpinner />
 {/if}

--- a/src/routes/(app)/big-picture/cashflow.svelte
+++ b/src/routes/(app)/big-picture/cashflow.svelte
@@ -5,7 +5,7 @@
 	import { formatCurrency } from '$lib/components/currency';
 	import Currency from '$lib/components/currency.svelte';
 	import SectionTitle from '$lib/components/section-title.svelte';
-	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
+	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { m } from '$lib/paraglide/messages';
 
@@ -247,6 +247,6 @@
 			</div>
 		</Tooltip.Provider>
 	</div>
-{:else}
+{:else if cashflow.isLoading}
 	<Skeleton class="h-[calc(50vh+2rem)] max-h-[22rem] min-h-72" />
 {/if}

--- a/src/routes/(app)/portfolio/+page.svelte
+++ b/src/routes/(app)/portfolio/+page.svelte
@@ -67,7 +67,7 @@
 		<SectionTitle title={m.portfolio_section_positions()} />
 		{#if securitiesContext.isLoading}
 			<div class="bg-background overflow-hidden rounded-sm shadow-md">
-				<Skeleton class="h-64" />
+				<Skeleton class="h-64" showSpinner />
 			</div>
 		{:else if rows.length === 0}
 			<Empty>{m.portfolio_empty()}</Empty>

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -248,7 +248,7 @@
 	<Section>
 		{#if importSessionsContext.isLoading}
 			<div class="bg-background overflow-hidden rounded-sm shadow-md">
-				<Skeleton class="h-64" />
+				<Skeleton class="h-64" showSpinner />
 			</div>
 		{:else}
 			<SectionTitle title={m.settings_imports_section_title()} />

--- a/src/routes/(app)/trades/+page.svelte
+++ b/src/routes/(app)/trades/+page.svelte
@@ -41,15 +41,13 @@
 		tradesContext.syncFromUrl();
 	});
 
-	// Keep page within valid bounds
 	$effect(() => {
 		if (tradesContext.page > tradesContext.totalPages) {
-			tradesContext.page = tradesContext.totalPages;
+			tradesContext.setPage(tradesContext.totalPages);
 		}
-		if (tradesContext.page < 1) tradesContext.page = 1;
+		if (tradesContext.page < 1) tradesContext.setPage(1);
 	});
 
-	// Reset pagination whenever the active filters change
 	$effect(() => {
 		void tradesContext.period;
 		void tradesContext.accountFilter;

--- a/src/routes/(app)/trades/securities/+page.svelte
+++ b/src/routes/(app)/trades/securities/+page.svelte
@@ -43,7 +43,7 @@
 		<SectionTitle title={m.securities_title()} />
 		{#if securitiesContext.isLoading}
 			<div class="bg-background overflow-hidden rounded-sm shadow-md">
-				<Skeleton class="h-64" />
+				<Skeleton class="h-64" showSpinner />
 			</div>
 		{:else if securitiesContext.securities.length === 0}
 			<Empty>{m.securities_empty()}</Empty>

--- a/src/routes/(app)/trades/securities/[id]/+page.svelte
+++ b/src/routes/(app)/trades/securities/[id]/+page.svelte
@@ -194,7 +194,7 @@
 			<SectionTitle title={m.securities_section_balances()} />
 			{#if securitiesContext.isLoading}
 				<div class="bg-background overflow-hidden rounded-sm shadow-md">
-					<Skeleton class="h-64" />
+					<Skeleton class="h-64" showSpinner />
 				</div>
 			{:else}
 				<div

--- a/src/routes/(app)/trades/trade-summary.svelte
+++ b/src/routes/(app)/trades/trade-summary.svelte
@@ -17,7 +17,7 @@
 >
 	<KeyValue
 		title={m.trades_summary_count_label()}
-		value={tradesContext.filteredRows.length}
+		value={tradesContext.totalItems}
 		variant="outline"
 		format="number"
 	/>

--- a/src/routes/(app)/trades/trades-table.svelte
+++ b/src/routes/(app)/trades/trades-table.svelte
@@ -38,7 +38,7 @@
 	}
 </script>
 
-{#if tradesContext.filteredRows.length === 0}
+{#if tradesContext.totalItems === 0}
 	<Empty>
 		{m.trades_table_empty()}
 	</Empty>
@@ -187,9 +187,10 @@
 					<Table.Row class="border-t">
 						<Table.Cell colspan={10} class="bg-background px-0 py-3 whitespace-normal">
 							<Pagination.Root
-								count={tradesContext.filteredRows.length}
+								count={tradesContext.totalItems}
 								perPage={tradesContext.pageSize}
-								bind:page={tradesContext.page}
+								page={tradesContext.page}
+								onPageChange={(page) => tradesContext.setPage(page)}
 							>
 								{#snippet children({ pages, currentPage })}
 									<Pagination.Content

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -20,21 +20,25 @@
 	import TransactionTable from './transaction-table.svelte';
 
 	const txContext = getTransactionsContext();
-	txContext.syncFromUrl();
+	let hasNavigated = $state(false);
 
-	// Sync filters from URL after navigation (e.g., clicking sidebar link)
 	afterNavigate(({ to }) => {
-		if (to?.url.pathname !== '/transactions') return;
+		if (to?.url.pathname !== resolve('/transactions')) return;
+		if (!hasNavigated) {
+			hasNavigated = true;
+			if (to.url.pathname + to.url.search !== txContext.currentListPath) {
+				txContext.syncFromUrl();
+			}
+			return;
+		}
 		txContext.syncFromUrl();
 	});
 
-	// Keep page within valid bounds
 	$effect(() => {
-		if (txContext.page > txContext.totalPages) txContext.page = txContext.totalPages;
-		if (txContext.page < 1) txContext.page = 1;
+		if (txContext.page > txContext.totalPages) txContext.setPage(txContext.totalPages);
+		if (txContext.page < 1) txContext.setPage(1);
 	});
 
-	// Reset pagination whenever the active filters change
 	$effect(() => {
 		void txContext.period;
 		void txContext.kind;

--- a/src/routes/(app)/transactions/transaction-summary.svelte
+++ b/src/routes/(app)/transactions/transaction-summary.svelte
@@ -13,7 +13,7 @@
 >
 	<KeyValue
 		title={m.transactions_summary_count_label()}
-		value={txContext.filteredRows.length}
+		value={txContext.totalItems}
 		variant="outline"
 		format="number"
 	/>

--- a/src/routes/(app)/transactions/transaction-table.svelte
+++ b/src/routes/(app)/transactions/transaction-table.svelte
@@ -11,7 +11,7 @@
 	import * as Table from '$lib/components/ui/table/index';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { m } from '$lib/paraglide/messages';
-	import { getTransactionsContext, type TransactionSortColumn } from '$lib/transactions.svelte';
+	import { getTransactionsContext } from '$lib/transactions.svelte';
 
 	const txContext = getTransactionsContext();
 
@@ -22,7 +22,7 @@
 	}
 
 	function handleSort(column: string) {
-		txContext.setSort(column as TransactionSortColumn);
+		txContext.setSort(column);
 	}
 
 	const dateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -43,7 +43,7 @@
 	}
 </script>
 
-{#if txContext.filteredRows.length === 0}
+{#if txContext.totalItems === 0}
 	<Empty>
 		{m.transactions_table_empty()}
 	</Empty>
@@ -205,9 +205,10 @@
 					<Table.Row class="border-t">
 						<Table.Cell colspan={6} class="bg-background px-0 py-3 whitespace-normal">
 							<Pagination.Root
-								count={txContext.filteredRows.length}
+								count={txContext.totalItems}
 								perPage={txContext.pageSize}
-								bind:page={txContext.page}
+								page={txContext.page}
+								onPageChange={(page) => txContext.setPage(page)}
 							>
 								{#snippet children({ pages, currentPage })}
 									<Pagination.Content

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import type { RecordSubscription } from 'pocketbase';
+
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAssetsContext } from '$lib/assets.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -22,103 +24,350 @@
 
 	import ChartNetWorth from './growth.svelte';
 	import Performance from './performance.svelte';
+	import {
+		buildPreparedMaps,
+		computeBoundedHistoryStart,
+		type PeriodKey,
+		type TrendSecurityBalance
+	} from './trends';
 
 	const pb = getPocketBaseContext();
 	const accountsCtx = getAccountsContext();
 	const assetsCtx = getAssetsContext();
 
-	let period: '3m' | '6m' | 'ytd' | '1y' | '2y' | '5y' | 'max' = $state('1y');
+	let period: PeriodKey = $state('1y');
 	let rawAccounts: AccountsResponse[] = $state([]);
 	let rawAssets: AssetsResponse[] = $state([]);
 	let rawAccountBalances: AccountBalancesResponse[] = $state([]);
-	let rawSecurityBalances: Pick<
-		SecurityBalancesResponse<number, number, number, number>,
-		'id' | 'account' | 'security' | 'value' | 'quantity' | 'asOf'
-	>[] = $state([]);
+	let rawSecurityBalances: TrendSecurityBalance[] = $state([]);
 	let rawAssetBalances: AssetBalancesResponse[] = $state([]);
+	let historyStart: Date | null = $state(null);
+
+	const includedAccounts = $derived.by(() =>
+		new Map(
+			(accountsCtx?.accounts ?? [])
+				.filter((account) => !account.participantExcluded)
+				.map((account) => [account.id, account] as const)
+		)
+	);
+	const includedAssets = $derived.by(() =>
+		new Map(
+			(assetsCtx?.assets ?? [])
+				.filter((asset) => !asset.participantExcluded)
+				.map((asset) => [asset.id, asset] as const)
+		)
+	);
+	const includedSignature = $derived.by(() =>
+		JSON.stringify({
+			accounts: (accountsCtx?.accounts ?? []).map((account) => [
+				account.id,
+				account.participantExcluded,
+				account.perspective,
+				account.closed,
+				account.balanceGroup
+			]),
+			assets: (assetsCtx?.assets ?? []).map((asset) => [
+				asset.id,
+				asset.participantExcluded,
+				asset.perspective,
+				asset.sold,
+				asset.balanceGroup
+			])
+		})
+	);
+	const prepared = $derived.by(() =>
+		buildPreparedMaps(
+			rawAccounts,
+			rawAssets,
+			rawAccountBalances,
+			rawSecurityBalances,
+			rawAssetBalances
+		)
+	);
+
+	function isDefined<T>(value: T | null | undefined): value is T {
+		return value !== null && value !== undefined;
+	}
+
+	function quoteFilterValue(value: string) {
+		return value.replaceAll("'", "\\'");
+	}
+
+	function filterByIds(field: string, ids: string[]) {
+		return ids.map((id) => `${field}='${quoteFilterValue(id)}'`).join(' || ');
+	}
+
+	function historyFilter(field: string, ids: string[], start: Date | null) {
+		const idsFilter = filterByIds(field, ids);
+		if (!idsFilter) return '';
+		return start ? `(${idsFilter}) && asOf>='${start.toISOString()}'` : idsFilter;
+	}
+
+	function compareBalances<T extends { asOf: string; created: string; id: string }>(a: T, b: T) {
+		if (a.asOf !== b.asOf) return a.asOf.localeCompare(b.asOf);
+		if (a.created !== b.created) return a.created.localeCompare(b.created);
+		return a.id.localeCompare(b.id);
+	}
+
+	function computeHistoryStart() {
+		if (period === 'max') return null;
+		const periodStart = computeBoundedHistoryStart(period);
+		const performanceStart = computeBoundedHistoryStart('5y');
+		if (!periodStart) return performanceStart;
+		if (!performanceStart) return periodStart;
+		return periodStart < performanceStart ? periodStart : performanceStart;
+	}
+
+	function trimAccountBalances(records: AccountBalancesResponse[], start: Date | null) {
+		if (!start) return records.toSorted(compareBalances);
+		const previousByAccount = new Map<string, AccountBalancesResponse>();
+		const inRange: AccountBalancesResponse[] = [];
+		for (const record of records) {
+			if (new Date(record.asOf) >= start) {
+				inRange.push(record);
+				continue;
+			}
+			const previous = previousByAccount.get(record.account);
+			if (!previous || compareBalances(previous, record) < 0) previousByAccount.set(record.account, record);
+		}
+		return [...previousByAccount.values(), ...inRange].toSorted(compareBalances);
+	}
+
+	function trimSecurityBalances(records: TrendSecurityBalance[], start: Date | null) {
+		if (!start) return records.toSorted(compareBalances);
+		const previousByAccountSecurity = new Map<string, TrendSecurityBalance>();
+		const inRange: TrendSecurityBalance[] = [];
+		for (const record of records) {
+			if (new Date(record.asOf) >= start) {
+				inRange.push(record);
+				continue;
+			}
+			const key = `${record.account}:${record.security}`;
+			const previous = previousByAccountSecurity.get(key);
+			if (!previous || compareBalances(previous, record) < 0) {
+				previousByAccountSecurity.set(key, record);
+			}
+		}
+		return [...previousByAccountSecurity.values(), ...inRange].toSorted(compareBalances);
+	}
+
+	function trimAssetBalances(records: AssetBalancesResponse[], start: Date | null) {
+		if (!start) return records.toSorted(compareBalances);
+		const previousByAsset = new Map<string, AssetBalancesResponse>();
+		const inRange: AssetBalancesResponse[] = [];
+		for (const record of records) {
+			if (new Date(record.asOf) >= start) {
+				inRange.push(record);
+				continue;
+			}
+			const previous = previousByAsset.get(record.asset);
+			if (!previous || compareBalances(previous, record) < 0) previousByAsset.set(record.asset, record);
+		}
+		return [...previousByAsset.values(), ...inRange].toSorted(compareBalances);
+	}
+
+	function projectAccountBalance(balance: AccountBalancesResponse) {
+		const account = includedAccounts.get(balance.account);
+		if (!account) return null;
+		return {
+			...balance,
+			value:
+				account.closed && new Date(balance.asOf) >= new Date(account.closed)
+					? 0
+					: projectSignedValue(balance.value, account.perspective)
+		};
+	}
+
+	function projectSecurityBalance(balance: SecurityBalancesResponse<number, number, number, number>) {
+		const account = includedAccounts.get(balance.account);
+		if (!account) return null;
+		const value = toNumber(balance.value);
+		return {
+			id: balance.id,
+			account: balance.account,
+			security: balance.security,
+			created: balance.created,
+			asOf: balance.asOf,
+			value:
+				account.closed && new Date(balance.asOf) >= new Date(account.closed)
+					? 0
+					: value === null
+						? null
+						: projectSignedValue(value, account.perspective),
+			quantity:
+				account.closed && new Date(balance.asOf) >= new Date(account.closed)
+					? 0
+					: balance.quantity
+		};
+	}
+
+	function projectAssetBalance(balance: AssetBalancesResponse) {
+		const asset = includedAssets.get(balance.asset);
+		if (!asset) return null;
+		return {
+			...balance,
+			marketValue:
+				asset.sold && new Date(balance.asOf) >= new Date(asset.sold)
+					? 0
+					: projectSignedValue(balance.marketValue, asset.perspective)
+		};
+	}
+
+	async function previousAccountBalances(accountIds: string[], start: Date) {
+		return Promise.all(
+			accountIds.map(async (accountId) => {
+				const result = await pb.authedClient
+					.collection('accountBalances')
+					.getList<AccountBalancesResponse>(1, 1, {
+						filter: `account='${quoteFilterValue(accountId)}' && asOf<'${start.toISOString()}'`,
+						sort: '-asOf,-created,-id',
+						fields: 'id,account,value,asOf,created',
+						requestKey: null
+					});
+				return result.items[0] ?? null;
+			})
+		);
+	}
+
+	async function previousSecurityBalances(accountIds: string[], start: Date) {
+		const accountFilter = filterByIds('account', accountIds);
+		if (!accountFilter) return [];
+		const balances = await pb.authedClient
+			.collection('securityBalances')
+			.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+				filter: `(${accountFilter}) && asOf<'${start.toISOString()}'`,
+				sort: 'account,security,asOf,created,id',
+				fields: 'id,account,security,value,quantity,asOf,created',
+				requestKey: null
+			});
+
+		const latestByKey = new Map<
+			string,
+			{
+				balance: SecurityBalancesResponse<number, number, number, number>;
+				lastKnownValue: number | null;
+				soldOut: boolean;
+			}
+		>();
+		for (const balance of balances) {
+			const key = `${balance.account}:${balance.security}`;
+			const existing = latestByKey.get(key) ?? { balance, lastKnownValue: null, soldOut: false };
+			if (toNumber(balance.quantity) === 0) {
+				existing.lastKnownValue = 0;
+				existing.soldOut = true;
+			} else {
+				const value = toNumber(balance.value);
+				if (value !== null) {
+					existing.lastKnownValue = value;
+					existing.soldOut = false;
+				}
+			}
+			existing.balance = balance;
+			latestByKey.set(key, existing);
+		}
+		return Array.from(latestByKey.values()).map(({ balance, lastKnownValue, soldOut }) => ({
+			...balance,
+			value: soldOut ? balance.value : lastKnownValue
+		}));
+	}
+
+	async function previousAssetBalances(assetIds: string[], start: Date) {
+		return Promise.all(
+			assetIds.map(async (assetId) => {
+				const result = await pb.authedClient
+					.collection('assetBalances')
+					.getList<AssetBalancesResponse>(1, 1, {
+						filter: `asset='${quoteFilterValue(assetId)}' && asOf<'${start.toISOString()}'`,
+						sort: '-asOf,-created,-id',
+						fields: 'id,asset,marketValue,asOf,created',
+						requestKey: null
+					});
+				return result.items[0] ?? null;
+			})
+		);
+	}
+
+	let refreshSequence = 0;
 
 	async function refreshBalances() {
+		const sequence = ++refreshSequence;
+		const start = computeHistoryStart();
+		const accountIds = Array.from(includedAccounts.keys());
+		const assetIds = Array.from(includedAssets.keys());
+		const accountFilter = historyFilter('account', accountIds, start);
+		const securityFilter = historyFilter('account', accountIds, start);
+		const assetFilter = historyFilter('asset', assetIds, start);
 		try {
-			const [accountBalancesAll, securityBalancesAll, assetBalancesAll] = await Promise.all([
-				pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
-					sort: 'asOf,created,id',
-					fields: 'id,account,value,asOf',
-					requestKey: 'trends:accountBalances'
-				}),
-				pb.authedClient
-					.collection('securityBalances')
-					.getFullList<SecurityBalancesResponse<number, number, number, number>>({
-						sort: 'asOf,created,id',
-						fields: 'id,account,security,value,quantity,asOf',
-						requestKey: 'trends:securityBalances'
-					}),
-				pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
-					sort: 'asOf,created,id',
-					fields: 'id,asset,marketValue,asOf',
-					requestKey: 'trends:assetBalances'
-				})
+			const [accountBalancesRange, securityBalancesRangeRaw, assetBalancesRange] = await Promise.all([
+				accountFilter
+					? pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
+							sort: 'asOf,created,id',
+							filter: accountFilter,
+							fields: 'id,account,value,asOf,created',
+							requestKey: null
+						})
+					: [],
+				securityFilter
+					? pb.authedClient
+							.collection('securityBalances')
+							.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+								sort: 'asOf,created,id',
+								filter: securityFilter,
+								fields: 'id,account,security,value,quantity,asOf,created',
+								requestKey: null
+							})
+					: [],
+				assetFilter
+					? pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
+							sort: 'asOf,created,id',
+							filter: assetFilter,
+							fields: 'id,asset,marketValue,asOf,created',
+							requestKey: null
+						})
+					: []
 			]);
 
-			const includedAccounts = new Map(
-				(accountsCtx?.accounts ?? [])
-					.filter((a) => !a.participantExcluded)
-					.map((a) => [a.id, a] as const)
-			);
-			const includedAssets = new Map(
-				(assetsCtx?.assets ?? [])
-					.filter((a) => !a.participantExcluded)
-					.map((a) => [a.id, a] as const)
-			);
+			const securityBalancesRange = securityBalancesRangeRaw
+				.map(projectSecurityBalance)
+				.filter(isDefined);
+			const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] = start
+				? await Promise.all([
+						previousAccountBalances(accountIds, start),
+						previousSecurityBalances(accountIds, start),
+						previousAssetBalances(assetIds, start)
+					])
+				: [[], [], []];
 
-			const accountBalances = accountBalancesAll
-				.filter((b) => includedAccounts.has(b.account))
-				.map((balance) => {
-					const account = includedAccounts.get(balance.account)!;
-					return {
-						...balance,
-						value:
-							account.closed && new Date(balance.asOf) >= new Date(account.closed)
-								? 0
-								: projectSignedValue(balance.value, account.perspective)
-					};
-				});
-			const securityBalances = securityBalancesAll
-				.filter((b) => includedAccounts.has(b.account))
-				.map((balance) => {
-					const account = includedAccounts.get(balance.account)!;
-					const value = toNumber(balance.value);
-					return {
-						...balance,
-						value:
-							account.closed && new Date(balance.asOf) >= new Date(account.closed)
-								? 0
-								: value === null
-									? null
-									: projectSignedValue(value, account.perspective),
-						quantity:
-							account.closed && new Date(balance.asOf) >= new Date(account.closed)
-								? 0
-								: balance.quantity
-					};
-				});
-			const assetBalances = assetBalancesAll
-				.filter((b) => includedAssets.has(b.asset))
-				.map((balance) => {
-					const asset = includedAssets.get(balance.asset)!;
-					return {
-						...balance,
-						marketValue:
-							asset.sold && new Date(balance.asOf) >= new Date(asset.sold)
-								? 0
-								: projectSignedValue(balance.marketValue, asset.perspective)
-					};
-				});
+			if (sequence !== refreshSequence) return;
+
+			const accountBalances = trimAccountBalances(
+				[...accountBalancesPrevious, ...accountBalancesRange]
+					.map((balance) => (balance ? projectAccountBalance(balance) : null))
+					.filter(isDefined),
+				start
+			);
+			const securityBalances = trimSecurityBalances(
+				[
+					...securityBalancesPrevious
+						.map((balance) => (balance ? projectSecurityBalance(balance) : null))
+						.filter(isDefined),
+					...securityBalancesRange
+				],
+				start
+			);
+			const assetBalances = trimAssetBalances(
+				[...assetBalancesPrevious, ...assetBalancesRange]
+					.map((balance) => (balance ? projectAssetBalance(balance) : null))
+					.filter(isDefined),
+				start
+			);
 
 			rawAccounts = Array.from(includedAccounts.values());
 			rawAssets = Array.from(includedAssets.values());
 			rawAccountBalances = accountBalances;
 			rawSecurityBalances = securityBalances;
 			rawAssetBalances = assetBalances;
+			historyStart = start;
 		} catch (error) {
 			pb.handleConnectionError(error, 'trends', 'refresh_balances');
 		}
@@ -128,6 +377,131 @@
 	let refreshInFlight = false;
 	let pendingRefresh = false;
 	let bootstrapped = false;
+	let lastIncludedSignature = '';
+
+	function removeAccountBalance(id: string) {
+		rawAccountBalances = rawAccountBalances.filter((balance) => balance.id !== id);
+	}
+
+	function removeSecurityBalance(id: string) {
+		rawSecurityBalances = rawSecurityBalances.filter((balance) => balance.id !== id);
+	}
+
+	function removeAssetBalance(id: string) {
+		rawAssetBalances = rawAssetBalances.filter((balance) => balance.id !== id);
+	}
+
+	function handleAccountBalanceEvent(event: RecordSubscription<AccountBalancesResponse>) {
+		if (!event.action) return;
+		if (!bootstrapped) {
+			pendingRefresh = true;
+			return;
+		}
+		const existing = rawAccountBalances.find((balance) => balance.id === event.record.id);
+		if (event.action === 'delete') {
+			if (!existing) return;
+			removeAccountBalance(event.record.id);
+			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			return;
+		}
+		const balance = projectAccountBalance(event.record);
+		if (!balance) {
+			if (existing) {
+				removeAccountBalance(event.record.id);
+				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			}
+			return;
+		}
+		if (
+			historyStart &&
+			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+		) {
+			scheduleRefresh();
+			return;
+		}
+		rawAccountBalances = trimAccountBalances(
+			[...rawAccountBalances.filter((record) => record.id !== balance.id), balance],
+			historyStart
+		);
+		if (existing && existing.account !== balance.account) scheduleRefresh();
+	}
+
+	function handleSecurityBalanceEvent(
+		event: RecordSubscription<SecurityBalancesResponse<number, number, number, number>>
+	) {
+		if (!event.action) return;
+		if (!bootstrapped) {
+			pendingRefresh = true;
+			return;
+		}
+		const existing = rawSecurityBalances.find((balance) => balance.id === event.record.id);
+		if (event.action === 'delete') {
+			if (!existing) return;
+			removeSecurityBalance(event.record.id);
+			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			return;
+		}
+		const balance = projectSecurityBalance(event.record);
+		if (!balance) {
+			if (existing) {
+				removeSecurityBalance(event.record.id);
+				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			}
+			return;
+		}
+		if (
+			historyStart &&
+			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+		) {
+			scheduleRefresh();
+			return;
+		}
+		rawSecurityBalances = trimSecurityBalances(
+			[...rawSecurityBalances.filter((record) => record.id !== balance.id), balance],
+			historyStart
+		);
+		if (
+			existing &&
+			(existing.account !== balance.account || existing.security !== balance.security)
+		) {
+			scheduleRefresh();
+		}
+	}
+
+	function handleAssetBalanceEvent(event: RecordSubscription<AssetBalancesResponse>) {
+		if (!event.action) return;
+		if (!bootstrapped) {
+			pendingRefresh = true;
+			return;
+		}
+		const existing = rawAssetBalances.find((balance) => balance.id === event.record.id);
+		if (event.action === 'delete') {
+			if (!existing) return;
+			removeAssetBalance(event.record.id);
+			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			return;
+		}
+		const balance = projectAssetBalance(event.record);
+		if (!balance) {
+			if (existing) {
+				removeAssetBalance(event.record.id);
+				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			}
+			return;
+		}
+		if (
+			historyStart &&
+			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+		) {
+			scheduleRefresh();
+			return;
+		}
+		rawAssetBalances = trimAssetBalances(
+			[...rawAssetBalances.filter((record) => record.id !== balance.id), balance],
+			historyStart
+		);
+		if (existing && existing.asset !== balance.asset) scheduleRefresh();
+	}
 
 	async function doRefresh() {
 		refreshInFlight = true;
@@ -153,18 +527,63 @@
 	}
 
 	$effect(() => {
-		void refreshBalances().then(() => {
+		let disposed = false;
+		const unsubscribes: Array<() => void> = [];
+		function addSubscription(subscription: Promise<() => void>) {
+			subscription
+				.then((unsubscribe) => {
+					if (disposed) {
+						unsubscribe();
+						return;
+					}
+					unsubscribes.push(unsubscribe);
+				})
+				.catch((error) => pb.handleSubscriptionError(error, 'trends', 'subscribe_balances'));
+		}
+
+		addSubscription(
+			pb.authedClient
+				.collection('accountBalances')
+				.subscribe<AccountBalancesResponse>('*', handleAccountBalanceEvent)
+		);
+		addSubscription(
+			pb.authedClient
+				.collection('securityBalances')
+				.subscribe<SecurityBalancesResponse<number, number, number, number>>(
+					'*',
+					handleSecurityBalanceEvent
+				)
+		);
+		addSubscription(
+			pb.authedClient
+				.collection('assetBalances')
+				.subscribe<AssetBalancesResponse>('*', handleAssetBalanceEvent)
+		);
+
+		return () => {
+			disposed = true;
+			if (refreshTimer) clearTimeout(refreshTimer);
+			for (const unsubscribe of unsubscribes) unsubscribe();
+		};
+	});
+
+	$effect(() => {
+		void doRefresh().then(() => {
 			bootstrapped = true;
 		});
 	});
 
 	$effect(() => {
-		if (accountsCtx?.lastBalanceEvent) scheduleRefresh();
+		const signature = includedSignature;
+		if (!bootstrapped) {
+			lastIncludedSignature = signature;
+			return;
+		}
+		if (signature === lastIncludedSignature) return;
+		lastIncludedSignature = signature;
+		scheduleRefresh();
 	});
 
-	$effect(() => {
-		if (assetsCtx?.lastBalanceEvent) scheduleRefresh();
-	});
 </script>
 
 <header class="bg-background flex h-16 shrink-0 items-center gap-2 border-b">
@@ -199,6 +618,7 @@
 
 			<ChartNetWorth
 				bind:period
+				{prepared}
 				{rawAccounts}
 				{rawAssets}
 				{rawAccountBalances}
@@ -211,6 +631,8 @@
 	<Section>
 		<SectionTitle title={m.trends_performance_section_title()} />
 		<Performance
+			{prepared}
+			{historyStart}
 			{rawAccounts}
 			{rawAssets}
 			{rawAccountBalances}

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -42,6 +42,9 @@
 	let rawAccountBalances: AccountBalancesResponse[] = $state([]);
 	let rawSecurityBalances: TrendSecurityBalance[] = $state([]);
 	let rawAssetBalances: AssetBalancesResponse[] = $state([]);
+	let rawFullHistoryAccountBalances: AccountBalancesResponse[] = $state([]);
+	let rawFullHistorySecurityBalances: TrendSecurityBalance[] = $state([]);
+	let rawFullHistoryAssetBalances: AssetBalancesResponse[] = $state([]);
 	let historyStart: Date | null = $state(null);
 
 	const includedAccounts = $derived.by(
@@ -87,6 +90,15 @@
 			rawAssetBalances
 		)
 	);
+	const fullHistoryPrepared = $derived.by(() =>
+		buildPreparedMaps(
+			rawAccounts,
+			rawAssets,
+			rawFullHistoryAccountBalances,
+			rawFullHistorySecurityBalances,
+			rawFullHistoryAssetBalances
+		)
+	);
 
 	function isDefined<T>(value: T | null | undefined): value is T {
 		return value !== null && value !== undefined;
@@ -100,11 +112,25 @@
 		return ids.map((id) => `${field}='${quoteFilterValue(id)}'`).join(' || ');
 	}
 
-	function historyFilter(field: string, ids: string[], start: Date | null) {
-		const idsFilter = filterByIds(field, ids);
+	function historyFilter(idsFilter: string, start: Date | null) {
 		if (!idsFilter) return '';
 		return start ? `(${idsFilter}) && asOf>='${start.toISOString()}'` : idsFilter;
 	}
+
+	type TrendBalanceRecord = { asOf: string; created: string; id: string };
+
+	type BalanceRealtimeConfig<
+		TRecord extends TrendBalanceRecord,
+		TBalance extends TrendBalanceRecord
+	> = {
+		records: () => TBalance[];
+		fullHistoryRecords: () => TBalance[];
+		setRecords: (records: TBalance[]) => void;
+		setFullHistoryRecords: (records: TBalance[]) => void;
+		project: (record: TRecord) => TBalance | null;
+		carryKey: (record: TBalance) => string;
+		identityChanged: (existing: TBalance, balance: TBalance) => boolean;
+	};
 
 	function compareBalances<T extends { asOf: string; created: string; id: string }>(a: T, b: T) {
 		if (a.asOf !== b.asOf) return a.asOf.localeCompare(b.asOf);
@@ -121,54 +147,24 @@
 		return periodStart < performanceStart ? periodStart : performanceStart;
 	}
 
-	function trimAccountBalances(records: AccountBalancesResponse[], start: Date | null) {
+	function trimBalances<T extends TrendBalanceRecord>(
+		records: T[],
+		start: Date | null,
+		carryKey: (record: T) => string
+	) {
 		if (!start) return records.toSorted(compareBalances);
-		const previousByAccount = new SvelteMap<string, AccountBalancesResponse>();
-		const inRange: AccountBalancesResponse[] = [];
+		const previousByKey = new SvelteMap<string, T>();
+		const inRange: T[] = [];
 		for (const record of records) {
 			if (new Date(record.asOf) >= start) {
 				inRange.push(record);
 				continue;
 			}
-			const previous = previousByAccount.get(record.account);
-			if (!previous || compareBalances(previous, record) < 0)
-				previousByAccount.set(record.account, record);
+			const key = carryKey(record);
+			const previous = previousByKey.get(key);
+			if (!previous || compareBalances(previous, record) < 0) previousByKey.set(key, record);
 		}
-		return [...previousByAccount.values(), ...inRange].toSorted(compareBalances);
-	}
-
-	function trimSecurityBalances(records: TrendSecurityBalance[], start: Date | null) {
-		if (!start) return records.toSorted(compareBalances);
-		const previousByAccountSecurity = new SvelteMap<string, TrendSecurityBalance>();
-		const inRange: TrendSecurityBalance[] = [];
-		for (const record of records) {
-			if (new Date(record.asOf) >= start) {
-				inRange.push(record);
-				continue;
-			}
-			const key = `${record.account}:${record.security}`;
-			const previous = previousByAccountSecurity.get(key);
-			if (!previous || compareBalances(previous, record) < 0) {
-				previousByAccountSecurity.set(key, record);
-			}
-		}
-		return [...previousByAccountSecurity.values(), ...inRange].toSorted(compareBalances);
-	}
-
-	function trimAssetBalances(records: AssetBalancesResponse[], start: Date | null) {
-		if (!start) return records.toSorted(compareBalances);
-		const previousByAsset = new SvelteMap<string, AssetBalancesResponse>();
-		const inRange: AssetBalancesResponse[] = [];
-		for (const record of records) {
-			if (new Date(record.asOf) >= start) {
-				inRange.push(record);
-				continue;
-			}
-			const previous = previousByAsset.get(record.asset);
-			if (!previous || compareBalances(previous, record) < 0)
-				previousByAsset.set(record.asset, record);
-		}
-		return [...previousByAsset.values(), ...inRange].toSorted(compareBalances);
+		return [...previousByKey.values(), ...inRange].toSorted(compareBalances);
 	}
 
 	function projectAccountBalance(balance: AccountBalancesResponse) {
@@ -234,8 +230,7 @@
 		);
 	}
 
-	async function previousSecurityBalances(accountIds: string[], start: Date) {
-		const accountFilter = filterByIds('account', accountIds);
+	async function previousSecurityBalances(accountFilter: string, start: Date) {
 		if (!accountFilter) return [];
 		const balances = await pb.authedClient
 			.collection('securityBalances')
@@ -292,6 +287,38 @@
 		);
 	}
 
+	async function listAccountBalances(filter: string) {
+		if (!filter) return [];
+		return pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
+			sort: 'asOf,created,id',
+			filter,
+			fields: 'id,account,value,asOf,created',
+			requestKey: null
+		});
+	}
+
+	async function listSecurityBalances(filter: string) {
+		if (!filter) return [];
+		return pb.authedClient
+			.collection('securityBalances')
+			.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+				sort: 'asOf,created,id',
+				filter,
+				fields: 'id,account,security,value,quantity,asOf,created',
+				requestKey: null
+			});
+	}
+
+	async function listAssetBalances(filter: string) {
+		if (!filter) return [];
+		return pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
+			sort: 'asOf,created,id',
+			filter,
+			fields: 'id,asset,marketValue,asOf,created',
+			requestKey: null
+		});
+	}
+
 	let refreshSequence = 0;
 
 	async function refreshBalances() {
@@ -299,80 +326,96 @@
 		const start = computeHistoryStart();
 		const accountIds = Array.from(includedAccounts.keys());
 		const assetIds = Array.from(includedAssets.keys());
-		const accountFilter = historyFilter('account', accountIds, start);
-		const securityFilter = historyFilter('account', accountIds, start);
-		const assetFilter = historyFilter('asset', assetIds, start);
+		const accountFilter = filterByIds('account', accountIds);
+		const assetFilter = filterByIds('asset', assetIds);
+		const accountHistoryFilter = historyFilter(accountFilter, start);
+		const assetHistoryFilter = historyFilter(assetFilter, start);
 		try {
-			const [accountBalancesRange, securityBalancesRangeRaw, assetBalancesRange] =
-				await Promise.all([
-					accountFilter
-						? pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
-								sort: 'asOf,created,id',
-								filter: accountFilter,
-								fields: 'id,account,value,asOf,created',
-								requestKey: null
-							})
-						: [],
-					securityFilter
-						? pb.authedClient
-								.collection('securityBalances')
-								.getFullList<SecurityBalancesResponse<number, number, number, number>>({
-									sort: 'asOf,created,id',
-									filter: securityFilter,
-									fields: 'id,account,security,value,quantity,asOf,created',
-									requestKey: null
-								})
-						: [],
-					assetFilter
-						? pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
-								sort: 'asOf,created,id',
-								filter: assetFilter,
-								fields: 'id,asset,marketValue,asOf,created',
-								requestKey: null
-							})
-						: []
-				]);
+			const [
+				accountBalancesRange,
+				securityBalancesRangeRaw,
+				assetBalancesRange,
+				fullHistoryRanges
+			] = await Promise.all([
+				listAccountBalances(accountHistoryFilter),
+				listSecurityBalances(accountHistoryFilter),
+				listAssetBalances(assetHistoryFilter),
+				start
+					? Promise.all([
+							listAccountBalances(accountFilter),
+							listSecurityBalances(accountFilter),
+							listAssetBalances(assetFilter)
+						])
+					: Promise.resolve(null)
+			]);
+			let accountBalancesFullHistory = accountBalancesRange;
+			let securityBalancesFullHistoryRaw = securityBalancesRangeRaw;
+			let assetBalancesFullHistory = assetBalancesRange;
+			if (fullHistoryRanges) {
+				[accountBalancesFullHistory, securityBalancesFullHistoryRaw, assetBalancesFullHistory] =
+					fullHistoryRanges;
+			}
 
 			const securityBalancesRange = securityBalancesRangeRaw
+				.map(projectSecurityBalance)
+				.filter(isDefined);
+			const securityBalancesFullHistory = securityBalancesFullHistoryRaw
 				.map(projectSecurityBalance)
 				.filter(isDefined);
 			const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] = start
 				? await Promise.all([
 						previousAccountBalances(accountIds, start),
-						previousSecurityBalances(accountIds, start),
+						previousSecurityBalances(accountFilter, start),
 						previousAssetBalances(assetIds, start)
 					])
 				: [[], [], []];
 
 			if (sequence !== refreshSequence) return;
 
-			const accountBalances = trimAccountBalances(
+			const accountBalances = trimBalances(
 				[...accountBalancesPrevious, ...accountBalancesRange]
 					.map((balance) => (balance ? projectAccountBalance(balance) : null))
 					.filter(isDefined),
-				start
+				start,
+				(balance) => balance.account
 			);
-			const securityBalances = trimSecurityBalances(
+			const securityBalances = trimBalances(
 				[
 					...securityBalancesPrevious
 						.map((balance) => (balance ? projectSecurityBalance(balance) : null))
 						.filter(isDefined),
 					...securityBalancesRange
 				],
-				start
+				start,
+				(balance) => `${balance.account}:${balance.security}`
 			);
-			const assetBalances = trimAssetBalances(
+			const assetBalances = trimBalances(
 				[...assetBalancesPrevious, ...assetBalancesRange]
 					.map((balance) => (balance ? projectAssetBalance(balance) : null))
 					.filter(isDefined),
-				start
+				start,
+				(balance) => balance.asset
 			);
-
 			rawAccounts = Array.from(includedAccounts.values());
 			rawAssets = Array.from(includedAssets.values());
 			rawAccountBalances = accountBalances;
 			rawSecurityBalances = securityBalances;
 			rawAssetBalances = assetBalances;
+			rawFullHistoryAccountBalances = trimBalances(
+				accountBalancesFullHistory.map(projectAccountBalance).filter(isDefined),
+				null,
+				(balance) => balance.account
+			);
+			rawFullHistorySecurityBalances = trimBalances(
+				securityBalancesFullHistory,
+				null,
+				(balance) => `${balance.account}:${balance.security}`
+			);
+			rawFullHistoryAssetBalances = trimBalances(
+				assetBalancesFullHistory.map(projectAssetBalance).filter(isDefined),
+				null,
+				(balance) => balance.asset
+			);
 			historyStart = start;
 		} catch (error) {
 			pb.handleConnectionError(error, 'trends', 'refresh_balances');
@@ -385,39 +428,53 @@
 	let bootstrapped = false;
 	let lastIncludedSignature = '';
 
-	function removeAccountBalance(id: string) {
-		rawAccountBalances = rawAccountBalances.filter((balance) => balance.id !== id);
-	}
-
-	function removeSecurityBalance(id: string) {
-		rawSecurityBalances = rawSecurityBalances.filter((balance) => balance.id !== id);
-	}
-
-	function removeAssetBalance(id: string) {
-		rawAssetBalances = rawAssetBalances.filter((balance) => balance.id !== id);
-	}
-
-	function handleAccountBalanceEvent(event: RecordSubscription<AccountBalancesResponse>) {
+	function handleBalanceEvent<
+		TRecord extends TrendBalanceRecord,
+		TBalance extends TrendBalanceRecord
+	>(event: RecordSubscription<TRecord>, config: BalanceRealtimeConfig<TRecord, TBalance>) {
 		if (!event.action) return;
 		if (!bootstrapped) {
 			pendingRefresh = true;
 			return;
 		}
-		const existing = rawAccountBalances.find((balance) => balance.id === event.record.id);
+		const records = config.records();
+		const fullHistoryRecords = config.fullHistoryRecords();
+		const existing = records.find((balance) => balance.id === event.record.id);
+		const fullHistoryExisting = fullHistoryRecords.find(
+			(balance) => balance.id === event.record.id
+		);
 		if (event.action === 'delete') {
-			if (!existing) return;
-			removeAccountBalance(event.record.id);
-			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			return;
-		}
-		const balance = projectAccountBalance(event.record);
-		if (!balance) {
 			if (existing) {
-				removeAccountBalance(event.record.id);
+				config.setRecords(records.filter((balance) => balance.id !== event.record.id));
 				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			}
+			if (fullHistoryExisting) {
+				config.setFullHistoryRecords(
+					fullHistoryRecords.filter((balance) => balance.id !== event.record.id)
+				);
 			}
 			return;
 		}
+		const balance = config.project(event.record);
+		if (!balance) {
+			if (existing) {
+				config.setRecords(records.filter((record) => record.id !== event.record.id));
+				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
+			}
+			if (fullHistoryExisting) {
+				config.setFullHistoryRecords(
+					fullHistoryRecords.filter((record) => record.id !== event.record.id)
+				);
+			}
+			return;
+		}
+		config.setFullHistoryRecords(
+			trimBalances(
+				[...fullHistoryRecords.filter((record) => record.id !== balance.id), balance],
+				null,
+				config.carryKey
+			)
+		);
 		if (
 			historyStart &&
 			((existing && new Date(existing.asOf) < historyStart) ||
@@ -426,90 +483,14 @@
 			scheduleRefresh();
 			return;
 		}
-		rawAccountBalances = trimAccountBalances(
-			[...rawAccountBalances.filter((record) => record.id !== balance.id), balance],
-			historyStart
+		config.setRecords(
+			trimBalances(
+				[...records.filter((record) => record.id !== balance.id), balance],
+				historyStart,
+				config.carryKey
+			)
 		);
-		if (existing && existing.account !== balance.account) scheduleRefresh();
-	}
-
-	function handleSecurityBalanceEvent(
-		event: RecordSubscription<SecurityBalancesResponse<number, number, number, number>>
-	) {
-		if (!event.action) return;
-		if (!bootstrapped) {
-			pendingRefresh = true;
-			return;
-		}
-		const existing = rawSecurityBalances.find((balance) => balance.id === event.record.id);
-		if (event.action === 'delete') {
-			if (!existing) return;
-			removeSecurityBalance(event.record.id);
-			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			return;
-		}
-		const balance = projectSecurityBalance(event.record);
-		if (!balance) {
-			if (existing) {
-				removeSecurityBalance(event.record.id);
-				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			}
-			return;
-		}
-		if (
-			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) ||
-				new Date(balance.asOf) < historyStart)
-		) {
-			scheduleRefresh();
-			return;
-		}
-		rawSecurityBalances = trimSecurityBalances(
-			[...rawSecurityBalances.filter((record) => record.id !== balance.id), balance],
-			historyStart
-		);
-		if (
-			existing &&
-			(existing.account !== balance.account || existing.security !== balance.security)
-		) {
-			scheduleRefresh();
-		}
-	}
-
-	function handleAssetBalanceEvent(event: RecordSubscription<AssetBalancesResponse>) {
-		if (!event.action) return;
-		if (!bootstrapped) {
-			pendingRefresh = true;
-			return;
-		}
-		const existing = rawAssetBalances.find((balance) => balance.id === event.record.id);
-		if (event.action === 'delete') {
-			if (!existing) return;
-			removeAssetBalance(event.record.id);
-			if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			return;
-		}
-		const balance = projectAssetBalance(event.record);
-		if (!balance) {
-			if (existing) {
-				removeAssetBalance(event.record.id);
-				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			}
-			return;
-		}
-		if (
-			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) ||
-				new Date(balance.asOf) < historyStart)
-		) {
-			scheduleRefresh();
-			return;
-		}
-		rawAssetBalances = trimAssetBalances(
-			[...rawAssetBalances.filter((record) => record.id !== balance.id), balance],
-			historyStart
-		);
-		if (existing && existing.asset !== balance.asset) scheduleRefresh();
+		if (existing && config.identityChanged(existing, balance)) scheduleRefresh();
 	}
 
 	async function doRefresh() {
@@ -553,19 +534,46 @@
 		addSubscription(
 			pb.authedClient
 				.collection('accountBalances')
-				.subscribe<AccountBalancesResponse>('*', handleAccountBalanceEvent)
+				.subscribe<AccountBalancesResponse>('*', (event) =>
+					handleBalanceEvent(event, {
+						records: () => rawAccountBalances,
+						fullHistoryRecords: () => rawFullHistoryAccountBalances,
+						setRecords: (records) => (rawAccountBalances = records),
+						setFullHistoryRecords: (records) => (rawFullHistoryAccountBalances = records),
+						project: projectAccountBalance,
+						carryKey: (balance) => balance.account,
+						identityChanged: (existing, balance) => existing.account !== balance.account
+					})
+				)
 		);
 		addSubscription(
 			pb.authedClient
 				.collection('securityBalances')
-				.subscribe<
-					SecurityBalancesResponse<number, number, number, number>
-				>('*', handleSecurityBalanceEvent)
+				.subscribe<SecurityBalancesResponse<number, number, number, number>>('*', (event) =>
+					handleBalanceEvent(event, {
+						records: () => rawSecurityBalances,
+						fullHistoryRecords: () => rawFullHistorySecurityBalances,
+						setRecords: (records) => (rawSecurityBalances = records),
+						setFullHistoryRecords: (records) => (rawFullHistorySecurityBalances = records),
+						project: projectSecurityBalance,
+						carryKey: (balance) => `${balance.account}:${balance.security}`,
+						identityChanged: (existing, balance) =>
+							existing.account !== balance.account || existing.security !== balance.security
+					})
+				)
 		);
 		addSubscription(
-			pb.authedClient
-				.collection('assetBalances')
-				.subscribe<AssetBalancesResponse>('*', handleAssetBalanceEvent)
+			pb.authedClient.collection('assetBalances').subscribe<AssetBalancesResponse>('*', (event) =>
+				handleBalanceEvent(event, {
+					records: () => rawAssetBalances,
+					fullHistoryRecords: () => rawFullHistoryAssetBalances,
+					setRecords: (records) => (rawAssetBalances = records),
+					setFullHistoryRecords: (records) => (rawFullHistoryAssetBalances = records),
+					project: projectAssetBalance,
+					carryKey: (balance) => balance.asset,
+					identityChanged: (existing, balance) => existing.asset !== balance.asset
+				})
+			)
 		);
 
 		return () => {
@@ -639,12 +647,12 @@
 		<SectionTitle title={m.trends_performance_section_title()} />
 		<Performance
 			{prepared}
-			{historyStart}
+			{fullHistoryPrepared}
 			{rawAccounts}
 			{rawAssets}
-			{rawAccountBalances}
-			{rawSecurityBalances}
-			{rawAssetBalances}
+			{rawFullHistoryAccountBalances}
+			{rawFullHistorySecurityBalances}
+			{rawFullHistoryAssetBalances}
 		/>
 	</Section>
 </Page>

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -112,9 +112,9 @@
 		return ids.map((id) => `${field}='${quoteFilterValue(id)}'`).join(' || ');
 	}
 
-	function historyFilter(idsFilter: string, start: Date | null) {
+	function historyFilter(idsFilter: string, start: Date) {
 		if (!idsFilter) return '';
-		return start ? `(${idsFilter}) && asOf>='${start.toISOString()}'` : idsFilter;
+		return `(${idsFilter}) && asOf>='${start.toISOString()}'`;
 	}
 
 	type TrendBalanceRecord = { asOf: string; created: string; id: string };
@@ -136,15 +136,6 @@
 		if (a.asOf !== b.asOf) return a.asOf.localeCompare(b.asOf);
 		if (a.created !== b.created) return a.created.localeCompare(b.created);
 		return a.id.localeCompare(b.id);
-	}
-
-	function computeHistoryStart() {
-		if (period === 'max') return null;
-		const periodStart = computeBoundedHistoryStart(period);
-		const performanceStart = computeBoundedHistoryStart('5y');
-		if (!periodStart) return performanceStart;
-		if (!performanceStart) return periodStart;
-		return periodStart < performanceStart ? periodStart : performanceStart;
 	}
 
 	function trimBalances<T extends TrendBalanceRecord>(
@@ -323,7 +314,8 @@
 
 	async function refreshBalances() {
 		const sequence = ++refreshSequence;
-		const start = computeHistoryStart();
+		const start = computeBoundedHistoryStart('5y');
+		if (!start) return;
 		const accountIds = Array.from(includedAccounts.keys());
 		const assetIds = Array.from(includedAssets.keys());
 		const accountFilter = filterByIds('account', accountIds);
@@ -335,26 +327,17 @@
 				accountBalancesRange,
 				securityBalancesRangeRaw,
 				assetBalancesRange,
-				fullHistoryRanges
+				accountBalancesFullHistory,
+				securityBalancesFullHistoryRaw,
+				assetBalancesFullHistory
 			] = await Promise.all([
 				listAccountBalances(accountHistoryFilter),
 				listSecurityBalances(accountHistoryFilter),
 				listAssetBalances(assetHistoryFilter),
-				start
-					? Promise.all([
-							listAccountBalances(accountFilter),
-							listSecurityBalances(accountFilter),
-							listAssetBalances(assetFilter)
-						])
-					: Promise.resolve(null)
+				listAccountBalances(accountFilter),
+				listSecurityBalances(accountFilter),
+				listAssetBalances(assetFilter)
 			]);
-			let accountBalancesFullHistory = accountBalancesRange;
-			let securityBalancesFullHistoryRaw = securityBalancesRangeRaw;
-			let assetBalancesFullHistory = assetBalancesRange;
-			if (fullHistoryRanges) {
-				[accountBalancesFullHistory, securityBalancesFullHistoryRaw, assetBalancesFullHistory] =
-					fullHistoryRanges;
-			}
 
 			const securityBalancesRange = securityBalancesRangeRaw
 				.map(projectSecurityBalance)
@@ -362,13 +345,12 @@
 			const securityBalancesFullHistory = securityBalancesFullHistoryRaw
 				.map(projectSecurityBalance)
 				.filter(isDefined);
-			const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] = start
-				? await Promise.all([
-						previousAccountBalances(accountIds, start),
-						previousSecurityBalances(accountFilter, start),
-						previousAssetBalances(assetIds, start)
-					])
-				: [[], [], []];
+			const [accountBalancesPrevious, securityBalancesPrevious, assetBalancesPrevious] =
+				await Promise.all([
+					previousAccountBalances(accountIds, start),
+					previousSecurityBalances(accountFilter, start),
+					previousAssetBalances(assetIds, start)
+				]);
 
 			if (sequence !== refreshSequence) return;
 
@@ -633,12 +615,14 @@
 
 			<ChartNetWorth
 				bind:period
-				{prepared}
+				prepared={period === 'max' ? fullHistoryPrepared : prepared}
 				{rawAccounts}
 				{rawAssets}
-				{rawAccountBalances}
-				{rawSecurityBalances}
-				{rawAssetBalances}
+				rawAccountBalances={period === 'max' ? rawFullHistoryAccountBalances : rawAccountBalances}
+				rawSecurityBalances={period === 'max'
+					? rawFullHistorySecurityBalances
+					: rawSecurityBalances}
+				rawAssetBalances={period === 'max' ? rawFullHistoryAssetBalances : rawAssetBalances}
 			/>
 		</Section>
 	</Tabs.Root>

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { RecordSubscription } from 'pocketbase';
+	import { untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	import { getAccountsContext } from '$lib/accounts.svelte';
@@ -566,8 +567,10 @@
 	});
 
 	$effect(() => {
-		void doRefresh().then(() => {
-			bootstrapped = true;
+		untrack(() => {
+			void doRefresh().then(() => {
+				bootstrapped = true;
+			});
 		});
 	});
 

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { RecordSubscription } from 'pocketbase';
+	import { SvelteMap } from 'svelte/reactivity';
 
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAssetsContext } from '$lib/assets.svelte';
@@ -43,19 +44,21 @@
 	let rawAssetBalances: AssetBalancesResponse[] = $state([]);
 	let historyStart: Date | null = $state(null);
 
-	const includedAccounts = $derived.by(() =>
-		new Map(
-			(accountsCtx?.accounts ?? [])
-				.filter((account) => !account.participantExcluded)
-				.map((account) => [account.id, account] as const)
-		)
+	const includedAccounts = $derived.by(
+		() =>
+			new Map(
+				(accountsCtx?.accounts ?? [])
+					.filter((account) => !account.participantExcluded)
+					.map((account) => [account.id, account] as const)
+			)
 	);
-	const includedAssets = $derived.by(() =>
-		new Map(
-			(assetsCtx?.assets ?? [])
-				.filter((asset) => !asset.participantExcluded)
-				.map((asset) => [asset.id, asset] as const)
-		)
+	const includedAssets = $derived.by(
+		() =>
+			new Map(
+				(assetsCtx?.assets ?? [])
+					.filter((asset) => !asset.participantExcluded)
+					.map((asset) => [asset.id, asset] as const)
+			)
 	);
 	const includedSignature = $derived.by(() =>
 		JSON.stringify({
@@ -120,7 +123,7 @@
 
 	function trimAccountBalances(records: AccountBalancesResponse[], start: Date | null) {
 		if (!start) return records.toSorted(compareBalances);
-		const previousByAccount = new Map<string, AccountBalancesResponse>();
+		const previousByAccount = new SvelteMap<string, AccountBalancesResponse>();
 		const inRange: AccountBalancesResponse[] = [];
 		for (const record of records) {
 			if (new Date(record.asOf) >= start) {
@@ -128,14 +131,15 @@
 				continue;
 			}
 			const previous = previousByAccount.get(record.account);
-			if (!previous || compareBalances(previous, record) < 0) previousByAccount.set(record.account, record);
+			if (!previous || compareBalances(previous, record) < 0)
+				previousByAccount.set(record.account, record);
 		}
 		return [...previousByAccount.values(), ...inRange].toSorted(compareBalances);
 	}
 
 	function trimSecurityBalances(records: TrendSecurityBalance[], start: Date | null) {
 		if (!start) return records.toSorted(compareBalances);
-		const previousByAccountSecurity = new Map<string, TrendSecurityBalance>();
+		const previousByAccountSecurity = new SvelteMap<string, TrendSecurityBalance>();
 		const inRange: TrendSecurityBalance[] = [];
 		for (const record of records) {
 			if (new Date(record.asOf) >= start) {
@@ -153,7 +157,7 @@
 
 	function trimAssetBalances(records: AssetBalancesResponse[], start: Date | null) {
 		if (!start) return records.toSorted(compareBalances);
-		const previousByAsset = new Map<string, AssetBalancesResponse>();
+		const previousByAsset = new SvelteMap<string, AssetBalancesResponse>();
 		const inRange: AssetBalancesResponse[] = [];
 		for (const record of records) {
 			if (new Date(record.asOf) >= start) {
@@ -161,7 +165,8 @@
 				continue;
 			}
 			const previous = previousByAsset.get(record.asset);
-			if (!previous || compareBalances(previous, record) < 0) previousByAsset.set(record.asset, record);
+			if (!previous || compareBalances(previous, record) < 0)
+				previousByAsset.set(record.asset, record);
 		}
 		return [...previousByAsset.values(), ...inRange].toSorted(compareBalances);
 	}
@@ -178,7 +183,9 @@
 		};
 	}
 
-	function projectSecurityBalance(balance: SecurityBalancesResponse<number, number, number, number>) {
+	function projectSecurityBalance(
+		balance: SecurityBalancesResponse<number, number, number, number>
+	) {
 		const account = includedAccounts.get(balance.account);
 		if (!account) return null;
 		const value = toNumber(balance.value);
@@ -195,9 +202,7 @@
 						? null
 						: projectSignedValue(value, account.perspective),
 			quantity:
-				account.closed && new Date(balance.asOf) >= new Date(account.closed)
-					? 0
-					: balance.quantity
+				account.closed && new Date(balance.asOf) >= new Date(account.closed) ? 0 : balance.quantity
 		};
 	}
 
@@ -241,7 +246,7 @@
 				requestKey: null
 			});
 
-		const latestByKey = new Map<
+		const latestByKey = new SvelteMap<
 			string,
 			{
 				balance: SecurityBalancesResponse<number, number, number, number>;
@@ -298,34 +303,35 @@
 		const securityFilter = historyFilter('account', accountIds, start);
 		const assetFilter = historyFilter('asset', assetIds, start);
 		try {
-			const [accountBalancesRange, securityBalancesRangeRaw, assetBalancesRange] = await Promise.all([
-				accountFilter
-					? pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
-							sort: 'asOf,created,id',
-							filter: accountFilter,
-							fields: 'id,account,value,asOf,created',
-							requestKey: null
-						})
-					: [],
-				securityFilter
-					? pb.authedClient
-							.collection('securityBalances')
-							.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+			const [accountBalancesRange, securityBalancesRangeRaw, assetBalancesRange] =
+				await Promise.all([
+					accountFilter
+						? pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
 								sort: 'asOf,created,id',
-								filter: securityFilter,
-								fields: 'id,account,security,value,quantity,asOf,created',
+								filter: accountFilter,
+								fields: 'id,account,value,asOf,created',
 								requestKey: null
 							})
-					: [],
-				assetFilter
-					? pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
-							sort: 'asOf,created,id',
-							filter: assetFilter,
-							fields: 'id,asset,marketValue,asOf,created',
-							requestKey: null
-						})
-					: []
-			]);
+						: [],
+					securityFilter
+						? pb.authedClient
+								.collection('securityBalances')
+								.getFullList<SecurityBalancesResponse<number, number, number, number>>({
+									sort: 'asOf,created,id',
+									filter: securityFilter,
+									fields: 'id,account,security,value,quantity,asOf,created',
+									requestKey: null
+								})
+						: [],
+					assetFilter
+						? pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
+								sort: 'asOf,created,id',
+								filter: assetFilter,
+								fields: 'id,asset,marketValue,asOf,created',
+								requestKey: null
+							})
+						: []
+				]);
 
 			const securityBalancesRange = securityBalancesRangeRaw
 				.map(projectSecurityBalance)
@@ -414,7 +420,8 @@
 		}
 		if (
 			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+			((existing && new Date(existing.asOf) < historyStart) ||
+				new Date(balance.asOf) < historyStart)
 		) {
 			scheduleRefresh();
 			return;
@@ -451,7 +458,8 @@
 		}
 		if (
 			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+			((existing && new Date(existing.asOf) < historyStart) ||
+				new Date(balance.asOf) < historyStart)
 		) {
 			scheduleRefresh();
 			return;
@@ -491,7 +499,8 @@
 		}
 		if (
 			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) || new Date(balance.asOf) < historyStart)
+			((existing && new Date(existing.asOf) < historyStart) ||
+				new Date(balance.asOf) < historyStart)
 		) {
 			scheduleRefresh();
 			return;
@@ -549,10 +558,9 @@
 		addSubscription(
 			pb.authedClient
 				.collection('securityBalances')
-				.subscribe<SecurityBalancesResponse<number, number, number, number>>(
-					'*',
-					handleSecurityBalanceEvent
-				)
+				.subscribe<
+					SecurityBalancesResponse<number, number, number, number>
+				>('*', handleSecurityBalanceEvent)
 		);
 		addSubscription(
 			pb.authedClient
@@ -583,7 +591,6 @@
 		lastIncludedSignature = signature;
 		scheduleRefresh();
 	});
-
 </script>
 
 <header class="bg-background flex h-16 shrink-0 items-center gap-2 border-b">

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -269,5 +269,5 @@
 		</Chart.Container>
 	</div>
 {:else}
-	<Skeleton class="h-96" />
+	<Skeleton class="h-96" showSpinner />
 {/if}

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -17,17 +17,18 @@
 
 	import {
 		advanceTrendSecurityValue,
-		buildPreparedMaps,
 		computeRangeForPeriod,
 		latestIndexBeforeOrEqual,
 		type BalanceGroup,
 		type PeriodKey,
+		type PreparedTrendMaps,
 		type TrendSecurityBalance,
 		type TrendSecurityValueState
 	} from './trends';
 
 	let {
 		period = $bindable(),
+		prepared = $bindable(),
 		rawAccounts = $bindable(),
 		rawAssets = $bindable(),
 		rawAccountBalances = $bindable(),
@@ -35,6 +36,7 @@
 		rawAssetBalances = $bindable()
 	}: {
 		period: PeriodKey;
+		prepared: PreparedTrendMaps;
 		rawAccounts: AccountsResponse[];
 		rawAssets: AssetsResponse[];
 		rawAccountBalances: AccountBalancesResponse[];
@@ -127,13 +129,7 @@
 			assetBalancesByAssetId,
 			accountById,
 			assetById
-		} = buildPreparedMaps(
-			rawAccounts,
-			rawAssets,
-			rawAccountBalances,
-			rawSecurityBalances,
-			rawAssetBalances
-		);
+		} = prepared;
 
 		const accountIndexPointer = new SvelteMap<string, number>();
 		for (const [accountId, balances] of accountBalancesByAccountId)

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -28,12 +28,12 @@
 
 	let {
 		period = $bindable(),
-		prepared = $bindable(),
-		rawAccounts = $bindable(),
-		rawAssets = $bindable(),
-		rawAccountBalances = $bindable(),
-		rawSecurityBalances = $bindable(),
-		rawAssetBalances = $bindable()
+		prepared,
+		rawAccounts,
+		rawAssets,
+		rawAccountBalances,
+		rawSecurityBalances,
+		rawAssetBalances
 	}: {
 		period: PeriodKey;
 		prepared: PreparedTrendMaps;

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -106,7 +106,7 @@
 		return Math.max(48, Math.ceil(maxW) + 16);
 	});
 
-	async function recomputeSeries() {
+	function recomputeSeries() {
 		if (!rawAccounts.length && !rawAssets.length) return;
 		const { start, end } = computeRangeForPeriod(
 			period,
@@ -211,7 +211,7 @@
 		series = rows;
 	}
 
-	$effect(() => void recomputeSeries());
+	$effect(() => recomputeSeries());
 </script>
 
 {#if series.length}

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -557,5 +557,5 @@
 		</div>
 	</div>
 {:else}
-	<Skeleton class="h-64" />
+	<Skeleton class="h-64" showSpinner />
 {/if}

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -16,6 +16,7 @@
 
 	import {
 		advanceTrendSecurityValue,
+		findEarliestBalanceDate,
 		type BalanceGroup,
 		type PreparedTrendMaps,
 		type TrendSecurityBalance,
@@ -23,21 +24,21 @@
 	} from './trends';
 
 	let {
-		prepared = $bindable(),
-		historyStart = $bindable(),
-		rawAccounts = $bindable(),
-		rawAssets = $bindable(),
-		rawAccountBalances = $bindable(),
-		rawSecurityBalances = $bindable(),
-		rawAssetBalances = $bindable()
+		prepared,
+		fullHistoryPrepared,
+		rawAccounts,
+		rawAssets,
+		rawFullHistoryAccountBalances,
+		rawFullHistorySecurityBalances,
+		rawFullHistoryAssetBalances
 	}: {
 		prepared: PreparedTrendMaps;
-		historyStart: Date | null;
+		fullHistoryPrepared: PreparedTrendMaps;
 		rawAccounts: AccountsResponse[];
 		rawAssets: AssetsResponse[];
-		rawAccountBalances: AccountBalancesResponse[];
-		rawSecurityBalances: TrendSecurityBalance[];
-		rawAssetBalances: AssetBalancesResponse[];
+		rawFullHistoryAccountBalances: AccountBalancesResponse[];
+		rawFullHistorySecurityBalances: TrendSecurityBalance[];
+		rawFullHistoryAssetBalances: AssetBalancesResponse[];
 	} = $props();
 
 	type PeriodOffset = {
@@ -67,26 +68,26 @@
 		return d;
 	}
 
-	function percentChange(currentValue: number, previousValue: number): number | null {
+	function percentChange(currentValue: number, previousValue: number) {
 		if (!previousValue || previousValue === 0) return null;
 		return (currentValue - previousValue) / Math.abs(previousValue);
 	}
 
-	function percentChangeDebtMagnitude(currentValue: number, previousValue: number): number | null {
+	function percentChangeDebtMagnitude(currentValue: number, previousValue: number) {
 		if (!previousValue || previousValue === 0) return null;
 		const currentAbs = Math.abs(currentValue);
 		const previousAbs = Math.abs(previousValue);
 		return (currentAbs - previousAbs) / previousAbs;
 	}
 
-	function computeTotals(anchorDates: Date[]) {
+	function computeTotals(maps: PreparedTrendMaps, anchorDates: Date[]) {
 		const {
 			accountBalancesByAccountId,
 			securityBalancesByAccountSecurity,
 			assetBalancesByAssetId,
 			accountById,
 			assetById
-		} = prepared;
+		} = maps;
 		const ascendingDates = [...anchorDates].sort((a, b) => a.getTime() - b.getTime());
 		const indexByTime = new Map(
 			ascendingDates.map((date, index) => [date.getTime(), index] as const)
@@ -182,39 +183,25 @@
 		const END_OF_TIME = new Date('9999-12-31T23:59:59.999Z');
 		const now = END_OF_TIME;
 
-		let earliest: Date | null = null;
-		for (const b of rawAccountBalances) {
-			const d = new Date(b.asOf);
-			if (!earliest || d < earliest) earliest = d;
-		}
-		for (const b of rawSecurityBalances) {
-			const d = new Date(b.asOf);
-			if (!earliest || d < earliest) earliest = d;
-		}
-		for (const b of rawAssetBalances) {
-			const d = new Date(b.asOf);
-			if (!earliest || d < earliest) earliest = d;
-		}
-
-		const visiblePeriods = historyStart
-			? periods.filter((periodDef) => !periodDef.offset.max)
-			: periods;
-		const anchorDates = visiblePeriods.map((periodDef) => {
-			if (periodDef.offset.max) return earliest ? new Date(earliest) : now;
+		const boundedPeriods = periods.filter((periodDef) => !periodDef.offset.max);
+		const anchorDates = boundedPeriods.map((periodDef) => {
 			if (periodDef.offset.ytd) return endOfDay(startOfYear(new UTCDate()));
 			const anchorDate = subtractFromDate(new UTCDate(), periodDef.offset);
 			return endOfDay(anchorDate);
 		});
-		const totals = computeTotals([...anchorDates, now]);
+		const totals = computeTotals(prepared, [...anchorDates, now]);
 		const current = totals[totals.length - 1];
 
 		const allTimes = [
-			...rawAccountBalances.map((balance) => new Date(balance.asOf).getTime()),
-			...rawSecurityBalances.map((balance) => new Date(balance.asOf).getTime()),
-			...rawAssetBalances.map((balance) => new Date(balance.asOf).getTime())
+			...rawFullHistoryAccountBalances.map((balance) => new Date(balance.asOf).getTime()),
+			...rawFullHistorySecurityBalances.map((balance) => new Date(balance.asOf).getTime()),
+			...rawFullHistoryAssetBalances.map((balance) => new Date(balance.asOf).getTime())
 		];
 		const uniqueAscendingTimes = Array.from(new Set(allTimes)).sort((a, b) => a - b);
-		const totalsAll = computeTotals(uniqueAscendingTimes.map((timestamp) => new Date(timestamp)));
+		const totalsAll = computeTotals(
+			fullHistoryPrepared,
+			uniqueAscendingTimes.map((timestamp) => new Date(timestamp))
+		);
 		let baseline = { net: 0, cash: 0, debt: 0, investment: 0, other: 0 };
 		for (const row of totalsAll) {
 			if (baseline.net === 0 && row.net !== 0) baseline.net = row.net;
@@ -232,68 +219,84 @@
 				break;
 		}
 
-		const columns = visiblePeriods.map((periodDef, columnIndex) => {
-			const previousTotals = totals[columnIndex];
+		const fullHistoryCurrent = computeTotals(fullHistoryPrepared, [now])[0];
+		const fullHistoryEarliest = findEarliestBalanceDate(
+			rawFullHistoryAccountBalances,
+			rawFullHistorySecurityBalances,
+			rawFullHistoryAssetBalances
+		);
+		let boundedColumnIndex = 0;
+		const columns = periods.map((periodDef) => {
+			if (periodDef.offset.max) {
+				return {
+					key: periodDef.key,
+					label: periodDef.label,
+					at: fullHistoryEarliest ? new Date(fullHistoryEarliest) : now,
+					values: {
+						net: {
+							pct: percentChange(fullHistoryCurrent.net, baseline.net),
+							cur: fullHistoryCurrent.net,
+							prev: baseline.net
+						},
+						cash: {
+							pct: percentChange(fullHistoryCurrent.cash, baseline.cash),
+							cur: fullHistoryCurrent.cash,
+							prev: baseline.cash
+						},
+						debt: {
+							pct: percentChangeDebtMagnitude(fullHistoryCurrent.debt, baseline.debt),
+							cur: fullHistoryCurrent.debt,
+							prev: baseline.debt
+						},
+						investment: {
+							pct: percentChange(fullHistoryCurrent.investment, baseline.investment),
+							cur: fullHistoryCurrent.investment,
+							prev: baseline.investment
+						},
+						other: {
+							pct: percentChange(fullHistoryCurrent.other, baseline.other),
+							cur: fullHistoryCurrent.other,
+							prev: baseline.other
+						}
+					}
+				};
+			}
+
+			const previousTotals = totals[boundedColumnIndex];
+			const at = anchorDates[boundedColumnIndex];
+			boundedColumnIndex++;
 
 			return {
 				key: periodDef.key,
 				label: periodDef.label,
-				at: anchorDates[columnIndex],
-				values: periodDef.offset.max
-					? {
-							net: {
-								pct: percentChange(current.net, baseline.net),
-								cur: current.net,
-								prev: baseline.net
-							},
-							cash: {
-								pct: percentChange(current.cash, baseline.cash),
-								cur: current.cash,
-								prev: baseline.cash
-							},
-							debt: {
-								pct: percentChangeDebtMagnitude(current.debt, baseline.debt),
-								cur: current.debt,
-								prev: baseline.debt
-							},
-							investment: {
-								pct: percentChange(current.investment, baseline.investment),
-								cur: current.investment,
-								prev: baseline.investment
-							},
-							other: {
-								pct: percentChange(current.other, baseline.other),
-								cur: current.other,
-								prev: baseline.other
-							}
-						}
-					: {
-							net: {
-								pct: percentChange(current.net, previousTotals.net),
-								cur: current.net,
-								prev: previousTotals.net
-							},
-							cash: {
-								pct: percentChange(current.cash, previousTotals.cash),
-								cur: current.cash,
-								prev: previousTotals.cash
-							},
-							debt: {
-								pct: percentChangeDebtMagnitude(current.debt, previousTotals.debt),
-								cur: current.debt,
-								prev: previousTotals.debt
-							},
-							investment: {
-								pct: percentChange(current.investment, previousTotals.investment),
-								cur: current.investment,
-								prev: previousTotals.investment
-							},
-							other: {
-								pct: percentChange(current.other, previousTotals.other),
-								cur: current.other,
-								prev: previousTotals.other
-							}
-						}
+				at,
+				values: {
+					net: {
+						pct: percentChange(current.net, previousTotals.net),
+						cur: current.net,
+						prev: previousTotals.net
+					},
+					cash: {
+						pct: percentChange(current.cash, previousTotals.cash),
+						cur: current.cash,
+						prev: previousTotals.cash
+					},
+					debt: {
+						pct: percentChangeDebtMagnitude(current.debt, previousTotals.debt),
+						cur: current.debt,
+						prev: previousTotals.debt
+					},
+					investment: {
+						pct: percentChange(current.investment, previousTotals.investment),
+						cur: current.investment,
+						prev: previousTotals.investment
+					},
+					other: {
+						pct: percentChange(current.other, previousTotals.other),
+						cur: current.other,
+						prev: previousTotals.other
+					}
+				}
 			};
 		});
 

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -196,7 +196,9 @@
 			if (!earliest || d < earliest) earliest = d;
 		}
 
-		const visiblePeriods = historyStart ? periods.filter((periodDef) => !periodDef.offset.max) : periods;
+		const visiblePeriods = historyStart
+			? periods.filter((periodDef) => !periodDef.offset.max)
+			: periods;
 		const anchorDates = visiblePeriods.map((periodDef) => {
 			if (periodDef.offset.max) return earliest ? new Date(earliest) : now;
 			if (periodDef.offset.ytd) return endOfDay(startOfYear(new UTCDate()));

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -16,19 +16,23 @@
 
 	import {
 		advanceTrendSecurityValue,
-		buildPreparedMaps,
 		type BalanceGroup,
+		type PreparedTrendMaps,
 		type TrendSecurityBalance,
 		type TrendSecurityValueState
 	} from './trends';
 
 	let {
+		prepared = $bindable(),
+		historyStart = $bindable(),
 		rawAccounts = $bindable(),
 		rawAssets = $bindable(),
 		rawAccountBalances = $bindable(),
 		rawSecurityBalances = $bindable(),
 		rawAssetBalances = $bindable()
 	}: {
+		prepared: PreparedTrendMaps;
+		historyStart: Date | null;
 		rawAccounts: AccountsResponse[];
 		rawAssets: AssetsResponse[];
 		rawAccountBalances: AccountBalancesResponse[];
@@ -74,16 +78,6 @@
 		const previousAbs = Math.abs(previousValue);
 		return (currentAbs - previousAbs) / previousAbs;
 	}
-
-	const prepared = $derived.by(() =>
-		buildPreparedMaps(
-			rawAccounts,
-			rawAssets,
-			rawAccountBalances,
-			rawSecurityBalances,
-			rawAssetBalances
-		)
-	);
 
 	function computeTotals(anchorDates: Date[]) {
 		const {
@@ -202,7 +196,8 @@
 			if (!earliest || d < earliest) earliest = d;
 		}
 
-		const anchorDates = periods.map((periodDef) => {
+		const visiblePeriods = historyStart ? periods.filter((periodDef) => !periodDef.offset.max) : periods;
+		const anchorDates = visiblePeriods.map((periodDef) => {
 			if (periodDef.offset.max) return earliest ? new Date(earliest) : now;
 			if (periodDef.offset.ytd) return endOfDay(startOfYear(new UTCDate()));
 			const anchorDate = subtractFromDate(new UTCDate(), periodDef.offset);
@@ -235,7 +230,7 @@
 				break;
 		}
 
-		const columns = periods.map((periodDef, columnIndex) => {
+		const columns = visiblePeriods.map((periodDef, columnIndex) => {
 			const previousTotals = totals[columnIndex];
 
 			return {

--- a/src/routes/(app)/trends/trends.ts
+++ b/src/routes/(app)/trends/trends.ts
@@ -14,7 +14,7 @@ export type PeriodKey = '3m' | '6m' | 'ytd' | '1y' | '2y' | '5y' | 'max';
 export type BalanceGroup = 'CASH' | 'DEBT' | 'INVESTMENT' | 'OTHER';
 export type TrendSecurityBalance = Pick<
 	SecurityBalancesResponse<number, number, number, number>,
-	'id' | 'account' | 'security' | 'value' | 'quantity' | 'asOf'
+	'id' | 'account' | 'security' | 'value' | 'quantity' | 'asOf' | 'created'
 >;
 
 export type TrendSecurityValueState = {
@@ -22,6 +22,17 @@ export type TrendSecurityValueState = {
 	lastKnownValue: number | null;
 	soldOut: boolean;
 };
+
+export function computeBoundedHistoryStart(period: PeriodKey) {
+	const now = startOfDay(new UTCDate());
+	if (period === '3m') return subMonths(now, 3);
+	if (period === '6m') return subMonths(now, 6);
+	if (period === 'ytd') return startOfYear(now);
+	if (period === '1y') return subYears(now, 1);
+	if (period === '2y') return subYears(now, 2);
+	if (period === '5y') return subYears(now, 5);
+	return null;
+}
 
 export function latestIndexBeforeOrEqual<T extends { asOf: string }>(
 	entries: T[],
@@ -62,12 +73,8 @@ export function computeRangeForPeriod(
 	rawAssetBalances: AssetBalancesResponse[]
 ) {
 	const now = startOfDay(new UTCDate());
-	if (period === '3m') return { start: subMonths(now, 3), end: now };
-	if (period === '6m') return { start: subMonths(now, 6), end: now };
-	if (period === 'ytd') return { start: startOfYear(now), end: now };
-	if (period === '1y') return { start: subYears(now, 1), end: now };
-	if (period === '2y') return { start: subYears(now, 2), end: now };
-	if (period === '5y') return { start: subYears(now, 5), end: now };
+	const boundedStart = computeBoundedHistoryStart(period);
+	if (boundedStart) return { start: boundedStart, end: now };
 
 	const earliest = findEarliestBalanceDate(
 		rawAccountBalances,
@@ -98,9 +105,10 @@ export function buildPreparedMaps(
 		existing.push(balance);
 		securityBalancesByAccountSecurity.set(key, existing);
 	}
+	const assetById = new Map(assets.map((a) => [a.id, a] as const));
 	const assetBalancesByAssetId = new Map<string, AssetBalancesResponse[]>();
 	for (const balance of assetBalances) {
-		if (!assets.find((a) => a.id === balance.asset)) continue;
+		if (!assetById.has(balance.asset)) continue;
 		const existing = assetBalancesByAssetId.get(balance.asset) || [];
 		existing.push(balance);
 		assetBalancesByAssetId.set(balance.asset, existing);
@@ -110,9 +118,11 @@ export function buildPreparedMaps(
 		securityBalancesByAccountSecurity,
 		assetBalancesByAssetId,
 		accountById: new Map(accounts.map((a) => [a.id, a] as const)),
-		assetById: new Map(assets.map((a) => [a.id, a] as const))
+		assetById
 	};
 }
+
+export type PreparedTrendMaps = ReturnType<typeof buildPreparedMaps>;
 
 export function advanceTrendSecurityValue(
 	balances: TrendSecurityBalance[],


### PR DESCRIPTION
- Optimizes collection-based realtime flows for cashflow, current balances, trends, transactions, and trades.
- Adds targeted PocketBase indexes for high-volume account, balance, transaction, and trade queries.
- Preserves reactive behavior while reducing broad refreshes, repeated recomputation, and oversized table queries.
- Adds loading skeleton coverage for cashflow and a shared spinner treatment for skeleton placeholders.
- Keeps backend aggregate endpoints out of scope and continues using PocketBase collection reads/realtime.

## Index benchmark

Validated the new `idx_transactions_excluded_date (excluded, date)` index against the cashflow query (`excluded = '' AND date >= ? AND date < ?`) on a SQLite copy of the demo data scaled to ~300k transactions. Each access path was timed 300×; all return identical results — only the plan differs:

| Access path | Plan (EXPLAIN QUERY PLAN) | Per query |
| --- | --- | --- |
| `idx_transactions_excluded_date` (new) | `SEARCH ... USING COVERING INDEX (excluded=? AND date>? AND date<?)` | ~0.26–2.7 ms |
| `idx_transactions_account_date` (old fallback, skip-scan) | `SEARCH ... USING INDEX (ANY(account) AND date>? AND date<?)` | ~2.3–66 ms |
| full table scan | `SCAN` | ~15–17 ms |

The new index is **9–24× faster** than the old fallback, with the margin scaling by how many rows fall in the cashflow window. The old `(account, date)` index can't cover the `excluded` filter, so it does a table lookup per candidate row; `(excluded, date)` covers the whole query. Confirmed the planner selects the new index on a fresh database.

Closes #353
