### PR TITLE
fix: group thousands in percentages and integer counts

### DIFF
--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -206,7 +206,7 @@ test('assets table shows appreciation and depreciation for whole-value assets', 
 		owner: user.id,
 		asOf: new Date().toISOString(),
 		bookValue: 45000,
-		marketValue: 87500
+		marketValue: 562500
 	});
 
 	const lossAsset = await seedAsset({
@@ -231,9 +231,9 @@ test('assets table shows appreciation and depreciation for whole-value assets', 
 	await expect(growthPortfolioRow).toBeVisible();
 	await expectAssetRowCells(growthPortfolioRow, [
 		[4, '$45,000.00'],
-		[5, '$42,500.00'],
-		[6, '+94.4%'],
-		[7, '$87,500.00']
+		[5, '$517,500.00'],
+		[6, '+1,150.0%'],
+		[7, '$562,500.00']
 	]);
 
 	const lossPortfolioRow = page.getByRole('row', { name: 'Loss Portfolio' });

--- a/src/lib/components/key-value.svelte
+++ b/src/lib/components/key-value.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Currency from '$lib/components/currency.svelte';
 	import Number from '$lib/components/number.svelte';
+	import { formatPercent } from '$lib/utils';
 
 	type Variant = 'filled' | 'outline' | 'cash' | 'debt' | 'investment' | 'other';
 
@@ -38,9 +39,9 @@
 		{#if value === null}
 			<span class="text-muted-foreground">~</span>
 		{:else if format === 'percent'}
-			<Number value={`${value > 0 ? '+' : ''}${value.toFixed(1)}%`} />
+			<Number value={formatPercent(value)} />
 		{:else if format === 'number'}
-			<Number {value} />
+			<Number value={value.toLocaleString('en-US')} />
 		{:else}
 			<Currency {value} {decimalScale} />
 		{/if}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,14 @@ export function toNumber(value: unknown) {
 	return Number.isFinite(numberValue) ? numberValue : null;
 }
 
+export function formatPercent(value: number) {
+	const normalized = value === 0 ? 0 : value;
+	return `${normalized > 0 ? '+' : ''}${normalized.toLocaleString('en-US', {
+		minimumFractionDigits: 1,
+		maximumFractionDigits: 1
+	})}%`;
+}
+
 // Validates a `?from=` redirect target. Returns the value only if it is a
 // same-origin relative path (starts with a single `/`, not `//` or `/\`, and
 // contains no protocol scheme before the first slash). Returns null otherwise.

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -42,7 +42,7 @@
 		gainLossPercentOrNull,
 		sumOrUnknown
 	} from '$lib/security-balance-values';
-	import { sanitizeFromParam } from '$lib/utils';
+	import { formatPercent, sanitizeFromParam } from '$lib/utils';
 
 	import BalanceForm from './balance-form.svelte';
 	import DetailsForm from './details-form.svelte';
@@ -515,7 +515,7 @@
 										<span class="text-muted-foreground">~</span>
 									{:else}
 										<NumberDisplay
-											value={`${gainLossPercent > 0 ? '+' : ''}${gainLossPercent.toFixed(1)}%`}
+											value={formatPercent(gainLossPercent)}
 											sentiment={gainLossPercent > 0
 												? 'positive'
 												: gainLossPercent < 0

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -25,6 +25,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import {
 		createSortComparator,
+		formatPercent,
 		getSortFromUrl,
 		setSortInUrl,
 		toggleSort,
@@ -377,7 +378,7 @@
 												</Table.Cell>
 												<Table.Cell class="text-right tabular-nums">
 													<Number
-														value={`${row.gainPercent > 0 ? '+' : ''}${row.gainPercent.toFixed(1)}%`}
+														value={formatPercent(row.gainPercent)}
 														sentiment={row.gainPercent > 0
 															? 'positive'
 															: row.gainPercent < 0

--- a/src/routes/(app)/portfolio/+page.svelte
+++ b/src/routes/(app)/portfolio/+page.svelte
@@ -16,6 +16,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { formatSecurityQuantity } from '$lib/security-balance-values';
+	import { formatPercent } from '$lib/utils';
 
 	const securitiesContext = getSecuritiesContext();
 
@@ -183,7 +184,7 @@
 										<span class="text-muted-foreground">~</span>
 									{:else}
 										<NumberDisplay
-											value={`${gainLossPercent > 0 ? '+' : ''}${gainLossPercent.toFixed(1)}%`}
+											value={formatPercent(gainLossPercent)}
 											sentiment={gainLossPercent > 0
 												? 'positive'
 												: gainLossPercent < 0

--- a/src/routes/(app)/trades/securities/[id]/+page.svelte
+++ b/src/routes/(app)/trades/securities/[id]/+page.svelte
@@ -26,6 +26,7 @@
 		gainLossPercentOrNull,
 		sumOrUnknown
 	} from '$lib/security-balance-values';
+	import { formatPercent } from '$lib/utils';
 
 	import BalanceFields from '../balance-fields.svelte';
 	import { createSecurityBalanceFormData, toSecurityBalanceInput } from '../balance-form';
@@ -299,7 +300,7 @@
 											<span class="text-muted-foreground">~</span>
 										{:else}
 											<NumberDisplay
-												value={`${gainLossPercent > 0 ? '+' : ''}${gainLossPercent.toFixed(1)}%`}
+												value={formatPercent(gainLossPercent)}
 												sentiment={gainLossPercent > 0
 													? 'positive'
 													: gainLossPercent < 0


### PR DESCRIPTION
- Adds thousands separators to every user-facing percentage and integer count, which previously rendered ungrouped (e.g. `+1191.5%`, `12345`) and read inconsistently next to already-grouped currency in the same row.
- Introduces a single shared `formatPercent` helper in `utils.ts`, collapsing four duplicated inline `toFixed(1)%` table cells (portfolio, accounts, assets, securities) into one definition.
- Routes the KeyValue cards — the portfolio Net gain % summary and the transaction/trade/account/asset counts — through shared formatting.
- Output is identical below 1,000; commas appear only at 1,000+. The trends percentages already grouped via their own `Intl` formatter and are intentionally unchanged.
- Adds an end-to-end assertion (`+1,150.0%`) so the grouping can't silently regress.

Closes #350
