### PR TITLE
fix: show empty trends charts instead of a perpetual loading skeleton

### DIFF
--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -275,3 +275,24 @@ test('trends performance table', async ({ page }) => {
 	await expect(debtCells.nth(7).getByRole('button', { name: '+50%' })).toBeVisible(); // 5Y
 	await expect(debtCells.nth(8).getByRole('button', { name: '+200%' })).toBeVisible(); // MAX
 });
+
+test('trends renders empty charts for a vault with no data', async ({ page }) => {
+	const user = await seedUser('violet');
+
+	await page.goto('/');
+	await signIn(page, user.email);
+
+	await goToPageViaSidebar(page, 'Trends');
+
+	// Regression: an empty vault must settle to empty growth/performance visuals, not a
+	// perpetual loading skeleton. Both skeletons render a spinner until the first balance
+	// fetch completes; afterwards the empty chart and zeroed table take their place.
+	await expect(page.locator('[data-slot="skeleton"].h-96')).toBeHidden();
+	await expect(page.locator('[data-slot="skeleton"].h-64')).toBeHidden();
+
+	const growthChart = page.locator('[data-growth-period="1y"]');
+	await expect(growthChart).toBeVisible();
+	await expect(growthChart).toHaveAttribute('data-growth-points', '0');
+
+	await expect(page.getByRole('row', { name: /Net worth/ })).toBeVisible();
+});

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -21,6 +21,15 @@ test('trends performance table', async ({ page }) => {
 	await page.goto('/');
 	await signIn(page, user.email);
 
+	// Empty vault: trends must settle to empty visuals, not a perpetual skeleton.
+	await goToPageViaSidebar(page, 'Trends');
+	await expect(page.locator('[data-slot="skeleton"].h-96')).toBeHidden();
+	await expect(page.locator('[data-slot="skeleton"].h-64')).toBeHidden();
+	const emptyGrowthChart = page.locator('[data-growth-period="1y"]');
+	await expect(emptyGrowthChart).toBeVisible();
+	await expect(emptyGrowthChart).toHaveAttribute('data-growth-points', '0');
+	await page.goto('/');
+
 	const cashAccount = await seedAccount({
 		name: 'Perf Test',
 		balanceGroup: AccountsBalanceGroupOptions.CASH,
@@ -274,25 +283,4 @@ test('trends performance table', async ({ page }) => {
 	await expect(debtCells.nth(6).getByRole('button', { name: '+42.9%' })).toBeVisible(); // 2Y
 	await expect(debtCells.nth(7).getByRole('button', { name: '+50%' })).toBeVisible(); // 5Y
 	await expect(debtCells.nth(8).getByRole('button', { name: '+200%' })).toBeVisible(); // MAX
-});
-
-test('trends renders empty charts for a vault with no data', async ({ page }) => {
-	const user = await seedUser('violet');
-
-	await page.goto('/');
-	await signIn(page, user.email);
-
-	await goToPageViaSidebar(page, 'Trends');
-
-	// Regression: an empty vault must settle to empty growth/performance visuals, not a
-	// perpetual loading skeleton. Both skeletons render a spinner until the first balance
-	// fetch completes; afterwards the empty chart and zeroed table take their place.
-	await expect(page.locator('[data-slot="skeleton"].h-96')).toBeHidden();
-	await expect(page.locator('[data-slot="skeleton"].h-64')).toBeHidden();
-
-	const growthChart = page.locator('[data-growth-period="1y"]');
-	await expect(growthChart).toBeVisible();
-	await expect(growthChart).toHaveAttribute('data-growth-points', '0');
-
-	await expect(page.getByRole('row', { name: /Net worth/ })).toBeVisible();
 });

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -37,6 +37,9 @@
 	const accountsCtx = getAccountsContext();
 	const assetsCtx = getAssetsContext();
 
+	let bootstrapped = $state(false);
+	const isLoading = $derived(!bootstrapped);
+
 	let period: PeriodKey = $state('1y');
 	let rawAccounts: AccountsResponse[] = $state([]);
 	let rawAssets: AssetsResponse[] = $state([]);
@@ -408,7 +411,6 @@
 	let refreshTimer: number | null = null;
 	let refreshInFlight = false;
 	let pendingRefresh = false;
-	let bootstrapped = false;
 	let lastIncludedSignature = '';
 
 	function handleBalanceEvent<
@@ -618,6 +620,7 @@
 
 			<ChartNetWorth
 				bind:period
+				{isLoading}
 				prepared={period === 'max' ? fullHistoryPrepared : prepared}
 				{rawAccounts}
 				{rawAssets}
@@ -633,6 +636,7 @@
 	<Section>
 		<SectionTitle title={m.trends_performance_section_title()} />
 		<Performance
+			{isLoading}
 			{prepared}
 			{fullHistoryPrepared}
 			{rawAccounts}

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -28,6 +28,7 @@
 
 	let {
 		period = $bindable(),
+		isLoading,
 		prepared,
 		rawAccounts,
 		rawAssets,
@@ -36,6 +37,7 @@
 		rawAssetBalances
 	}: {
 		period: PeriodKey;
+		isLoading: boolean;
 		prepared: PreparedTrendMaps;
 		rawAccounts: AccountsResponse[];
 		rawAssets: AssetsResponse[];
@@ -107,7 +109,10 @@
 	});
 
 	function recomputeSeries() {
-		if (!rawAccounts.length && !rawAssets.length) return;
+		if (!rawAccounts.length && !rawAssets.length) {
+			series = [];
+			return;
+		}
 		const { start, end } = computeRangeForPeriod(
 			period,
 			rawAccountBalances,
@@ -214,7 +219,9 @@
 	$effect(() => recomputeSeries());
 </script>
 
-{#if series.length}
+{#if isLoading}
+	<Skeleton class="h-96" showSpinner />
+{:else}
 	<div
 		class="bg-background overflow-visible rounded-sm shadow-md"
 		data-growth-period={period}
@@ -268,6 +275,4 @@
 			</LineChart>
 		</Chart.Container>
 	</div>
-{:else}
-	<Skeleton class="h-96" showSpinner />
 {/if}

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -24,6 +24,7 @@
 	} from './trends';
 
 	let {
+		isLoading,
 		prepared,
 		fullHistoryPrepared,
 		rawAccounts,
@@ -32,6 +33,7 @@
 		rawFullHistorySecurityBalances,
 		rawFullHistoryAssetBalances
 	}: {
+		isLoading: boolean;
 		prepared: PreparedTrendMaps;
 		fullHistoryPrepared: PreparedTrendMaps;
 		rawAccounts: AccountsResponse[];
@@ -178,8 +180,24 @@
 		other: m.trends_series_other_label()
 	};
 
+	const zeroTotals = { net: 0, cash: 0, debt: 0, investment: 0, other: 0 };
+
 	const table = $derived.by(() => {
-		if (!rawAccounts.length && !rawAssets.length) return null;
+		if (!rawAccounts.length && !rawAssets.length) {
+			const columns = periods.map((periodDef) => ({
+				key: periodDef.key,
+				label: periodDef.label,
+				at: new Date(),
+				values: {
+					net: { pct: null, cur: 0, prev: 0 },
+					cash: { pct: null, cur: 0, prev: 0 },
+					debt: { pct: null, cur: 0, prev: 0 },
+					investment: { pct: null, cur: 0, prev: 0 },
+					other: { pct: null, cur: 0, prev: 0 }
+				}
+			}));
+			return { columns, current: zeroTotals, allocation: { ...zeroTotals } };
+		}
 		const END_OF_TIME = new Date('9999-12-31T23:59:59.999Z');
 		const now = END_OF_TIME;
 
@@ -333,7 +351,9 @@
 	}
 </script>
 
-{#if table}
+{#if isLoading}
+	<Skeleton class="h-64" showSpinner />
+{:else}
 	<div class="bg-background rounded-sm shadow-md">
 		<div class="overflow-x-auto">
 			<Tooltip.Provider delayDuration={150}>
@@ -556,6 +576,4 @@
 			</Tooltip.Provider>
 		</div>
 	</div>
-{:else}
-	<Skeleton class="h-64" showSpinner />
 {/if}


### PR DESCRIPTION
- The growth and performance sections on `/trends` gated their loading skeleton on whether data points existed, so a vault with no accounts or assets showed the skeleton forever
- Gate the skeleton on the first balance fetch completing instead, so it clears once the data settles
- Render an empty growth chart (empty axes) and a zeroed performance table when there is genuinely no data
- Add an e2e test seeding an empty vault and asserting `/trends` renders the empty visuals rather than a perpetual skeleton

No linked issue (confirmed by user)