### PR TITLE
fix: stop aborted account refreshes from surfacing as connection failures

### DIFF
--- a/e2e/error-handling.test.ts
+++ b/e2e/error-handling.test.ts
@@ -72,6 +72,56 @@ test('shows auth error toast when session expires', async ({ page }) => {
 	).toBeVisible();
 });
 
+test('stays silent when a request is aborted mid-flight', async ({ page }) => {
+	const user = await seedUser('hannah');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
+
+	await page.route('**/api/collections/transactions/**', (route) => {
+		route.abort('aborted');
+	});
+
+	await page.goto('/transactions');
+	await expect(page).toHaveURL('/transactions');
+	await expect(
+		page.locator('[data-sonner-toast]', {
+			hasText: "Can't connect to the database server"
+		})
+	).not.toBeVisible();
+});
+
+test('forces logout without reload when a request returns 401 mid-session', async ({ page }) => {
+	const user = await seedUser('isabel');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
+	await expect(page).not.toHaveURL('/auth');
+
+	await page.route('**/api/collections/**', (route) => {
+		route.fulfill({
+			status: 401,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				code: 401,
+				message: 'The request requires valid record authorization token to be set.',
+				data: {}
+			})
+		});
+	});
+
+	await page.goto('/transactions');
+	await expect(page).toHaveURL('/auth');
+	await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+	await expect(
+		page.locator('[data-sonner-toast]', {
+			hasText: 'Your session has expired'
+		})
+	).toBeVisible();
+});
+
 test('logs out user automatically when their account is deleted', async ({ page }) => {
 	const user = await seedUser('george');
 

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -132,6 +132,13 @@ export class AuthContext {
 			this.currentUserId = '';
 		}
 	}
+
+	invalidateSession() {
+		this.unsubscribeFromCurrentUser();
+		this._pb.authStore.clear();
+		this.currentUser = null;
+		this.currentUserId = '';
+	}
 }
 
 const CONTEXT_KEY = 'auth-store';

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -40,10 +40,7 @@ export class AuthContext {
 			this.currentUserId = this._pb.authStore.record?.id ?? '';
 			return true;
 		} catch {
-			this.unsubscribeFromCurrentUser();
-			this._pb.authStore.clear();
-			this.currentUser = null;
-			this.currentUserId = '';
+			this.teardownSession();
 			toast.error(m.error_auth_failed(), { id: 'auth-error' });
 			return false;
 		}
@@ -69,12 +66,16 @@ export class AuthContext {
 			.catch((error) => console.error('[auth:unsubscribe]', error));
 	}
 
+	private teardownSession() {
+		this.unsubscribeFromCurrentUser();
+		this._pb.authStore.clear();
+		this.currentUser = null;
+		this.currentUserId = '';
+	}
+
 	private onCurrentUserEvent(e: RecordSubscription<UsersResponse>) {
 		if (e.action === 'delete') {
-			this.unsubscribeFromCurrentUser();
-			this._pb.authStore.clear();
-			this.currentUser = null;
-			this.currentUserId = '';
+			this.teardownSession();
 		}
 	}
 
@@ -134,10 +135,7 @@ export class AuthContext {
 	}
 
 	invalidateSession() {
-		this.unsubscribeFromCurrentUser();
-		this._pb.authStore.clear();
-		this.currentUser = null;
-		this.currentUserId = '';
+		this.teardownSession();
 	}
 }
 

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -18,6 +18,7 @@ enum ToastId {
 export class PocketBaseContext {
 	authedClient: TypedPocketBase;
 	setupStatus: SetupStatus = $state('checking');
+	onAuthInvalidated?: () => void;
 
 	constructor() {
 		this.authedClient = new PocketBase(env.PUBLIC_PB_URL || 'http://127.0.0.1:42070');
@@ -85,31 +86,44 @@ export class PocketBaseContext {
 		console.error(`[${context}:${operation}]`, error);
 	}
 
+	private isTransientError(error: unknown) {
+		return error instanceof ClientResponseError && error.isAbort;
+	}
+
 	private isAuthError(error: unknown) {
 		return error instanceof ClientResponseError && (error.status === 401 || error.status === 403);
 	}
 
 	private getErrorType(error: unknown, errorContext: 'connection' | 'subscription') {
+		if (this.isTransientError(error)) {
+			return { isAuth: false, isTransient: true } as const;
+		}
 		if (this.isAuthError(error)) {
-			return { isAuth: true, toastId: ToastId.AUTH_ERROR };
+			return { isAuth: true, isTransient: false, toastId: ToastId.AUTH_ERROR } as const;
 		}
 		const toastId =
 			errorContext === 'subscription' ? ToastId.SUBSCRIPTION_ERROR : ToastId.CONNECTION_ERROR;
-		return { isAuth: false, toastId };
+		return { isAuth: false, isTransient: false, toastId } as const;
 	}
 
 	handleConnectionError(error: unknown, context: string, operation: string) {
-		this.captureError(error, context, operation);
 		const errorType = this.getErrorType(error, 'connection');
+		if (errorType.isTransient) return;
+
+		this.captureError(error, context, operation);
 		const message = errorType.isAuth ? m.error_auth_failed() : m.error_connection_failed();
 		toast.error(message, { id: errorType.toastId });
+		if (errorType.isAuth) this.onAuthInvalidated?.();
 	}
 
 	handleSubscriptionError(error: unknown, context: string, operation: string) {
-		this.captureError(error, context, operation);
 		const errorType = this.getErrorType(error, 'subscription');
+		if (errorType.isTransient) return;
+
+		this.captureError(error, context, operation);
 		const message = errorType.isAuth ? m.error_auth_failed() : m.error_subscription_failed();
 		toast.error(message, { id: errorType.toastId });
+		if (errorType.isAuth) this.onAuthInvalidated?.();
 	}
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,8 @@
 	const auth = setAuthContext(pb.authedClient);
 	setDemoContext(pb.authedClient, auth);
 
+	pb.onAuthInvalidated = () => auth.invalidateSession();
+
 	if (browser) {
 		void initializeLocale();
 	}


### PR DESCRIPTION
- Aborted or superseded PocketBase requests were misclassified as generic connection failures, showing a false "can't connect to the database server" toast that masked real connectivity problems
- Classifies an aborted request (`ClientResponseError.isAbort`) as transient and stays silent, while a genuinely unreachable backend still surfaces its connection toast
- Restores auth invalidation on a real 401/403 mid-session: the user now gets the session-expired toast and is reactively logged out (redirected to `/auth`) without a page reload, fixing the regression where #348 removed `authStore.clear()` to stop spurious logouts on transient requests
- Routes invalidation through `AuthContext` so the SDK auth store and the `currentUserId` that drives the route guard clear together
- Collapses the four duplicated session-teardown sequences into a single `teardownSession()` helper (`logout()` keeps its `try`/`finally` guarantee)
- Adds e2e coverage for both new behaviors: aborted requests stay silent, and a mid-session 401 forces logout without a reload

Closes #357