### PR TITLE
feat: seed securities and trades in the demo

### DIFF
--- a/e2e/demo-seed.test.ts
+++ b/e2e/demo-seed.test.ts
@@ -15,4 +15,16 @@ test('/demo route seeds data and displays net worth', async ({ page }) => {
 	await expect(page.getByRole('region', { name: 'Investments' })).toBeVisible();
 	await expect(page.getByRole('region', { name: 'Debt' })).toBeVisible();
 	await expect(page.getByRole('region', { name: 'Other assets' })).toBeVisible();
+
+	// Seeded trades are visible under the default "last 3 months" filter
+	await page.goto('/trades');
+	await expect(page.getByText('Sold GameStop')).toBeVisible({ timeout: 30_000 });
+	await expect(page.getByText('Bought SPDR S&P 500').first()).toBeVisible();
+	await expect(page.getByText('Bought Bitcoin').first()).toBeVisible();
+	await expect(page.getByText('Bought Ethereum').first()).toBeVisible();
+
+	// Portfolio shows the seeded holdings
+	await page.goto('/portfolio');
+	await expect(page.getByText('SPDR S&P 500 ETF Trust')).toBeVisible({ timeout: 30_000 });
+	await expect(page.getByText('Bitcoin')).toBeVisible();
 });

--- a/e2e/demo-seed.test.ts
+++ b/e2e/demo-seed.test.ts
@@ -18,13 +18,13 @@ test('/demo route seeds data and displays net worth', async ({ page }) => {
 
 	// Seeded trades are visible under the default "last 3 months" filter
 	await page.goto('/trades');
-	await expect(page.getByText('Sold GameStop')).toBeVisible({ timeout: 30_000 });
+	await expect(page.getByText('Sold GameStop')).toBeVisible();
 	await expect(page.getByText('Bought SPDR S&P 500').first()).toBeVisible();
 	await expect(page.getByText('Bought Bitcoin').first()).toBeVisible();
 	await expect(page.getByText('Bought Ethereum').first()).toBeVisible();
 
 	// Portfolio shows the seeded holdings
 	await page.goto('/portfolio');
-	await expect(page.getByText('SPDR S&P 500 ETF Trust')).toBeVisible({ timeout: 30_000 });
+	await expect(page.getByText('SPDR S&P 500 ETF Trust')).toBeVisible();
 	await expect(page.getByText('Bitcoin')).toBeVisible();
 });

--- a/src/lib/demo/seed-data/accounts.ts
+++ b/src/lib/demo/seed-data/accounts.ts
@@ -63,6 +63,14 @@ export const ACCOUNT_WALLET: AccountDefinition = {
 	isAutoCalculated: false
 };
 
+export const ACCOUNT_CRYPTO_BROKERAGE: AccountDefinition = {
+	name: "Alice's Crypto Brokerage",
+	balanceGroup: AccountsBalanceGroupOptions.INVESTMENT,
+	balanceType: 'Crypto',
+	institution: 'Coinpurse',
+	isAutoCalculated: false
+};
+
 export const ALL_ACCOUNTS = [
 	ACCOUNT_CHECKING,
 	ACCOUNT_SAVINGS,
@@ -70,5 +78,6 @@ export const ALL_ACCOUNTS = [
 	ACCOUNT_AUTO_LOAN,
 	ACCOUNT_ROTH_IRA,
 	ACCOUNT_401K,
-	ACCOUNT_WALLET
+	ACCOUNT_WALLET,
+	ACCOUNT_CRYPTO_BROKERAGE
 ];

--- a/src/lib/demo/seed-data/assets.ts
+++ b/src/lib/demo/seed-data/assets.ts
@@ -16,25 +16,5 @@ export const ALL_ASSETS: AssetDefinition[] = [
 		name: '1998 Fiat Multipla',
 		balanceGroup: AssetsBalanceGroupOptions.OTHER,
 		balanceType: 'Vehicle'
-	},
-	{
-		name: 'SPDR S&P 500 ETF Trust',
-		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
-		balanceType: 'Security'
-	},
-	{
-		name: 'GameStop',
-		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
-		balanceType: 'Security'
-	},
-	{
-		name: 'Bitcoin',
-		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
-		balanceType: 'Cryptocurrency'
-	},
-	{
-		name: 'Ethereum',
-		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
-		balanceType: 'Cryptocurrency'
 	}
 ];

