### PR TITLE
fix: prevent stale auth and realtime 403s during authenticated navigation

### DIFF
--- a/e2e/realtime-auth-lifecycle.test.ts
+++ b/e2e/realtime-auth-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { signIn } from './playwright.helpers';
+import { seedUser } from './pocketbase.helpers';
+
+function collectRealtimeAuthForbidden(page: Page) {
+	const forbidden: string[] = [];
+	page.on('response', (response) => {
+		const url = response.url();
+		const isRealtimeAuth =
+			url.includes('/api/realtime') || url.includes('/api/collections/users/auth-refresh');
+		if (isRealtimeAuth && response.status() === 403) {
+			forbidden.push(`${response.status()} ${url}`);
+		}
+	});
+	return forbidden;
+}
+
+async function logOut(page: Page) {
+	const logoutButton = page.getByRole('button', { name: 'Log out' });
+	if (!(await logoutButton.isVisible())) {
+		await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
+		await expect(logoutButton).toBeVisible();
+	}
+	await logoutButton.click();
+}
+
+test('logging out from a realtime route emits no realtime authorization 403', async ({ page }) => {
+	const user = await seedUser('quill');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await page.goto('/big-picture');
+	await expect(page.getByRole('region', { name: 'Income per month' })).toBeVisible();
+
+	const forbidden = collectRealtimeAuthForbidden(page);
+
+	await logOut(page);
+	await expect(page).toHaveURL('/auth');
+	await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+	await expect(page.getByText('Your session has expired')).not.toBeVisible();
+	expect(forbidden).toEqual([]);
+});
+
+test('navigating between authenticated realtime routes emits no realtime 403', async ({ page }) => {
+	const user = await seedUser('roman');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+
+	const forbidden = collectRealtimeAuthForbidden(page);
+
+	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
+
+	await page.goto('/big-picture');
+	await expect(page.getByRole('region', { name: 'Income per month' })).toBeVisible();
+
+	await page.goto('/transactions');
+	await expect(page.getByRole('region', { name: 'Transactions summary' })).toBeVisible();
+
+	await page.goto('/trades');
+	await expect(page.getByRole('region', { name: 'Trades summary' })).toBeVisible();
+
+	await page.goto('/');
+	await expect(page.getByRole('region', { name: 'Net worth' })).toBeVisible();
+	await expect(page.getByText('Your session has expired')).not.toBeVisible();
+	expect(forbidden).toEqual([]);
+});

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -67,6 +67,7 @@ class AccountsContext {
 	private refreshSequence = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(
 		pb: PocketBaseContext,
@@ -74,6 +75,7 @@ class AccountsContext {
 	) {
 		this._pb = pb;
 		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
 	}
@@ -488,6 +490,7 @@ class AccountsContext {
 	}
 
 	dispose() {
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -2,6 +2,7 @@ import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
+import { getAuthContext } from './auth.svelte';
 import { setBalanceTypesContext } from './balance-types.svelte';
 import {
 	AssetSharesAccessRoleOptions,
@@ -61,20 +62,26 @@ class AssetsContext {
 	private rawAssets: AssetsResponse[] = $state([]);
 	private latestBalanceByAsset = new SvelteMap<string, LatestAssetBalance>();
 	private _pb: PocketBaseContext;
+	private _auth: ReturnType<typeof getAuthContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
 	private _refreshAssetsSequence = 0;
+	private _activeUserId = '';
+	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(
 		pb: PocketBaseContext,
 		balanceTypesContext: ReturnType<typeof setBalanceTypesContext>
 	) {
 		this._pb = pb;
+		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
 	}
 
 	private get currentUserId() {
-		return this._pb.authedClient.authStore.record?.id ?? '';
+		return this._auth.currentUserId;
 	}
 
 	getTypeName(id: string) {
@@ -135,17 +142,39 @@ class AssetsContext {
 		}
 	}
 
-	private async init() {
-		try {
+	private init() {
+		$effect(() => {
 			const userId = this.currentUserId;
-			this.realtimeSubscribe();
+			if (userId === this._activeUserId) return;
+			this.unsubscribeRealtime();
+			this._activeUserId = userId;
+			if (!userId) {
+				this._refreshAssetsSequence++;
+				this.rawAssets = [];
+				this.latestBalanceByAsset.clear();
+				this.shares = [];
+				this.lastBalanceEvent = 0;
+				this.isLoading = false;
+				return;
+			}
+			this.isLoading = true;
+			this.lastBalanceEvent = 0;
+			this.realtimeSubscribe(userId);
+			void this.refreshForCurrentUser();
+		});
+	}
+
+	private async refreshForCurrentUser() {
+		const userId = this.currentUserId;
+		try {
 			await this.refreshShares(userId);
 			await this.refreshAssets();
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
+			if (userId !== this.currentUserId) return;
 			this._pb.handleConnectionError(error, 'assets', 'init');
 		} finally {
-			this.isLoading = false;
+			if (userId === this.currentUserId) this.isLoading = false;
 		}
 	}
 
@@ -183,9 +212,8 @@ class AssetsContext {
 		return true;
 	}
 
-	private realtimeSubscribe() {
-		const userId = this.currentUserId;
-		if (!userId) return;
+	private realtimeSubscribe(userId = this._activeUserId) {
+		if (this._isSubscribed || !userId || userId !== this._activeUserId) return;
 
 		this._pb.authedClient
 			.collection('assets')
@@ -199,7 +227,7 @@ class AssetsContext {
 				});
 			})
 			.catch((error) => {
-				if (userId === this.currentUserId) {
+				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets');
 				} else {
 					console.error('[assetsStore] Stale subscription failed:', error);
@@ -209,7 +237,7 @@ class AssetsContext {
 			.collection('assetBalances')
 			.subscribe<AssetBalancesResponse>('*', (event) => this.onAssetBalanceEvent(event, userId))
 			.catch((error) => {
-				if (userId === this.currentUserId) {
+				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances');
 				} else {
 					console.error('[assetsStore] Stale subscription failed:', error);
@@ -219,12 +247,21 @@ class AssetsContext {
 			.collection('assetShares')
 			.subscribe<AssetSharesResponse>('*', (event) => this.onAssetShareEvent(event, userId))
 			.catch((error) => {
-				if (userId === this.currentUserId) {
+				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares');
 				} else {
 					console.error('[assetsStore] Stale subscription failed:', error);
 				}
 			});
+		this._isSubscribed = true;
+	}
+
+	private unsubscribeRealtime() {
+		if (!this._isSubscribed) return;
+		this._isSubscribed = false;
+		this._pb.authedClient.collection('assets').unsubscribe('*');
+		this._pb.authedClient.collection('assetBalances').unsubscribe('*');
+		this._pb.authedClient.collection('assetShares').unsubscribe('*');
 	}
 
 	private async onAssetEvent(e: RecordSubscription<AssetsResponse>, userId: string) {
@@ -471,9 +508,8 @@ class AssetsContext {
 
 	dispose() {
 		this._refreshAssetsSequence++;
-		this._pb.authedClient.collection('assets').unsubscribe('*');
-		this._pb.authedClient.collection('assetBalances').unsubscribe('*');
-		this._pb.authedClient.collection('assetShares').unsubscribe('*');
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this.unsubscribeRealtime();
 	}
 }
 

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,6 +1,11 @@
-import PocketBase, { type BaseAuthStore, type RecordSubscription } from 'pocketbase';
+import PocketBase, {
+	ClientResponseError,
+	type BaseAuthStore,
+	type RecordSubscription
+} from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 import { toast } from 'svelte-sonner';
+import { SvelteSet } from 'svelte/reactivity';
 
 import { m } from '$lib/paraglide/messages.js';
 import type { UsersResponse } from '$lib/pocketbase.schema';
@@ -13,6 +18,7 @@ export class AuthContext {
 	error: string | null = $state(null);
 
 	private _pb: PocketBase;
+	private _realtimeTeardowns = new SvelteSet<() => void>();
 
 	constructor(pb: PocketBase) {
 		this._pb = pb;
@@ -36,14 +42,16 @@ export class AuthContext {
 
 		try {
 			await this._pb.collection('users').authRefresh();
-			this.currentUser = this._pb.authStore;
-			this.currentUserId = this._pb.authStore.record?.id ?? '';
-			return true;
-		} catch {
-			this.teardownSession();
-			toast.error(m.error_auth_failed(), { id: 'auth-error' });
-			return false;
+		} catch (error) {
+			if (error instanceof ClientResponseError && (error.status === 401 || error.status === 403)) {
+				this.teardownSession();
+				toast.error(m.error_auth_failed(), { id: 'auth-error' });
+				return false;
+			}
 		}
+		this.currentUser = this._pb.authStore;
+		this.currentUserId = this._pb.authStore.record?.id ?? '';
+		return true;
 	}
 
 	private subscribeToCurrentUser() {
@@ -66,7 +74,26 @@ export class AuthContext {
 			.catch((error) => console.error('[auth:unsubscribe]', error));
 	}
 
+	private runRealtimeTeardowns() {
+		for (const teardown of this._realtimeTeardowns) {
+			try {
+				teardown();
+			} catch (error) {
+				console.error('[auth:teardown]', error);
+			}
+		}
+	}
+
+	registerRealtimeTeardown(teardown: () => void) {
+		this._realtimeTeardowns.add(teardown);
+	}
+
+	unregisterRealtimeTeardown(teardown: () => void) {
+		this._realtimeTeardowns.delete(teardown);
+	}
+
 	private teardownSession() {
+		this.runRealtimeTeardowns();
 		this.unsubscribeFromCurrentUser();
 		this._pb.authStore.clear();
 		this.currentUser = null;
@@ -126,6 +153,7 @@ export class AuthContext {
 	async logout() {
 		this.error = null;
 		try {
+			this.runRealtimeTeardowns();
 			this.unsubscribeFromCurrentUser();
 			this._pb.authStore.clear();
 		} finally {

--- a/src/lib/balance-types.svelte.ts
+++ b/src/lib/balance-types.svelte.ts
@@ -1,6 +1,7 @@
 import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
+import { getAuthContext } from './auth.svelte';
 import type { BalanceTypesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -8,32 +9,67 @@ class BalanceTypesContext {
 	byId: Record<string, BalanceTypesResponse> = $state({});
 
 	private _pb: PocketBaseContext;
+	private _auth: ReturnType<typeof getAuthContext>;
+	private _activeUserId = '';
+	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
+		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this.init();
 	}
 
-	private async init() {
-		// Subscribe FIRST to avoid missing events during initial fetch
-		this.realtimeSubscribe();
+	private init() {
+		$effect(() => {
+			const userId = this._auth.currentUserId;
+			if (userId === this._activeUserId) return;
+			this.unsubscribeRealtime();
+			this._activeUserId = userId;
+			if (!userId) {
+				this.byId = {};
+				return;
+			}
+			this.realtimeSubscribe(userId);
+			void this.refreshForCurrentUser(userId);
+		});
+	}
+
+	private async refreshForCurrentUser(userId: string) {
 		try {
 			const list = await this._pb.authedClient
 				.collection('balanceTypes')
 				.getFullList<BalanceTypesResponse>();
+			if (userId !== this._activeUserId) return;
 			const map: Record<string, BalanceTypesResponse> = {};
 			for (const bt of list) map[bt.id] = bt;
 			this.byId = map;
 		} catch (error) {
+			if (userId !== this._activeUserId) return;
 			this._pb.handleConnectionError(error, 'balance_types', 'init');
 		}
 	}
 
-	private realtimeSubscribe() {
+	private realtimeSubscribe(userId = this._activeUserId) {
+		if (this._isSubscribed || !userId || userId !== this._activeUserId) return;
+		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('balanceTypes')
 			.subscribe('*', this.onEvent.bind(this))
-			.catch((error) => this._pb.handleSubscriptionError(error, 'balance_types', 'subscribe'));
+			.catch((error) => {
+				if (userId === this._activeUserId) {
+					this._pb.handleSubscriptionError(error, 'balance_types', 'subscribe');
+				} else {
+					console.error('[balanceTypesStore] Stale subscription failed:', error);
+				}
+			});
+	}
+
+	private unsubscribeRealtime() {
+		if (!this._isSubscribed) return;
+		this._isSubscribed = false;
+		this._pb.authedClient.collection('balanceTypes').unsubscribe('*');
 	}
 
 	private onEvent(e: RecordSubscription<BalanceTypesResponse>) {
@@ -79,7 +115,8 @@ class BalanceTypesContext {
 	}
 
 	dispose() {
-		this._pb.authedClient.collection('balanceTypes').unsubscribe();
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this.unsubscribeRealtime();
 	}
 }
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -5,6 +5,7 @@ import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 import { getAccountsContext, type AccountWithBalance } from './accounts.svelte';
+import { getAuthContext } from './auth.svelte';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 import { projectSignedValue } from './sharing';
@@ -48,25 +49,57 @@ class CashflowContext {
 	isLoading: boolean = $state(true);
 
 	private _pb: PocketBaseContext;
+	private _auth: ReturnType<typeof getAuthContext>;
 	private _accountsContext: ReturnType<typeof getAccountsContext>;
 	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _unsubscribe: (() => void) | null = null;
 	private _disposed = false;
+	private _activeUserId = '';
+	private _isSubscribed = false;
 	private _recomputeSequence = 0;
 	private _recomputeAllInFlight = 0;
 	private _transactionsById = new SvelteMap<string, TransactionsResponse>();
 	private _activeWindow: CashflowWindow | null = null;
 	private _hasTransactionSnapshot = false;
 	private _watchedAccountsKey: string | null = null;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
+		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this._accountsContext = getAccountsContext();
 		this.init();
 	}
 
 	private init() {
-		this.realtimeSubscribe();
+		$effect(() => {
+			const userId = this._auth.currentUserId;
+			if (userId === this._activeUserId) return;
+			this.unsubscribeRealtime();
+			this._activeUserId = userId;
+			if (!userId) {
+				this._recomputeSequence++;
+				if (this._debounceTimer) {
+					clearTimeout(this._debounceTimer);
+					this._debounceTimer = null;
+				}
+				this._transactionsById = new SvelteMap();
+				this._activeWindow = null;
+				this._hasTransactionSnapshot = false;
+				this._watchedAccountsKey = null;
+				this.periods = [];
+				this.avg3m = { income: 0, expenses: 0, surplus: 0 };
+				this.avg6m = { income: 0, expenses: 0, surplus: 0 };
+				this.avgYtd = { income: 0, expenses: 0, surplus: 0 };
+				this.avg1y = { income: 0, expenses: 0, surplus: 0 };
+				this.isLoading = false;
+				return;
+			}
+			this.isLoading = true;
+			this.realtimeSubscribe(userId);
+		});
+
 		// Perf-critical: `accounts` is a $derived that gets a new identity on every
 		// balance tick, so this effect re-runs constantly. It must NOT refetch all
 		// transactions each time. We gate on `watchedAccountsKey` (account ids +
@@ -76,7 +109,9 @@ class CashflowContext {
 		// Reverting this to recomputeAll(accounts) on every run reintroduces a full
 		// transactions getFullList on every balance event (the regression this fixes).
 		$effect(() => {
+			const userId = this._auth.currentUserId;
 			const accounts = this._accountsContext.accounts;
+			if (!userId || userId !== this._activeUserId) return;
 			const watchedAccountsKey = this.getWatchedAccountsKey(accounts);
 			const activeWindow = this._activeWindow;
 			const cashflowWindow = this.getCashflowWindow();
@@ -113,12 +148,14 @@ class CashflowContext {
 			.join('|');
 	}
 
-	private realtimeSubscribe() {
+	private realtimeSubscribe(userId = this._activeUserId) {
+		if (this._isSubscribed || !userId || userId !== this._activeUserId) return;
+		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('transactions')
 			.subscribe('*', this.onTransactionEvent.bind(this))
 			.then((unsubscribe) => {
-				if (this._disposed) {
+				if (this._disposed || userId !== this._activeUserId) {
 					unsubscribe();
 					return;
 				}
@@ -126,8 +163,20 @@ class CashflowContext {
 				this._unsubscribe = unsubscribe;
 			})
 			.catch((error) => {
-				if (!this._disposed) this._pb.handleSubscriptionError(error, 'cashflow', 'subscribe');
+				if (this._disposed) return;
+				if (userId === this._activeUserId) {
+					this._pb.handleSubscriptionError(error, 'cashflow', 'subscribe');
+				} else {
+					console.error('[cashflowStore] Stale subscription failed:', error);
+				}
 			});
+	}
+
+	private unsubscribeRealtime() {
+		if (!this._isSubscribed) return;
+		this._isSubscribed = false;
+		this._unsubscribe?.();
+		this._unsubscribe = null;
 	}
 
 	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
@@ -355,8 +404,8 @@ class CashflowContext {
 			clearTimeout(this._debounceTimer);
 			this._debounceTimer = null;
 		}
-		this._unsubscribe?.();
-		this._unsubscribe = null;
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this.unsubscribeRealtime();
 	}
 }
 

--- a/src/lib/import-sessions.svelte.ts
+++ b/src/lib/import-sessions.svelte.ts
@@ -1,6 +1,7 @@
 import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
+import { getAuthContext } from './auth.svelte';
 import type { ImportSessionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -9,31 +10,75 @@ class ImportSessionsContext {
 	isLoading: boolean = $state(true);
 
 	private _pb: PocketBaseContext;
+	private _auth: ReturnType<typeof getAuthContext>;
+	private _activeUserId = '';
+	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
+		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this.init();
 	}
 
-	private async init() {
-		try {
-			this.realtimeSubscribe();
+	private get currentUserId() {
+		return this._auth.currentUserId;
+	}
 
-			this.sessions = await this._pb.authedClient
+	private init() {
+		$effect(() => {
+			const userId = this.currentUserId;
+			if (userId === this._activeUserId) return;
+			this.unsubscribeRealtime();
+			this._activeUserId = userId;
+			if (!userId) {
+				this.sessions = [];
+				this.isLoading = false;
+				return;
+			}
+			this.isLoading = true;
+			this.realtimeSubscribe(userId);
+			void this.refreshForCurrentUser();
+		});
+	}
+
+	private async refreshForCurrentUser() {
+		const userId = this.currentUserId;
+		try {
+			const sessions = await this._pb.authedClient
 				.collection('importSessions')
 				.getFullList<ImportSessionsResponse>({ sort: '-created' });
-			this.isLoading = false;
+			if (userId !== this.currentUserId) return;
+			this.sessions = sessions;
 		} catch (error) {
+			if (userId !== this.currentUserId) return;
 			this._pb.handleConnectionError(error, 'importSessions', 'init');
-			this.isLoading = false;
+		} finally {
+			if (userId === this.currentUserId) this.isLoading = false;
 		}
 	}
 
-	private realtimeSubscribe() {
+	private realtimeSubscribe(userId = this._activeUserId) {
+		if (this._isSubscribed || !userId || userId !== this._activeUserId) return;
+
 		this._pb.authedClient
 			.collection('importSessions')
 			.subscribe('*', this.onSessionEvent.bind(this))
-			.catch((error) => this._pb.handleSubscriptionError(error, 'importSessions', 'subscribe'));
+			.catch((error) => {
+				if (userId === this._activeUserId) {
+					this._pb.handleSubscriptionError(error, 'importSessions', 'subscribe');
+				} else {
+					console.error('[importSessionsStore] Stale subscription failed:', error);
+				}
+			});
+		this._isSubscribed = true;
+	}
+
+	private unsubscribeRealtime() {
+		if (!this._isSubscribed) return;
+		this._isSubscribed = false;
+		this._pb.authedClient.collection('importSessions').unsubscribe('*');
 	}
 
 	private onSessionEvent(e: RecordSubscription<ImportSessionsResponse>) {
@@ -47,7 +92,8 @@ class ImportSessionsContext {
 	}
 
 	dispose() {
-		this._pb.authedClient.collection('importSessions').unsubscribe();
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this.unsubscribeRealtime();
 	}
 }
 

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -85,10 +85,12 @@ class SecuritiesContext {
 	private refreshSequence = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this._accounts = getAccountsContext();
 		this.init();
 	}
@@ -429,6 +431,7 @@ class SecuritiesContext {
 	}
 
 	dispose() {
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		this.clearPositionRefreshTimers();
 		this.unsubscribeRealtime();
 	}

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -72,6 +72,7 @@ class TradesContext {
 	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private _activeUserId = '';
 	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
 	private _refreshSequence = 0;
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
@@ -96,6 +97,7 @@ class TradesContext {
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this._accountsContext = getAccountsContext();
 		this._securitiesContext = getSecuritiesContext();
 		this.syncFromUrl(false);
@@ -640,6 +642,7 @@ class TradesContext {
 	}
 
 	dispose() {
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
 		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
 		if (this._refreshTimer) clearTimeout(this._refreshTimer);

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -88,6 +88,9 @@ class TransactionsContext {
 	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 	private _activeUserId = '';
 	private _isSubscribed = false;
+	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _unsubscribe: (() => void) | null = null;
+	private _unsubscribeLabels: (() => void) | null = null;
 	private _refreshSequence = 0;
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
@@ -115,6 +118,7 @@ class TransactionsContext {
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
+		this._auth.registerRealtimeTeardown(this._teardownCallback);
 		this._accountsContext = getAccountsContext();
 		this.syncFromUrl(false);
 		this.init();
@@ -532,6 +536,13 @@ class TransactionsContext {
 			.subscribe<TransactionsResponse<TransactionExpand>>('*', (event) =>
 				this.onTransactionEvent(event, userId)
 			)
+			.then((unsubscribe) => {
+				if (userId !== this._activeUserId) {
+					unsubscribe();
+					return;
+				}
+				this._unsubscribe = unsubscribe;
+			})
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'transactions', 'subscribe_transactions');
@@ -548,6 +559,13 @@ class TransactionsContext {
 		this._pb.authedClient
 			.collection('transactionLabels')
 			.subscribe('*', () => this.refreshLabels(userId))
+			.then((unsubscribe) => {
+				if (userId !== this._activeUserId) {
+					unsubscribe();
+					return;
+				}
+				this._unsubscribeLabels = unsubscribe;
+			})
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'transactionLabels', 'subscribe_labels');
@@ -560,8 +578,10 @@ class TransactionsContext {
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
-		this._pb.authedClient.collection('transactions').unsubscribe('*');
-		this._pb.authedClient.collection('transactionLabels').unsubscribe('*');
+		this._unsubscribe?.();
+		this._unsubscribe = null;
+		this._unsubscribeLabels?.();
+		this._unsubscribeLabels = null;
 	}
 
 	private onTransactionEvent(
@@ -951,6 +971,7 @@ class TransactionsContext {
 	}
 
 	dispose() {
+		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
 		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
 		if (this._refreshTimer) clearTimeout(this._refreshTimer);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -3,6 +3,7 @@
 
 	import { setAccountsContext } from '$lib/accounts.svelte';
 	import { setAssetsContext } from '$lib/assets.svelte';
+	import { getAuthContext } from '$lib/auth.svelte';
 	import { setBalanceTypesContext } from '$lib/balance-types.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { setImportSessionsContext } from '$lib/import-sessions.svelte';
@@ -14,6 +15,7 @@
 	let { children } = $props();
 
 	const pb = getPocketBaseContext();
+	const auth = getAuthContext();
 	const balanceTypesContext = setBalanceTypesContext(pb);
 	const accountsContext = setAccountsContext(pb, balanceTypesContext);
 	const assetsContext = setAssetsContext(pb, balanceTypesContext);
@@ -33,6 +35,8 @@
 <Sidebar.Provider>
 	<AppSidebar />
 	<Sidebar.Inset>
-		{@render children?.()}
+		{#if auth.currentUserId}
+			{@render children?.()}
+		{/if}
 	</Sidebar.Inset>
 </Sidebar.Provider>


### PR DESCRIPTION
- Realtime stores could subscribe while auth was unsettled or survive an auth change, producing PocketBase `403` / "authorization don't match" errors during authenticated navigation
- Convert the four eager stores (cashflow, assets, balance-types, import-sessions) to the auth-reactive lifecycle the other stores already use, so subscriptions deterministically tear down on auth change
- Gate the `(app)` subtree render on the current user, and add a teardown registry in `AuthContext` that unsubscribes every store synchronously before the auth token is cleared, closing the realtime reconnect race
- Replace the transactions store's broad collection-wide unsubscribe with captured-closure teardown, removing the collision with cashflow's subscription on the shared collection
- Classify auth-refresh failures so a connection blip no longer logs the user out: only a genuine `401`/`403` clears the session
- Add e2e coverage asserting logout and authenticated navigation emit no realtime `403`s

Closes #349