### PR TITLE
fix: enforce parent ownership for cash and balance writes

### DIFF
--- a/e2e/ownership-security.test.ts
+++ b/e2e/ownership-security.test.ts
@@ -1,0 +1,166 @@
+import { expect, test } from '@playwright/test';
+
+import {
+	AccountsBalanceGroupOptions,
+	AssetsBalanceGroupOptions
+} from '../src/lib/pocketbase.schema';
+import {
+	getUserPB,
+	pbSend,
+	resetDatabase,
+	seedAccount,
+	seedAsset,
+	seedTransaction,
+	seedUser
+} from './pocketbase.helpers';
+
+async function latestAccountBalance(email: string, accountId: string) {
+	const pb = await getUserPB(email);
+	const balances = await pb.collection('accountBalances').getList(1, 1, {
+		filter: `account = "${accountId}"`,
+		sort: '-asOf,-created'
+	});
+	return balances.items[0]?.value ?? null;
+}
+
+test.beforeEach(async () => {
+	await resetDatabase();
+});
+
+test('rejects foreign-parent writes and preserves owner balance', async () => {
+	const alice = await seedUser('alice');
+	const bob = await seedUser('bob');
+
+	const aliceAccount = await seedAccount({
+		name: 'Alice Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: alice.id,
+		balanceType: 'Checking',
+		autoCalculated: new Date().toISOString()
+	});
+	const aliceAsset = await seedAsset({
+		name: 'Alice Collectible',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: alice.id,
+		balanceType: 'Collectible'
+	});
+
+	await seedTransaction({
+		account: aliceAccount.id,
+		owner: alice.id,
+		date: new Date().toISOString(),
+		description: 'Opening deposit',
+		value: 1000
+	});
+	await expect.poll(async () => latestAccountBalance(alice.email, aliceAccount.id)).toBe(1000);
+	const balanceBeforeAttack = await latestAccountBalance(alice.email, aliceAccount.id);
+
+	const foreignTransaction = await pbSend(
+		'/api/collections/transactions/records',
+		{
+			owner: bob.id,
+			account: aliceAccount.id,
+			date: new Date().toISOString(),
+			description: 'Injected debit',
+			value: -999999
+		},
+		bob.email
+	);
+	expect(foreignTransaction.ok).toBe(false);
+	expect(foreignTransaction.status).toBe(400);
+
+	const foreignAccountBalance = await pbSend(
+		'/api/collections/accountBalances/records',
+		{
+			owner: bob.id,
+			account: aliceAccount.id,
+			asOf: new Date().toISOString(),
+			value: 500000
+		},
+		bob.email
+	);
+	expect(foreignAccountBalance.ok).toBe(false);
+	expect(foreignAccountBalance.status).toBe(400);
+
+	const foreignAssetBalance = await pbSend(
+		'/api/collections/assetBalances/records',
+		{
+			owner: bob.id,
+			asset: aliceAsset.id,
+			asOf: new Date().toISOString(),
+			bookValue: 500000,
+			marketValue: 500000
+		},
+		bob.email
+	);
+	expect(foreignAssetBalance.ok).toBe(false);
+	expect(foreignAssetBalance.status).toBe(400);
+
+	expect(await latestAccountBalance(alice.email, aliceAccount.id)).toBe(balanceBeforeAttack);
+});
+
+test('rejects reparenting a transaction to a foreign account or changing its owner', async () => {
+	const carol = await seedUser('carol');
+	const dave = await seedUser('dave');
+
+	const carolAccount = await seedAccount({
+		name: 'Carol Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: carol.id,
+		balanceType: 'Checking',
+		autoCalculated: new Date().toISOString()
+	});
+	const daveAccount = await seedAccount({
+		name: 'Dave Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: dave.id,
+		balanceType: 'Checking'
+	});
+
+	const transaction = await seedTransaction({
+		account: carolAccount.id,
+		owner: carol.id,
+		date: new Date().toISOString(),
+		description: 'Paycheck',
+		value: 2500
+	});
+	await expect.poll(async () => latestAccountBalance(carol.email, carolAccount.id)).toBe(2500);
+	const balanceBeforeAttack = await latestAccountBalance(carol.email, carolAccount.id);
+
+	const carolPB = await getUserPB(carol.email);
+	const reparent = carolPB
+		.collection('transactions')
+		.update(transaction.id, { account: daveAccount.id });
+	await expect(reparent).rejects.toMatchObject({ status: 404 });
+
+	const changeOwner = carolPB.collection('transactions').update(transaction.id, { owner: dave.id });
+	await expect(changeOwner).rejects.toMatchObject({ status: 403 });
+
+	expect(await latestAccountBalance(carol.email, carolAccount.id)).toBe(balanceBeforeAttack);
+});
+
+test('owner can create a transaction on their own account', async () => {
+	const erin = await seedUser('erin');
+
+	const account = await seedAccount({
+		name: 'Erin Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: erin.id,
+		balanceType: 'Checking',
+		autoCalculated: new Date().toISOString()
+	});
+
+	const response = await pbSend(
+		'/api/collections/transactions/records',
+		{
+			owner: erin.id,
+			account: account.id,
+			date: new Date().toISOString(),
+			description: 'Grocery run',
+			value: -80
+		},
+		erin.email
+	);
+	expect(response.ok).toBe(true);
+	await expect.poll(async () => latestAccountBalance(erin.email, account.id)).toBe(-80);
+});