--- a/src/lib/demo/seed-data/balances.ts
+++ b/src/lib/demo/seed-data/balances.ts
@@ -86,50 +86,6 @@ export function generateWalletBalances(referenceDate: Date) {
 	];
 }
 
-export function generateSpyBalances(referenceDate: Date) {
-	return [
-		{ asOf: monthsAgo(0, referenceDate), marketValue: 29000 },
-		{ asOf: monthsAgo(1, referenceDate), marketValue: 28500 },
-		{ asOf: monthsAgo(3, referenceDate), marketValue: 27750 },
-		{ asOf: monthsAgo(6, referenceDate), marketValue: 26500 },
-		{ asOf: monthsAgo(9, referenceDate), marketValue: 25500 },
-		{ asOf: monthsAgo(12, referenceDate), marketValue: 24500 },
-		{ asOf: monthsAgo(18, referenceDate), marketValue: 22500 }
-	];
-}
-
-export function generateGamestopBalances(referenceDate: Date) {
-	return [
-		{ asOf: monthsAgo(0, referenceDate), marketValue: 3125 },
-		{ asOf: monthsAgo(1, referenceDate), marketValue: 12500 },
-		{ asOf: monthsAgo(2, referenceDate), marketValue: 40625 },
-		{ asOf: monthsAgo(4, referenceDate), marketValue: 37500 },
-		{ asOf: monthsAgo(6, referenceDate), marketValue: 12500 },
-		{ asOf: monthsAgo(10, referenceDate), marketValue: 6250 },
-		{ asOf: monthsAgo(13, referenceDate), marketValue: 3125 }
-	];
-}
-
-export function generateBitcoinBalances(referenceDate: Date) {
-	return [
-		{ asOf: monthsAgo(0, referenceDate), marketValue: 69420 },
-		{ asOf: monthsAgo(1, referenceDate), marketValue: 60900 },
-		{ asOf: monthsAgo(5, referenceDate), marketValue: 43225 },
-		{ asOf: monthsAgo(7, referenceDate), marketValue: 48840 },
-		{ asOf: monthsAgo(13, referenceDate), marketValue: 18948.75 }
-	];
-}
-
-export function generateEthereumBalances(referenceDate: Date) {
-	return [
-		{ asOf: monthsAgo(0, referenceDate), marketValue: 17500 },
-		{ asOf: monthsAgo(3, referenceDate), marketValue: 8250 },
-		{ asOf: monthsAgo(9, referenceDate), marketValue: 5400 },
-		{ asOf: monthsAgo(11, referenceDate), marketValue: 2250 },
-		{ asOf: monthsAgo(17, referenceDate), marketValue: 2625 }
-	];
-}
-
 export function generateCollectibleBalances(referenceDate: Date) {
 	return [
 		{ asOf: monthsAgo(6, referenceDate), marketValue: 14500 },

--- a/src/lib/demo/seed-data/securities.ts
+++ b/src/lib/demo/seed-data/securities.ts
@@ -1,0 +1,208 @@
+import { subDays } from 'date-fns';
+
+import { SecurityTransactionsTypeOptions } from '$lib/pocketbase.schema';
+
+import { ACCOUNT_401K, ACCOUNT_CRYPTO_BROKERAGE, ACCOUNT_ROTH_IRA } from './accounts';
+
+export interface DemoSecurity {
+	name: string;
+	symbol: string;
+	account: string;
+}
+
+export interface DemoSecurityBalance {
+	asOf: string;
+	quantity: number;
+	price: number;
+	value: number;
+	costBasis: number;
+}
+
+export interface DemoTrade {
+	date: string;
+	type: SecurityTransactionsTypeOptions;
+	description: string;
+	quantity?: number;
+	price?: number;
+	amount?: number;
+	fees?: number;
+}
+
+const SECURITY_SPY = 'SPDR S&P 500 ETF Trust';
+const SECURITY_GAMESTOP = 'GameStop';
+const SECURITY_BITCOIN = 'Bitcoin';
+const SECURITY_ETHEREUM = 'Ethereum';
+
+export const ALL_SECURITIES: DemoSecurity[] = [
+	{ name: SECURITY_SPY, symbol: 'SPY', account: ACCOUNT_401K.name },
+	{ name: SECURITY_GAMESTOP, symbol: 'GME', account: ACCOUNT_ROTH_IRA.name },
+	{ name: SECURITY_BITCOIN, symbol: 'BTC', account: ACCOUNT_CRYPTO_BROKERAGE.name },
+	{ name: SECURITY_ETHEREUM, symbol: 'ETH', account: ACCOUNT_CRYPTO_BROKERAGE.name }
+];
+
+interface SeriesTrade {
+	daysAgo: number;
+	type: SecurityTransactionsTypeOptions;
+	quantity: number;
+	price: number;
+	fees: number;
+}
+
+interface SeriesSnapshot {
+	daysAgo: number;
+	price: number;
+}
+
+interface SecuritySeries {
+	trades: SeriesTrade[];
+	// Market prices used to value the position at each balance snapshot. The
+	// daysAgo: 0 price multiplied by the net held quantity must equal the
+	// pinned latest value asserted by e2e/demo-seed.test.ts.
+	snapshots: SeriesSnapshot[];
+}
+
+const BUY = SecurityTransactionsTypeOptions.buy;
+const SELL = SecurityTransactionsTypeOptions.sell;
+
+// Every trade lands within the last ~45 days so it stays visible under the
+// trades ledger's default "last 3 months" filter for any run date. The stories
+// and net quantities are unchanged - only the dates are compressed.
+const SECURITY_SERIES: Record<string, SecuritySeries> = {
+	// Dollar-cost-averaging into the index. Net 50 shares.
+	// Latest: 50 x 580 = 29,000.
+	[SECURITY_SPY]: {
+		trades: [
+			{ daysAgo: 45, type: BUY, quantity: 20, price: 450, fees: 5 },
+			{ daysAgo: 30, type: BUY, quantity: 15, price: 490, fees: 5 },
+			{ daysAgo: 15, type: BUY, quantity: 10, price: 530, fees: 5 },
+			{ daysAgo: 5, type: BUY, quantity: 5, price: 565, fees: 5 }
+		],
+		snapshots: [
+			{ daysAgo: 45, price: 450 },
+			{ daysAgo: 30, price: 490 },
+			{ daysAgo: 15, price: 530 },
+			{ daysAgo: 7, price: 555 },
+			{ daysAgo: 5, price: 565 },
+			{ daysAgo: 0, price: 580 }
+		]
+	},
+	// The meme story: buy in, sell a big chunk near the peak for a fat realized
+	// gain, then re-buy after the crash. Net 125 shares.
+	// Latest: 125 x 25 = 3,125.
+	[SECURITY_GAMESTOP]: {
+		trades: [
+			{ daysAgo: 45, type: BUY, quantity: 200, price: 40, fees: 10 },
+			{ daysAgo: 35, type: SELL, quantity: 100, price: 325, fees: 25 },
+			{ daysAgo: 10, type: BUY, quantity: 25, price: 28, fees: 5 }
+		],
+		snapshots: [
+			{ daysAgo: 45, price: 40 },
+			{ daysAgo: 35, price: 325 },
+			{ daysAgo: 20, price: 90 },
+			{ daysAgo: 10, price: 28 },
+			{ daysAgo: 3, price: 24 },
+			{ daysAgo: 0, price: 25 }
+		]
+	},
+	// Initial buy plus a buy-the-dip. Net 0.75 BTC.
+	// Latest: 0.75 x 92,560 = 69,420.
+	[SECURITY_BITCOIN]: {
+		trades: [
+			{ daysAgo: 40, type: BUY, quantity: 0.5, price: 35000, fees: 20 },
+			{ daysAgo: 12, type: BUY, quantity: 0.25, price: 44000, fees: 15 }
+		],
+		snapshots: [
+			{ daysAgo: 40, price: 35000 },
+			{ daysAgo: 25, price: 51000 },
+			{ daysAgo: 12, price: 44000 },
+			{ daysAgo: 4, price: 84000 },
+			{ daysAgo: 0, price: 92560 }
+		]
+	},
+	// Initial buy plus a follow-up buy. Net 5 ETH.
+	// Latest: 5 x 3,500 = 17,500.
+	[SECURITY_ETHEREUM]: {
+		trades: [
+			{ daysAgo: 42, type: BUY, quantity: 3, price: 1800, fees: 10 },
+			{ daysAgo: 18, type: BUY, quantity: 2, price: 2400, fees: 10 }
+		],
+		snapshots: [
+			{ daysAgo: 42, price: 1800 },
+			{ daysAgo: 30, price: 1500 },
+			{ daysAgo: 18, price: 2400 },
+			{ daysAgo: 8, price: 2900 },
+			{ daysAgo: 0, price: 3500 }
+		]
+	}
+};
+
+const SECURITY_LABELS: Record<string, string> = {
+	[SECURITY_SPY]: 'SPDR S&P 500',
+	[SECURITY_GAMESTOP]: 'GameStop',
+	[SECURITY_BITCOIN]: 'Bitcoin',
+	[SECURITY_ETHEREUM]: 'Ethereum'
+};
+
+function toISODate(date: Date) {
+	return date.toISOString().split('T')[0];
+}
+
+function daysAgo(days: number, referenceDate: Date) {
+	return toISODate(subDays(referenceDate, days));
+}
+
+function roundToCents(value: number) {
+	return Math.round(value * 100) / 100;
+}
+
+export function generateSecurityBalances(name: string, referenceDate: Date) {
+	const series = SECURITY_SERIES[name];
+
+	return series.snapshots.map(({ daysAgo: days, price }) => {
+		// Trades up to (and including) this snapshot, oldest first.
+		const tradesToDate = series.trades
+			.filter((trade) => trade.daysAgo >= days)
+			.sort((a, b) => b.daysAgo - a.daysAgo);
+
+		// Fold trades chronologically. A sell reduces the held cost basis by the
+		// average cost of the shares sold, so the remaining position keeps a
+		// realistic (non-negative) cost basis even after a profitable sale.
+		let quantity = 0;
+		let costBasis = 0;
+		for (const trade of tradesToDate) {
+			if (trade.type === BUY) {
+				quantity += trade.quantity;
+				costBasis += trade.quantity * trade.price;
+			} else {
+				const averageCost = quantity > 0 ? costBasis / quantity : 0;
+				quantity -= trade.quantity;
+				costBasis -= trade.quantity * averageCost;
+			}
+		}
+
+		quantity = roundToCents(quantity);
+
+		return {
+			asOf: daysAgo(days, referenceDate),
+			quantity,
+			price,
+			value: roundToCents(quantity * price),
+			costBasis: roundToCents(costBasis)
+		};
+	});
+}
+
+export function generateSecurityTrades(name: string, referenceDate: Date) {
+	const series = SECURITY_SERIES[name];
+	const label = SECURITY_LABELS[name];
+
+	return series.trades.map((trade) => ({
+		date: daysAgo(trade.daysAgo, referenceDate),
+		type: trade.type,
+		description: `${trade.type === BUY ? 'Bought' : 'Sold'} ${label}`,
+		quantity: trade.quantity,
+		price: trade.price,
+		amount: roundToCents(trade.quantity * trade.price),
+		fees: trade.fees
+	}));
+}

--- a/src/lib/demo/seed.ts
+++ b/src/lib/demo/seed.ts
@@ -15,17 +15,18 @@ import { ALL_ASSETS } from './seed-data/assets';
 import {
 	generate401kBalances,
 	generateAutoLoanBalances,
-	generateBitcoinBalances,
 	generateCollectibleBalances,
-	generateEthereumBalances,
-	generateGamestopBalances,
 	generateRothIraBalances,
-	generateSpyBalances,
 	generateVehicleBalances,
 	generateWalletBalances,
 	type AccountBalanceDefinition,
 	type AssetBalanceDefinition
 } from './seed-data/balances';
+import {
+	ALL_SECURITIES,
+	generateSecurityBalances,
+	generateSecurityTrades
+} from './seed-data/securities';
 import {
 	generateCheckingTransactions,
 	generateCreditCardTransactions,
@@ -297,30 +298,50 @@ export async function seedDemoData(pb: TypedPocketBase, userId: string) {
 		assetIds['1998 Fiat Multipla'],
 		userId
 	);
-	await createAssetBalances(
-		pb,
-		generateSpyBalances(referenceDate),
-		assetIds['SPDR S&P 500 ETF Trust'],
-		userId
-	);
-	await createAssetBalances(
-		pb,
-		generateGamestopBalances(referenceDate),
-		assetIds['GameStop'],
-		userId
-	);
-	await createAssetBalances(
-		pb,
-		generateBitcoinBalances(referenceDate),
-		assetIds['Bitcoin'],
-		userId
-	);
-	await createAssetBalances(
-		pb,
-		generateEthereumBalances(referenceDate),
-		assetIds['Ethereum'],
-		userId
-	);
+
+	// Create securities with their positions and trades (sequentially)
+	const securityIds: IdMap = {};
+	for (const security of ALL_SECURITIES) {
+		const created = await pb.collection('securities').create({
+			name: security.name,
+			symbol: security.symbol,
+			owner: userId
+		});
+		securityIds[security.name] = created.id;
+	}
+
+	for (const security of ALL_SECURITIES) {
+		const accountId = accountIds[security.account];
+		const securityId = securityIds[security.name];
+
+		await runInBatches(generateSecurityBalances(security.name, referenceDate), (balance) =>
+			pb.collection('securityBalances').create({
+				account: accountId,
+				security: securityId,
+				owner: userId,
+				asOf: balance.asOf,
+				quantity: balance.quantity,
+				price: balance.price,
+				value: balance.value,
+				costBasis: balance.costBasis
+			})
+		);
+
+		await runInBatches(generateSecurityTrades(security.name, referenceDate), (trade) =>
+			pb.collection('securityTransactions').create({
+				account: accountId,
+				security: securityId,
+				owner: userId,
+				date: trade.date,
+				type: trade.type,
+				description: trade.description,
+				quantity: trade.quantity,
+				price: trade.price,
+				amount: trade.amount,
+				fees: trade.fees
+			})
+		);
+	}
 
 	// Wait for Go hooks to finish calculating balances for auto-calculated accounts
 	const autoCalculatedAccountIds = AUTO_CALCULATED_ACCOUNTS.map((a) => accountIds[a.name]);


### PR DESCRIPTION
- Seed SPY, GameStop, Bitcoin and Ethereum as real securities (positions + trades) instead of standalone assets, so the demo exercises the securities, portfolio, and trades pages.
- Hold SPY in Bob's 401k, GameStop in Alice's Roth IRA, and Bitcoin/Ethereum in a new "Alice's Crypto Brokerage" account.
- Give each security a multi-trade history (dollar-cost-averaging, a GameStop sell-the-peak story, crypto buy-the-dip) dated within the last three months so every trade is visible under the trades ledger's default filter.
- Remove the four instruments from the demo assets and keep the investment accounts' manual cash, so total net worth is unchanged ($184,719).
- Extend e2e/demo-seed.test.ts to assert the seeded trades and portfolio holdings actually render.

No linked issue