### PR TITLE
feat: localize number, currency, and date formatting

### DIFF
--- a/e2e/assets.test.ts
+++ b/e2e/assets.test.ts
@@ -246,6 +246,44 @@ test('assets table shows appreciation and depreciation for whole-value assets', 
 	]);
 });
 
+// Formatting follows the browser locale (navigator.language), independent of the
+// en/es UI language. Under de-DE the UI text stays English but numbers flip
+// separators: the gain renders as +1.150,0% instead of the en-US +1,150.0%.
+// See: https://github.com/fmaclen/canutin/issues/367
+test.describe('locale-aware formatting follows the browser locale', () => {
+	test.use({ locale: 'de-DE' });
+
+	test('gain percentage renders with German separators while UI stays English', async ({
+		page
+	}) => {
+		const user = await seedUser('ruth');
+
+		const gainAsset = await seedAsset({
+			name: 'Growth Portfolio',
+			balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
+			owner: user.id,
+			balanceType: 'Stock'
+		});
+		await seedAssetBalance({
+			asset: gainAsset.id,
+			owner: user.id,
+			asOf: new Date().toISOString(),
+			bookValue: 45000,
+			marketValue: 562500
+		});
+
+		await page.goto('/');
+		await signIn(page, user.email);
+		await goToPageViaSidebar(page, 'Assets');
+
+		await expect(page.getByRole('tab', { name: 'Owned' })).toBeVisible();
+
+		const growthPortfolioRow = page.getByRole('row', { name: 'Growth Portfolio' });
+		await expect(growthPortfolioRow).toBeVisible();
+		await expectAssetRowCells(growthPortfolioRow, [[6, '+1.150,0%']]);
+	});
+});
+
 test('user can add a new whole-valued asset', async ({ page }) => {
 	const user = await seedUser('liam');
 

--- a/e2e/transactions.filtering.test.ts
+++ b/e2e/transactions.filtering.test.ts
@@ -868,6 +868,60 @@ test('date range picker allows selecting custom range via calendar', async ({ pa
 	await expect(page.getByText('This Month Payment')).not.toBeVisible();
 });
 
+// Regression test for the date-range picker storing the wrong day for users ahead of
+// UTC. The picker builds the picked day in UTC field-space; a viewer in Asia/Tokyo
+// (UTC+9) picking day 10 must round-trip to periodFrom=...-10, not ...-09.
+test.describe('date range picker in a UTC+ timezone', () => {
+	test.use({ timezoneId: 'Asia/Tokyo' });
+
+	test('picked range round-trips to the same days', async ({ page }) => {
+		const user = await seedUser('tokyo');
+
+		const account = await seedAccount({
+			name: 'Tokyo Checking',
+			balanceGroup: AccountsBalanceGroupOptions.CASH,
+			owner: user.id,
+			balanceType: 'Checking'
+		});
+		await seedAccountBalance({
+			account: account.id,
+			owner: user.id,
+			asOf: new Date().toISOString(),
+			value: 5000
+		});
+
+		const now = new UTCDate();
+		const lastMonth = addMonths(startOfMonth(now), -1);
+		const lastMonthYear = lastMonth.getUTCFullYear();
+		const lastMonthIndex = lastMonth.getUTCMonth() + 1;
+		const pad = (value: number) => String(value).padStart(2, '0');
+		const expectedFrom = `${lastMonthYear}-${pad(lastMonthIndex)}-10`;
+		// End is exclusive: clicking day 20 (inclusive) stores the next UTC day, day 21.
+		const expectedTo = `${lastMonthYear}-${pad(lastMonthIndex)}-21`;
+
+		await seedTransaction({
+			account: account.id,
+			owner: user.id,
+			date: new UTCDate(lastMonthYear, lastMonth.getUTCMonth(), 15, 12, 0, 0, 0).toISOString(),
+			description: 'In Range Payment',
+			value: 200
+		});
+
+		await page.goto('/');
+		await signIn(page, user.email);
+		await goToPageViaSidebar(page, 'Transactions');
+
+		await page.getByLabel('Period').click();
+		await page.getByRole('button', { name: 'Previous' }).click();
+		await page.getByRole('button', { name: /10,/ }).first().click();
+		await page.getByRole('button', { name: /20,/ }).first().click();
+
+		await expect(page).toHaveURL(new RegExp(`periodFrom=${expectedFrom}`));
+		await expect(page).toHaveURL(new RegExp(`periodTo=${expectedTo}`));
+		await expect(page.getByText('In Range Payment')).toBeVisible();
+	});
+});
+
 test('switching from custom range back to preset clears custom URL params and updates transactions', async ({
 	page
 }) => {

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -6,6 +6,7 @@ import { SvelteMap } from 'svelte/reactivity';
 
 import { getAccountsContext, type AccountWithBalance } from './accounts.svelte';
 import { getAuthContext } from './auth.svelte';
+import { getFormattingLocale } from './interface-preferences.svelte';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 import { projectSignedValue } from './sharing';
@@ -390,7 +391,11 @@ class CashflowContext {
 				expenses: monthSums.expenses,
 				surplus: monthSums.income + monthSums.expenses,
 				isCurrentPeriod,
-				periodLabel: format(month, 'MMMM yyyy')
+				periodLabel: new Intl.DateTimeFormat(getFormattingLocale(), {
+					month: 'long',
+					year: 'numeric',
+					timeZone: 'UTC'
+				}).format(month)
 			});
 		}
 

--- a/src/lib/components/currency-field.svelte
+++ b/src/lib/components/currency-field.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { CurrencyInput, formatValue } from '@canutin/svelte-currency-input';
 
-	import { intlConfig } from './currency';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
+
+	import { getIntlConfig } from './currency';
 
 	interface Props {
 		id: string;
@@ -22,7 +24,7 @@
 	}: Props = $props();
 
 	const fieldIntlConfig = $derived(
-		isCurrency ? intlConfig : { locale: intlConfig.locale, style: 'decimal' as const }
+		isCurrency ? getIntlConfig() : { locale: getFormattingLocale(), style: 'decimal' as const }
 	);
 
 	const placeholder = $derived(

--- a/src/lib/components/currency.ts
+++ b/src/lib/components/currency.ts
@@ -1,7 +1,20 @@
 import { formatValue } from '@canutin/svelte-currency-input';
 
-export const intlConfig = { locale: 'en-US', currency: 'USD' };
+import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 
-export function formatCurrency(value: number | null | undefined, decimalScale = 0) {
-	return formatValue({ value: String(value ?? 0), intlConfig, decimalScale, roundValue: true });
+export function getIntlConfig(currency = 'USD') {
+	return { locale: getFormattingLocale(), currency };
+}
+
+export function formatCurrency(
+	value: number | null | undefined,
+	decimalScale = 0,
+	currency = 'USD'
+) {
+	return formatValue({
+		value: String(value ?? 0),
+		intlConfig: getIntlConfig(currency),
+		decimalScale,
+		roundValue: true
+	});
 }

--- a/src/lib/components/key-value.svelte
+++ b/src/lib/components/key-value.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Currency from '$lib/components/currency.svelte';
 	import Number from '$lib/components/number.svelte';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { formatPercent } from '$lib/utils';
 
 	type Variant = 'filled' | 'outline' | 'cash' | 'debt' | 'investment' | 'other';
@@ -41,7 +42,7 @@
 		{:else if format === 'percent'}
 			<Number value={formatPercent(value)} />
 		{:else if format === 'number'}
-			<Number value={value.toLocaleString('en-US')} />
+			<Number value={value.toLocaleString(getFormattingLocale())} />
 		{:else}
 			<Currency {value} {decimalScale} />
 		{/if}

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -3,6 +3,7 @@
 	import { Calendar as CalendarPrimitive } from 'bits-ui';
 	import type { Snippet } from 'svelte';
 
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
 	import type { ButtonVariant } from '../button/button.svelte';
@@ -16,7 +17,7 @@
 		weekdayFormat = 'short',
 		buttonVariant = 'ghost',
 		captionLayout = 'label',
-		locale = 'en-US',
+		locale = getFormattingLocale(),
 		months: monthsProp,
 		years,
 		monthFormat: monthFormatProp,

--- a/src/lib/components/ui/range-calendar/range-calendar.svelte
+++ b/src/lib/components/ui/range-calendar/range-calendar.svelte
@@ -4,6 +4,7 @@
 	import type { Snippet } from 'svelte';
 
 	import type { ButtonVariant } from '$lib/components/ui/button/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
 	import * as RangeCalendar from './index.js';
@@ -16,7 +17,7 @@
 		class: className,
 		buttonVariant = 'ghost',
 		captionLayout = 'label',
-		locale = 'en-US',
+		locale = getFormattingLocale(),
 		months: monthsProp,
 		years,
 		monthFormat: monthFormatProp,

--- a/src/lib/interface-preferences.svelte.ts
+++ b/src/lib/interface-preferences.svelte.ts
@@ -5,7 +5,14 @@ export const interfaceLocales = ['en', 'es'] as const;
 export type InterfaceLocale = (typeof interfaceLocales)[number];
 export type InterfaceThemeMode = 'system' | 'light' | 'dark';
 
-export const interfacePreferences = $state({ locale: 'en' as InterfaceLocale });
+export const interfacePreferences = $state({
+	locale: 'en' as InterfaceLocale,
+	formatLocale: 'en-US'
+});
+
+export function getFormattingLocale() {
+	return interfacePreferences.formatLocale;
+}
 
 function isInterfaceLocale(value: string | null | undefined): value is InterfaceLocale {
 	return value === 'en' || value === 'es';
@@ -59,6 +66,8 @@ export async function setInterfaceLocale(locale: InterfaceLocale) {
 }
 
 export async function initializeLocale() {
+	interfacePreferences.formatLocale = navigator.language || 'en-US';
+
 	const persistedLocale = readPersistedLocale();
 
 	if (persistedLocale) {

--- a/src/lib/security-balance-values.ts
+++ b/src/lib/security-balance-values.ts
@@ -1,13 +1,11 @@
 import { compareDesc } from 'date-fns';
 
+import { getFormattingLocale } from '$lib/interface-preferences.svelte';
+
 import { toNumber } from './utils';
 
-const quantityFormatter = new Intl.NumberFormat('en-US', {
-	maximumFractionDigits: 8
-});
-
 export function formatSecurityQuantity(value: number) {
-	return quantityFormatter.format(value);
+	return new Intl.NumberFormat(getFormattingLocale(), { maximumFractionDigits: 8 }).format(value);
 }
 
 export type SecurityBalanceValueInput = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+import { getFormattingLocale } from '$lib/interface-preferences.svelte';
+
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
@@ -14,7 +16,7 @@ export function toNumber(value: unknown) {
 
 export function formatPercent(value: number) {
 	const normalized = value === 0 ? 0 : value;
-	return `${normalized > 0 ? '+' : ''}${normalized.toLocaleString('en-US', {
+	return `${normalized > 0 ? '+' : ''}${normalized.toLocaleString(getFormattingLocale(), {
 		minimumFractionDigits: 1,
 		maximumFractionDigits: 1
 	})}%`;

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -29,6 +29,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import * as Table from '$lib/components/ui/table/index';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		AccountsBalanceGroupOptions,
@@ -84,7 +85,7 @@
 			)
 	);
 	const positionsMarketValue = $derived(sumOrUnknown(positionsRows.map((row) => row.value)));
-	const dateFormatter = new Intl.DateTimeFormat(undefined, {
+	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',

--- a/src/routes/(app)/accounts/[id]/balance-form.svelte
+++ b/src/routes/(app)/accounts/[id]/balance-form.svelte
@@ -4,6 +4,7 @@
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	interface Props {
@@ -33,7 +34,7 @@
 
 	const formattedAsOf = $derived(
 		parsedAsOf
-			? parsedAsOf.toLocaleDateString(undefined, {
+			? parsedAsOf.toLocaleDateString(getFormattingLocale(), {
 					year: 'numeric',
 					month: 'short',
 					day: 'numeric'
@@ -43,7 +44,7 @@
 
 	const fullAsOf = $derived(
 		parsedAsOf
-			? parsedAsOf.toLocaleString(undefined, {
+			? parsedAsOf.toLocaleString(getFormattingLocale(), {
 					year: 'numeric',
 					month: 'long',
 					day: 'numeric',

--- a/src/routes/(app)/assets/[id]/balance-form.svelte
+++ b/src/routes/(app)/assets/[id]/balance-form.svelte
@@ -4,6 +4,7 @@
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	interface Props {
@@ -27,7 +28,7 @@
 
 	const formattedAsOf = $derived(
 		parsedAsOf
-			? parsedAsOf.toLocaleDateString(undefined, {
+			? parsedAsOf.toLocaleDateString(getFormattingLocale(), {
 					year: 'numeric',
 					month: 'short',
 					day: 'numeric'
@@ -37,7 +38,7 @@
 
 	const fullAsOf = $derived(
 		parsedAsOf
-			? parsedAsOf.toLocaleString(undefined, {
+			? parsedAsOf.toLocaleString(getFormattingLocale(), {
 					year: 'numeric',
 					month: 'long',
 					day: 'numeric',

--- a/src/routes/(app)/big-picture/cashflow.svelte
+++ b/src/routes/(app)/big-picture/cashflow.svelte
@@ -7,6 +7,7 @@
 	import SectionTitle from '$lib/components/section-title.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 
 	const cashflow = getCashflowContext();
@@ -14,11 +15,17 @@
 
 	let hoveredIndex = $state<number | null>(null);
 
-	const monthFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', timeZone: 'UTC' });
-	const yearFormatter = new Intl.DateTimeFormat(undefined, { year: '2-digit', timeZone: 'UTC' });
+	const chartData = $derived.by(() => {
+		const monthFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
+			month: 'short',
+			timeZone: 'UTC'
+		});
+		const yearFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
+			year: '2-digit',
+			timeZone: 'UTC'
+		});
 
-	const chartData = $derived.by(() =>
-		periods.map((p) => {
+		return periods.map((p) => {
 			const isJanuary = p.month.getMonth() === 0;
 			const month = monthFormatter.format(p.month);
 			const periodFrom = format(p.month, 'yyyy-MM-dd');
@@ -29,8 +36,8 @@
 				label: isJanuary ? `${month} '${yearFormatter.format(p.month)}` : month,
 				transactionsUrl: `/transactions?periodFrom=${periodFrom}&periodTo=${periodTo}&periodLabel=${periodLabel}`
 			};
-		})
-	);
+		});
+	});
 
 	const chartRatios = $derived.by(() => {
 		if (!periods.length) {

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -22,6 +22,7 @@
 	import * as Table from '$lib/components/ui/table/index';
 	import { getImportSessionsContext } from '$lib/import-sessions.svelte';
 	import {
+		getFormattingLocale,
 		interfacePreferences,
 		setInterfaceLocale,
 		type InterfaceThemeMode
@@ -100,7 +101,7 @@
 	});
 
 	function formatDate(iso: string) {
-		return new Date(iso).toLocaleDateString(undefined, {
+		return new Date(iso).toLocaleDateString(getFormattingLocale(), {
 			year: 'numeric',
 			month: 'short',
 			day: 'numeric',

--- a/src/routes/(app)/trades/securities/[id]/+page.svelte
+++ b/src/routes/(app)/trades/securities/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import * as Table from '$lib/components/ui/table/index';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import {
@@ -60,7 +61,7 @@
 		accountsContext.accounts.filter((account) => !account.closed && account.canWrite)
 	);
 
-	const dateFormatter = new Intl.DateTimeFormat(undefined, {
+	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',

--- a/src/routes/(app)/trades/trades-filters.svelte
+++ b/src/routes/(app)/trades/trades-filters.svelte
@@ -3,7 +3,7 @@
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import type { DateRange } from 'bits-ui';
-	import { addDays, format, subDays } from 'date-fns';
+	import { addDays, subDays } from 'date-fns';
 
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import AccountPicker from '$lib/components/account-picker.svelte';
@@ -14,6 +14,7 @@
 	import * as Popover from '$lib/components/ui/popover/index.js';
 	import { RangeCalendar } from '$lib/components/ui/range-calendar/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { securityComboboxLabel, tradeTypeLabel } from '$lib/trade-display';
@@ -61,7 +62,13 @@
 	function formatCustomDateRange(from: Date, to: Date, label: string | null) {
 		if (label) return label;
 		const toInclusive = subDays(to, 1);
-		return `${format(from, 'MMM d, yyyy')} – ${format(toInclusive, 'MMM d, yyyy')}`;
+		const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+			timeZone: 'UTC'
+		});
+		return `${dateFormatter.format(from)} – ${dateFormatter.format(toInclusive)}`;
 	}
 
 	function handleSearchInput(event: Event) {
@@ -101,7 +108,7 @@
 	}
 
 	function dateValueToDate(dateValue: DateValue) {
-		return new Date(dateValue.year, dateValue.month - 1, dateValue.day);
+		return new Date(Date.UTC(dateValue.year, dateValue.month - 1, dateValue.day));
 	}
 
 	function handleCalendarChange(value: DateRange | undefined) {

--- a/src/routes/(app)/trades/trades-table.svelte
+++ b/src/routes/(app)/trades/trades-table.svelte
@@ -8,6 +8,7 @@
 	import RecordLink from '$lib/components/record-link.svelte';
 	import * as Pagination from '$lib/components/ui/pagination/index';
 	import * as Table from '$lib/components/ui/table/index';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { formatSecurityQuantity } from '$lib/security-balance-values';
 	import { tradeTypeLabel } from '$lib/trade-display';
@@ -21,7 +22,7 @@
 		await goto(resolve(`/trades/${id}?from=${encodeURIComponent(from)}`));
 	}
 
-	const dateFormatter = new Intl.DateTimeFormat(undefined, {
+	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',

--- a/src/routes/(app)/transactions/transaction-filters.svelte
+++ b/src/routes/(app)/transactions/transaction-filters.svelte
@@ -3,7 +3,7 @@
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import type { DateRange } from 'bits-ui';
-	import { addDays, format, subDays } from 'date-fns';
+	import { addDays, subDays } from 'date-fns';
 
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import AccountPicker from '$lib/components/account-picker.svelte';
@@ -14,6 +14,7 @@
 	import * as Popover from '$lib/components/ui/popover/index.js';
 	import { RangeCalendar } from '$lib/components/ui/range-calendar/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		getTransactionsContext,
@@ -61,7 +62,13 @@
 	function formatCustomDateRange(from: Date, to: Date, label: string | null): string {
 		if (label) return label;
 		const toInclusive = subDays(to, 1);
-		return `${format(from, 'MMM d, yyyy')} – ${format(toInclusive, 'MMM d, yyyy')}`;
+		const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+			timeZone: 'UTC'
+		});
+		return `${dateFormatter.format(from)} – ${dateFormatter.format(toInclusive)}`;
 	}
 
 	function handleSearchInput(e: Event) {
@@ -119,7 +126,7 @@
 	}
 
 	function dateValueToDate(dateValue: DateValue): Date {
-		return new Date(dateValue.year, dateValue.month - 1, dateValue.day);
+		return new Date(Date.UTC(dateValue.year, dateValue.month - 1, dateValue.day));
 	}
 
 	function handleCalendarChange(value: DateRange | undefined) {

--- a/src/routes/(app)/transactions/transaction-table.svelte
+++ b/src/routes/(app)/transactions/transaction-table.svelte
@@ -10,6 +10,7 @@
 	import * as Pagination from '$lib/components/ui/pagination/index';
 	import * as Table from '$lib/components/ui/table/index';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { getTransactionsContext } from '$lib/transactions.svelte';
 	import { cn } from '$lib/utils.js';
@@ -26,7 +27,7 @@
 		txContext.setSort(column);
 	}
 
-	const dateFormatter = new Intl.DateTimeFormat(undefined, {
+	const dateFormatter = new Intl.DateTimeFormat(getFormattingLocale(), {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',

--- a/src/routes/(app)/trends/performance.svelte
+++ b/src/routes/(app)/trends/performance.svelte
@@ -6,6 +6,7 @@
 	import { Skeleton } from '$lib/components/ui/skeleton/index';
 	import * as Table from '$lib/components/ui/table/index';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import type {
 		AccountBalancesResponse,
@@ -313,7 +314,7 @@
 
 	function formatPercent(v: number | null) {
 		if (v === null) return '~';
-		return new Intl.NumberFormat('en-US', {
+		return new Intl.NumberFormat(getFormattingLocale(), {
 			style: 'percent',
 			maximumFractionDigits: 1,
 			signDisplay: 'exceptZero'


### PR DESCRIPTION
- Adds a format-locale axis (`getFormattingLocale()`, defaulting to the browser's `navigator.language` and independent of the en/es UI language) and routes every number, currency, percentage, and date formatter through it instead of a hardcoded `en-US`.
- Makes `formatCurrency` accept an optional currency code (USD default), so multi-currency becomes a data change later rather than another formatting refactor.
- Converts the three user-facing `date-fns` labels to `Intl` with `timeZone: 'UTC'`, matching the app's "dates are UTC calendar dates rendered the same day for everyone" model; en-US output is byte-identical — only non-English locales change.
- Also fixes a pre-existing bug where the date-range pickers built local-midnight dates and stored the wrong day for users ahead of UTC; they now use `Date.UTC(...)` like the rest of the codebase.
- Adds e2e coverage: a `de-DE` browser locale renders `+1.150,0%` while the UI stays English (proving the format axis is decoupled from the language toggle), and an `Asia/Tokyo` timezone test pins the date-picker round-trip.

Closes #367