--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -57,9 +57,10 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 		return
 	}
 
+	owner := account.GetString("owner")
 	transactions, err := app.FindRecordsByFilter(
-		"transactions", "account = {:aid}", "", 0, 0,
-		map[string]any{"aid": accountID},
+		"transactions", "account = {:aid} && owner = {:owner}", "", 0, 0,
+		map[string]any{"aid": accountID, "owner": owner},
 	)
 	if err != nil {
 		log.Printf("Failed to fetch transactions for account %s: %v", accountID, err)

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -127,6 +127,26 @@ func main() {
 		return e.Next()
 	})
 
+	app.OnRecordValidate("transactions", "accountBalances").BindFunc(func(e *core.RecordEvent) error {
+		if err := validateSecurityOwnerImmutable(e.Record); err != nil {
+			return err
+		}
+		if err := validateParentOwner(e.App, e.Record, "accounts", "account"); err != nil {
+			return err
+		}
+		return e.Next()
+	})
+
+	app.OnRecordValidate("assetBalances").BindFunc(func(e *core.RecordEvent) error {
+		if err := validateSecurityOwnerImmutable(e.Record); err != nil {
+			return err
+		}
+		if err := validateParentOwner(e.App, e.Record, "assets", "asset"); err != nil {
+			return err
+		}
+		return e.Next()
+	})
+
 	app.OnRecordAfterCreateSuccess("transactions").BindFunc(func(e *core.RecordEvent) error {
 		if aid := e.Record.GetString("account"); aid != "" {
 			enqueueBalance(aid)

--- a/pocketbase/pb_migrations/1781972344_updated_transactions.js
+++ b/pocketbase/pb_migrations/1781972344_updated_transactions.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3174063690")
+
+  // update collection data
+  unmarshal({
+    "createRule": "@request.auth.id != \"\" && owner = @request.auth.id && account.owner = @request.auth.id",
+    "updateRule": "@request.auth.id != \"\" && owner = @request.auth.id && account.owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3174063690")
+
+  // update collection data
+  unmarshal({
+    "createRule": "owner = @request.auth.id",
+    "updateRule": "owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/pocketbase/pb_migrations/1781972345_updated_accountBalances.js
+++ b/pocketbase/pb_migrations/1781972345_updated_accountBalances.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // update collection data
+  unmarshal({
+    "createRule": "@request.auth.id != \"\" && owner = @request.auth.id && account.owner = @request.auth.id",
+    "updateRule": "@request.auth.id != \"\" && owner = @request.auth.id && account.owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // update collection data
+  unmarshal({
+    "createRule": "owner = @request.auth.id",
+    "updateRule": "owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/pocketbase/pb_migrations/1781972345_updated_assetBalances.js
+++ b/pocketbase/pb_migrations/1781972345_updated_assetBalances.js
@@ -1,0 +1,22 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1178802947")
+
+  // update collection data
+  unmarshal({
+    "createRule": "@request.auth.id != \"\" && owner = @request.auth.id && asset.owner = @request.auth.id",
+    "updateRule": "@request.auth.id != \"\" && owner = @request.auth.id && asset.owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1178802947")
+
+  // update collection data
+  unmarshal({
+    "createRule": "owner = @request.auth.id",
+    "updateRule": "owner = @request.auth.id"
+  }, collection)
+
+  return app.save(collection)
+})

--- a/pocketbase/security.go
+++ b/pocketbase/security.go
@@ -175,6 +175,14 @@ func validateSecurityOwnerImmutable(record *core.Record) error {
 	return nil
 }
 
+func validateParentOwner(app core.App, record *core.Record, parentCollection, relationField string) error {
+	parent, err := app.FindRecordById(parentCollection, record.GetString(relationField))
+	if err != nil || parent.GetString("owner") != record.GetString("owner") {
+		return apis.NewNotFoundError(relationField+" not found", nil)
+	}
+	return nil
+}
+
 func validateOptionalJSONNumbers(record *core.Record, fields ...string) error {
 	for _, field := range fields {
 		if _, _, err := optionalJSONNumber(record, field); err != nil {


### PR DESCRIPTION
- Validate parent ownership on create and update for transactions, account balances, and asset balances, so a user cannot attach an owned child record to another user's account or asset
- Block changing a record's owner after it is created
- Add a second enforcement layer by tightening the collection create/update API rules, while leaving shared-account read access intact
- Harden balance recalculation to ignore owner-mismatched transactions so stale bad rows cannot corrupt a derived balance
- Add end-to-end regression coverage for foreign-parent writes, reparenting, owner changes, and balance preservation

No linked issue (confirmed by user)