### PR TITLE
feat: add credits and debits totals to transactions summary

### DIFF
--- a/e2e/transactions.display.test.ts
+++ b/e2e/transactions.display.test.ts
@@ -325,8 +325,15 @@ test('transactions page shows correct count and net balance in summary', async (
 	const summaryRegion = page.getByRole('region', { name: 'Transactions summary' });
 	await expect(summaryRegion.getByText('Transactions')).toBeVisible();
 	await expect(summaryRegion.getByText('5', { exact: true })).toBeVisible();
-	await expect(summaryRegion.getByText('Net balance')).toBeVisible();
+	await expect(summaryRegion.getByText('Net amount')).toBeVisible();
 	await expect(summaryRegion.getByText('$450.67')).toBeVisible();
+
+	// Credits and debits cards both render under the "all" filter, the only state
+	// where both totals are uniquely visible: credits +801.25, debits -350.58
+	await expect(summaryRegion.getByText('Net credits')).toBeVisible();
+	await expect(summaryRegion.getByText('$801.25')).toBeVisible();
+	await expect(summaryRegion.getByText('Net debits')).toBeVisible();
+	await expect(summaryRegion.getByText('-$350.58')).toBeVisible();
 
 	// Change filter to "Credits only"
 	// Expected: count = 2 (excluded credits are shown only by the excluded filter), net balance = $801.25 (500.75 + 300.50)
@@ -334,7 +341,9 @@ test('transactions page shows correct count and net balance in summary', async (
 	await page.getByRole('option', { name: 'Credits only' }).click();
 
 	await expect(summaryRegion.getByText('2', { exact: true })).toBeVisible();
-	await expect(summaryRegion.getByText('$801.25')).toBeVisible();
+	await expect(summaryRegion.getByLabel('Net amount').getByText('$801.25')).toBeVisible();
+	// Net credits is hidden under the credits filter: it equals Net amount, so it's redundant
+	await expect(summaryRegion.getByText('Net credits')).not.toBeVisible();
 
 	// Change filter to "Debits only"
 	// Expected: count = 2, net balance = -$350.58 (-200.25 + -150.33)
@@ -342,7 +351,9 @@ test('transactions page shows correct count and net balance in summary', async (
 	await page.getByRole('option', { name: 'Debits only' }).click();
 
 	await expect(summaryRegion.getByText('2', { exact: true })).toBeVisible();
-	await expect(summaryRegion.getByText('-$350.58')).toBeVisible();
+	await expect(summaryRegion.getByLabel('Net amount').getByText('-$350.58')).toBeVisible();
+	// Net debits is hidden under the debits filter: it equals Net amount, so it's redundant
+	await expect(summaryRegion.getByText('Net debits')).not.toBeVisible();
 
 	// Change filter to "Excluded only"
 	// Expected: count = 1, net balance = $0.00 (excluded transactions don't count toward net)
@@ -351,4 +362,7 @@ test('transactions page shows correct count and net balance in summary', async (
 
 	await expect(summaryRegion.getByText('1', { exact: true })).toBeVisible();
 	await expect(summaryRegion.getByText('$0.00')).toBeVisible();
+	// Both cards are hidden under the excluded filter: their predicates require non-excluded rows
+	await expect(summaryRegion.getByText('Net credits')).not.toBeVisible();
+	await expect(summaryRegion.getByText('Net debits')).not.toBeVisible();
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,6 +4,8 @@
 	"app_tagline": "Personal finance platform",
 	"summary_net_balance": "Net balance",
 	"summary_net_amount": "Net amount",
+	"summary_net_credits": "Net credits",
+	"summary_net_debits": "Net debits",
 	"summary_net_market_value": "Net market value",
 	"summary_net_gain_loss": "Net gain/loss",
 	"summary_net_gain_percent": "Net gain %",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,6 +4,8 @@
 	"app_tagline": "Plataforma de finanzas personales",
 	"summary_net_balance": "Saldo neto",
 	"summary_net_amount": "Importe neto",
+	"summary_net_credits": "Créditos netos",
+	"summary_net_debits": "Débitos netos",
 	"summary_net_market_value": "Valor de mercado neto",
 	"summary_net_gain_loss": "Ganancia/pérdida neta",
 	"summary_net_gain_percent": "Ganancia neta %",

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -769,6 +769,34 @@ class TransactionsContext {
 			.reduce((sum, row) => sum + row.value, 0);
 	}
 
+	private get creditRows() {
+		return this.filteredRows.filter(
+			(row) => row.hasProjectedValue && row.value > 0 && !row.excluded
+		);
+	}
+
+	private get debitRows() {
+		return this.filteredRows.filter(
+			(row) => row.hasProjectedValue && row.value < 0 && !row.excluded
+		);
+	}
+
+	get creditsTotal() {
+		return this.creditRows.reduce((sum, row) => sum + row.value, 0);
+	}
+
+	get debitsTotal() {
+		return this.debitRows.reduce((sum, row) => sum + row.value, 0);
+	}
+
+	get hasCredits() {
+		return this.creditRows.length > 0;
+	}
+
+	get hasDebits() {
+		return this.debitRows.length > 0;
+	}
+
 	get customFromDate() {
 		return this._customFromDate;
 	}

--- a/src/routes/(app)/transactions/transaction-summary.svelte
+++ b/src/routes/(app)/transactions/transaction-summary.svelte
@@ -4,21 +4,45 @@
 	import { getTransactionsContext } from '$lib/transactions.svelte';
 
 	const txContext = getTransactionsContext();
+
+	const showCredits = $derived(txContext.hasCredits && txContext.kind !== 'credits');
+	const showDebits = $derived(txContext.hasDebits && txContext.kind !== 'debits');
+
+	const cardCount = $derived(2 + (showCredits ? 1 : 0) + (showDebits ? 1 : 0));
+	const columns = $derived(
+		cardCount === 4
+			? 'grid-cols-1 sm:grid-cols-2 xl:grid-cols-4'
+			: cardCount === 3
+				? 'grid-cols-1 lg:grid-cols-3'
+				: 'grid-cols-1 sm:grid-cols-2'
+	);
 </script>
 
-<div
-	role="region"
-	aria-label={m.transactions_summary_aria_label()}
-	class="grid grid-cols-1 gap-2 sm:grid-cols-2"
->
+<div role="region" aria-label={m.transactions_summary_aria_label()} class="grid gap-2 {columns}">
 	<KeyValue
 		title={m.transactions_summary_count_label()}
 		value={txContext.totalItems}
 		variant="outline"
 		format="number"
 	/>
+	{#if showCredits}
+		<KeyValue
+			title={m.summary_net_credits()}
+			value={txContext.creditsTotal}
+			variant="outline"
+			decimalScale={2}
+		/>
+	{/if}
+	{#if showDebits}
+		<KeyValue
+			title={m.summary_net_debits()}
+			value={txContext.debitsTotal}
+			variant="outline"
+			decimalScale={2}
+		/>
+	{/if}
 	<KeyValue
-		title={m.summary_net_balance()}
+		title={m.summary_net_amount()}
 		value={txContext.netBalance}
 		variant="outline"
 		decimalScale={2}


### PR DESCRIPTION
- Adds Net credits and Net debits totals to the transactions summary, next to the existing transaction count and net amount
- Labels the value cards consistently with the app's shared "Net …" family (Net credits, Net debits, Net amount), aligning the net card with the trades summary
- Renders the summary cards in even responsive rows (4-up → 2×2 → single column) so the layout never leaves an orphan card
- Shows each total only when the current filter contains that type, and hides a type's own card under its own filter since it would duplicate Net amount
- Adds English and Spanish translations for the new labels
- Extends the summary e2e test to cover the new cards and their per-filter visibility rules

Closes #288