### PR TITLE
fix: make import account resolution deterministic

### DIFF
--- a/e2e/import.securities.test.ts
+++ b/e2e/import.securities.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
-import { getUserPB, pbSend, seedUser } from './pocketbase.helpers';
+import { getUserPB, pbSend, seedAccount, seedUser } from './pocketbase.helpers';
 
 const IMPORT_PATH = '/api/canutin/import';
 const REVERT_PATH = '/api/canutin/import/revert';
@@ -342,4 +342,145 @@ test('reverting an import deletes securities, balances, and transactions', async
 
 	const session = await pb.collection('importSessions').getOne(result.sessionId);
 	expect(session.status).toBe('rolled_back');
+});
+
+test('security balance with a foreign accountId is rejected for ownership', async () => {
+	const owner = await seedUser('grace');
+	const intruder = await seedUser('gregory');
+	const ownerAccount = await seedAccount({
+		name: 'Grace Brokerage',
+		balanceGroup: 'INVESTMENT',
+		balanceType: 'Brokerage',
+		owner: owner.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'gregory-foreign-balance',
+				securityBalances: [
+					{
+						accountId: ownerAccount.id,
+						accountName: 'Grace Brokerage',
+						securityName: 'Apple Inc',
+						securitySymbol: 'AAPL',
+						asOf: '2025-06-15T00:00:00.000Z',
+						quantity: 5,
+						price: 100,
+						value: 500,
+						costBasis: 450
+					}
+				]
+			},
+			intruder.email
+		)
+	).json();
+	expect(result.status).toBe('failed');
+	expect(result.recordsFailed).toBe(1);
+	expect(result.securityBalances.created).toBe(0);
+
+	const ownerPB = await getUserPB(owner.email);
+	const onOwnerAccount = await ownerPB.collection('securityBalances').getFullList({
+		filter: `account = "${ownerAccount.id}"`
+	});
+	expect(onOwnerAccount.length).toBe(0);
+
+	const intruderPB = await getUserPB(intruder.email);
+	const intruderBalances = await intruderPB.collection('securityBalances').getFullList({
+		filter: `owner = "${intruder.id}"`
+	});
+	expect(intruderBalances.length).toBe(0);
+});
+
+test('ambiguous account name in a security transaction becomes a row error', async () => {
+	const user = await seedUser('greta');
+	await seedAccount({
+		name: 'Brokerage',
+		institution: 'Fidelity',
+		balanceGroup: 'INVESTMENT',
+		balanceType: 'Brokerage',
+		owner: user.id
+	});
+	await seedAccount({
+		name: 'Brokerage',
+		institution: 'Schwab',
+		balanceGroup: 'INVESTMENT',
+		balanceType: 'Brokerage',
+		owner: user.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'greta-ambiguous-trade',
+				securityTransactions: [
+					{
+						accountName: 'Brokerage',
+						securityName: 'Tesla Inc',
+						securitySymbol: 'TSLA',
+						date: '2025-06-10T00:00:00.000Z',
+						type: 'buy',
+						description: 'Bought Tesla shares',
+						quantity: 2,
+						price: 250,
+						amount: 500
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('failed');
+	expect(result.recordsFailed).toBe(1);
+	expect(result.securityTransactions.created).toBe(0);
+
+	const pb = await getUserPB(user.email);
+	const trades = await pb.collection('securityTransactions').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(trades.length).toBe(0);
+});
+
+test('security balance with a unique account name resolves to that account', async () => {
+	const user = await seedUser('gerald');
+	const brokerage = await seedAccount({
+		name: 'Gerald Brokerage',
+		balanceGroup: 'INVESTMENT',
+		balanceType: 'Brokerage',
+		owner: user.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'gerald-unique-balance',
+				securityBalances: [
+					{
+						accountName: 'Gerald Brokerage',
+						securityName: 'Apple Inc',
+						securitySymbol: 'AAPL',
+						asOf: '2025-06-15T00:00:00.000Z',
+						quantity: 5,
+						price: 100,
+						value: 500,
+						costBasis: 450
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.recordsFailed).toBe(0);
+	expect(result.securityBalances.created).toBe(1);
+
+	const pb = await getUserPB(user.email);
+	const balances = await pb.collection('securityBalances').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(balances.length).toBe(1);
+	expect(balances[0].account).toBe(brokerage.id);
 });

--- a/e2e/import.test.ts
+++ b/e2e/import.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
-import { getUserPB, PB_URL, pbSend, seedUser } from './pocketbase.helpers';
+import { getUserPB, PB_URL, pbSend, seedAccount, seedUser } from './pocketbase.helpers';
 
 function importPayload(sessionLabel: string) {
 	return {
@@ -298,7 +298,7 @@ test('revert non-existent session returns 404', async () => {
 	expect(response.status).toBe(404);
 });
 
-test('same-name accounts at different institutions resolve correctly', async () => {
+test('same-name accounts resolve by institution and balance group tuple', async () => {
 	const user = await seedUser('victor');
 
 	const payload = {
@@ -320,17 +320,212 @@ test('same-name accounts at different institutions resolve correctly', async () 
 		transactions: [
 			{
 				accountName: 'Savings',
+				institution: 'Bank B',
+				balanceGroup: 'CASH',
 				date: '2025-09-01T00:00:00.000Z',
-				description: 'Deposit at Bank A',
+				description: 'Deposit at Bank B',
 				value: 100,
-				externalId: 'bankA-001'
+				externalId: 'bankB-001'
 			}
 		]
 	};
 
 	const result = await (await pbSend(IMPORT_PATH, payload, user.email)).json();
+	expect(result.status).toBe('completed');
 	expect(result.accounts.created).toBe(2);
+	expect(result.recordsFailed).toBe(0);
 	expect(result.transactions.created).toBe(1);
+
+	const pb = await getUserPB(user.email);
+	const bankB = await pb
+		.collection('accounts')
+		.getFirstListItem(`name = "Savings" && institution = "Bank B" && owner = "${user.id}"`);
+	const transactions = await pb.collection('transactions').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(transactions.length).toBe(1);
+	expect(transactions[0].account).toBe(bankB.id);
+});
+
+test('same-name accounts resolve by explicit accountId', async () => {
+	const user = await seedUser('vincent');
+	const bankA = await seedAccount({
+		name: 'Savings',
+		institution: 'Bank A',
+		balanceGroup: 'CASH',
+		balanceType: 'Savings',
+		owner: user.id
+	});
+	const bankB = await seedAccount({
+		name: 'Savings',
+		institution: 'Bank B',
+		balanceGroup: 'CASH',
+		balanceType: 'Savings',
+		owner: user.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'vincent-account-id',
+				transactions: [
+					{
+						accountId: bankB.id,
+						accountName: 'Savings',
+						date: '2025-09-02T00:00:00.000Z',
+						description: 'Deposit by id',
+						value: 250,
+						externalId: 'vincent-001'
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.recordsFailed).toBe(0);
+	expect(result.transactions.created).toBe(1);
+
+	const pb = await getUserPB(user.email);
+	const transactions = await pb.collection('transactions').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(transactions.length).toBe(1);
+	expect(transactions[0].account).toBe(bankB.id);
+
+	const onBankA = await pb.collection('transactions').getFullList({
+		filter: `account = "${bankA.id}"`
+	});
+	expect(onBankA.length).toBe(0);
+});
+
+test('ambiguous same-name transaction becomes a row error and is not created', async () => {
+	const user = await seedUser('valerie');
+	await seedAccount({
+		name: 'Savings',
+		institution: 'Bank A',
+		balanceGroup: 'CASH',
+		balanceType: 'Savings',
+		owner: user.id
+	});
+	await seedAccount({
+		name: 'Savings',
+		institution: 'Bank B',
+		balanceGroup: 'CASH',
+		balanceType: 'Savings',
+		owner: user.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'valerie-ambiguous',
+				transactions: [
+					{
+						accountName: 'Savings',
+						date: '2025-09-03T00:00:00.000Z',
+						description: 'Ambiguous deposit',
+						value: 75
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('failed');
+	expect(result.recordsFailed).toBe(1);
+	expect(result.transactions.created).toBe(0);
+
+	const pb = await getUserPB(user.email);
+	const transactions = await pb.collection('transactions').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(transactions.length).toBe(0);
+});
+
+test('legacy single-name transaction resolves to its only owned account', async () => {
+	const user = await seedUser('valentina');
+	const checking = await seedAccount({
+		name: 'Valentina Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: user.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'valentina-legacy',
+				transactions: [
+					{
+						accountName: 'Valentina Checking',
+						date: '2025-09-04T00:00:00.000Z',
+						description: 'Legacy deposit',
+						value: 500
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.recordsFailed).toBe(0);
+	expect(result.transactions.created).toBe(1);
+
+	const pb = await getUserPB(user.email);
+	const transactions = await pb.collection('transactions').getFullList({
+		filter: `owner = "${user.id}"`
+	});
+	expect(transactions.length).toBe(1);
+	expect(transactions[0].account).toBe(checking.id);
+});
+
+test('foreign accountId is rejected and nothing lands on the other user account', async () => {
+	const owner = await seedUser('victoria');
+	const intruder = await seedUser('vladimir');
+	const ownerAccount = await seedAccount({
+		name: 'Victoria Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: owner.id
+	});
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'vladimir-foreign-id',
+				transactions: [
+					{
+						accountId: ownerAccount.id,
+						accountName: 'Victoria Checking',
+						date: '2025-09-05T00:00:00.000Z',
+						description: 'Cross-owner deposit',
+						value: 999
+					}
+				]
+			},
+			intruder.email
+		)
+	).json();
+	expect(result.status).toBe('failed');
+	expect(result.recordsFailed).toBe(1);
+	expect(result.transactions.created).toBe(0);
+
+	const pb = await getUserPB(owner.email);
+	const onOwnerAccount = await pb.collection('transactions').getFullList({
+		filter: `account = "${ownerAccount.id}"`
+	});
+	expect(onOwnerAccount.length).toBe(0);
+
+	const intruderPB = await getUserPB(intruder.email);
+	const intruderTransactions = await intruderPB.collection('transactions').getFullList({
+		filter: `owner = "${intruder.id}"`
+	});
+	expect(intruderTransactions.length).toBe(0);
 });
 
 test('revert cleans up orphaned labels and balance types', async () => {

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -63,13 +63,16 @@ type importAssetBal struct {
 }
 
 type importTransaction struct {
-	AccountName string   `json:"accountName"`
-	Date        string   `json:"date"`
-	Description string   `json:"description"`
-	Value       float64  `json:"value"`
-	ExternalID  string   `json:"externalId"`
-	Labels      []string `json:"labels"`
-	Excluded    bool     `json:"excluded"`
+	AccountID    string   `json:"accountId"`
+	AccountName  string   `json:"accountName"`
+	Institution  string   `json:"institution"`
+	BalanceGroup string   `json:"balanceGroup"`
+	Date         string   `json:"date"`
+	Description  string   `json:"description"`
+	Value        float64  `json:"value"`
+	ExternalID   string   `json:"externalId"`
+	Labels       []string `json:"labels"`
+	Excluded     bool     `json:"excluded"`
 }
 
 type importSecurityBalance struct {
@@ -465,26 +468,70 @@ func hasMatchingSecurityImportRecord(app core.App, collectionName string, filter
 	return false
 }
 
-func resolveImportAccount(app core.App, ownerID string, acctIndex map[string]string, accountID string, accountName string) (string, error) {
-	if strings.TrimSpace(accountID) != "" {
-		return strings.TrimSpace(accountID), nil
+func acctIndexKey(name, institution, balanceGroup string) string {
+	return name + "|" + institution + "|" + balanceGroup
+}
+
+// resolveImportAccount maps a row's account reference to an owned account id deterministically.
+// Resolution order: a provided accountId is loaded and accepted only when it belongs to ownerID; an
+// exact name|institution|balanceGroup tuple is matched against acctIndex then the database; a bare
+// accountName succeeds only when it resolves to exactly one owned account. A foreign/missing id or
+// an ambiguous name is returned as an error so the caller records it as a row-level failure.
+func resolveImportAccount(app core.App, ownerID string, acctIndex map[string]string, accountID, accountName, institution, balanceGroup string) (string, error) {
+	if id := strings.TrimSpace(accountID); id != "" {
+		account, err := app.FindRecordById("accounts", id)
+		if err != nil {
+			return "", fmt.Errorf("accountId %q not found", id)
+		}
+		if account.GetString("owner") != ownerID {
+			return "", fmt.Errorf("accountId %q is not owned by the importing user", id)
+		}
+		return account.Id, nil
 	}
 
-	for key, id := range acctIndex {
-		if strings.HasPrefix(key, accountName+"|") {
+	if institution != "" || balanceGroup != "" {
+		key := acctIndexKey(accountName, institution, balanceGroup)
+		if id, ok := acctIndex[key]; ok {
 			return id, nil
 		}
+		found, err := app.FindFirstRecordByFilter("accounts",
+			"name = {:name} && institution = {:institution} && balanceGroup = {:balanceGroup} && owner = {:owner}",
+			map[string]any{"name": accountName, "institution": institution, "balanceGroup": balanceGroup, "owner": ownerID},
+		)
+		if err != nil {
+			return "", fmt.Errorf("no account matches name %q with the provided institution and balance group", accountName)
+		}
+		acctIndex[key] = found.Id
+		return found.Id, nil
 	}
 
-	found, err := app.FindFirstRecordByFilter("accounts",
+	matchIDs := map[string]struct{}{}
+	for key, id := range acctIndex {
+		if name, _, found := strings.Cut(key, "|"); found && name == accountName {
+			matchIDs[id] = struct{}{}
+		}
+	}
+	dbMatches, err := app.FindRecordsByFilter("accounts",
 		"name = {:name} && owner = {:owner}",
+		"", 0, 0,
 		map[string]any{"name": accountName, "owner": ownerID},
 	)
 	if err != nil {
 		return "", err
 	}
-	acctIndex[accountName+"||"] = found.Id
-	return found.Id, nil
+	for _, match := range dbMatches {
+		matchIDs[match.Id] = struct{}{}
+	}
+
+	switch len(matchIDs) {
+	case 0:
+		return "", fmt.Errorf("no account matches name %q", accountName)
+	case 1:
+		for id := range matchIDs {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("account name %q is ambiguous; %d owned accounts match", accountName, len(matchIDs))
 }
 
 // NOTE: counts is the single place securities are tallied for the import summary, so that
@@ -627,7 +674,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			continue
 		}
 
-		acctIndex[acct.Name+"|"+institution+"|"+acct.BalanceGroup] = rec.Id
+		acctIndex[acctIndexKey(acct.Name, institution, acct.BalanceGroup)] = rec.Id
 
 		if created {
 			result.Accounts.Created++
@@ -735,7 +782,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	}
 
 	for _, tx := range payload.Transactions {
-		accountID, err := resolveImportAccount(app, ownerID, acctIndex, "", tx.AccountName)
+		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName, tx.Institution, tx.BalanceGroup)
 		if err != nil {
 			log.Printf("[import] failed to resolve account for transactions record (accountName=%q): %v", tx.AccountName, err)
 			errorCount++
@@ -810,7 +857,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	}
 
 	for _, balance := range payload.SecurityBalances {
-		accountID, err := resolveImportAccount(app, ownerID, acctIndex, balance.AccountID, balance.AccountName)
+		accountID, err := resolveImportAccount(app, ownerID, acctIndex, balance.AccountID, balance.AccountName, "", "")
 		if err != nil {
 			log.Printf("[import] failed to resolve account for securityBalances record (accountName=%q): %v", balance.AccountName, err)
 			errorCount++
@@ -863,7 +910,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	}
 
 	for _, tx := range payload.SecurityTransactions {
-		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName)
+		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName, "", "")
 		if err != nil {
 			log.Printf("[import] failed to resolve account for securityTransactions record (accountName=%q): %v", tx.AccountName, err)
 			errorCount++


### PR DESCRIPTION
- Resolve import accounts deterministically — by an ownership-verified accountId or an exact name/institution/balance-group tuple — instead of returning the first entry of a Go map whose iteration order is unstable, which could attach a transaction to an arbitrary same-name account
- Accept a name-only reference only when it matches exactly one owned account; ambiguous same-name matches become row errors
- Reject foreign account ids for both cash and security imports, so a record cannot attach to another user's account
- Add regression tests that assert the destination account id (not just counts) for same-name, accountId, legacy single-name, and cross-owner cases

No linked issue (confirmed by user)