### PR TITLE
fix: redact import logs and normalize logging

### DIFF
--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"sync"
 	"time"
 
@@ -49,7 +49,7 @@ func balanceWorker(ctx context.Context, app *pocketbase.PocketBase) {
 func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 	account, err := app.FindRecordById("accounts", accountID)
 	if err != nil {
-		log.Printf("Failed to find account %s: %v", accountID, err)
+		logEvent("balance", fmt.Sprintf("failed to find account %s", accountID), err)
 		return
 	}
 
@@ -63,7 +63,7 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 		map[string]any{"aid": accountID, "owner": owner},
 	)
 	if err != nil {
-		log.Printf("Failed to fetch transactions for account %s: %v", accountID, err)
+		logEvent("balance", fmt.Sprintf("failed to fetch transactions for account %s", accountID), err)
 		return
 	}
 
@@ -77,7 +77,7 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 
 	collection, err := app.FindCollectionByNameOrId("accountBalances")
 	if err != nil {
-		log.Printf("Failed to find accountBalances collection: %v", err)
+		logEvent("balance", "failed to find accountBalances collection", err)
 		return
 	}
 
@@ -88,6 +88,6 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 	balance.Set("owner", account.GetString("owner"))
 
 	if err := app.Save(balance); err != nil {
-		log.Printf("Failed to save balance for account %s: %v", accountID, err)
+		logEvent("balance", fmt.Sprintf("failed to save balance for account %s", accountID), err)
 	}
 }

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -481,10 +481,10 @@ func resolveImportAccount(app core.App, ownerID string, acctIndex map[string]str
 	if id := strings.TrimSpace(accountID); id != "" {
 		account, err := app.FindRecordById("accounts", id)
 		if err != nil {
-			return "", fmt.Errorf("accountId %q not found", id)
+			return "", errors.New("provided accountId not found")
 		}
 		if account.GetString("owner") != ownerID {
-			return "", fmt.Errorf("accountId %q is not owned by the importing user", id)
+			return "", errors.New("provided accountId is not owned by the importing user")
 		}
 		return account.Id, nil
 	}
@@ -499,7 +499,7 @@ func resolveImportAccount(app core.App, ownerID string, acctIndex map[string]str
 			map[string]any{"name": accountName, "institution": institution, "balanceGroup": balanceGroup, "owner": ownerID},
 		)
 		if err != nil {
-			return "", fmt.Errorf("no account matches name %q with the provided institution and balance group", accountName)
+			return "", errors.New("no account matches the provided name, institution and balance group")
 		}
 		acctIndex[key] = found.Id
 		return found.Id, nil
@@ -525,13 +525,13 @@ func resolveImportAccount(app core.App, ownerID string, acctIndex map[string]str
 
 	switch len(matchIDs) {
 	case 0:
-		return "", fmt.Errorf("no account matches name %q", accountName)
+		return "", errors.New("no account matches the provided name")
 	case 1:
 		for id := range matchIDs {
 			return id, nil
 		}
 	}
-	return "", fmt.Errorf("account name %q is ambiguous; %d owned accounts match", accountName, len(matchIDs))
+	return "", fmt.Errorf("provided account name is ambiguous; %d owned accounts match", len(matchIDs))
 }
 
 // NOTE: counts is the single place securities are tallied for the import summary, so that
@@ -585,6 +585,16 @@ func findOrCreateImportSecurity(app core.App, ownerID string, securityCache map[
 	return rec.Id, nil
 }
 
+// logImportError records an operational diagnostic for a failed import row. It deliberately logs
+// only non-sensitive context — session id, collection, row index, operation, and the error — so
+// server logs never carry user-supplied finance metadata (account/balance-type/security names,
+// symbols, transaction labels, descriptions, or notes). Callers must keep raw metadata out of both
+// the format arguments and the error they pass: the resolver and the per-collection loops construct
+// errors that name only operational identifiers (record ids, dates) or generic failure classes.
+func logImportError(sessionID, collection string, rowIndex int, operation string, err error) {
+	log.Printf("[import] session=%s collection=%s row=%d op=%s: %v", sessionID, collection, rowIndex, operation, err)
+}
+
 func handleImport(app core.App, re *core.RequestEvent) error {
 	info, _ := re.RequestInfo()
 	auth := info.Auth
@@ -635,7 +645,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	// from a clean one. Per-row detail lives in the [import] operational logs.
 	errorCount := 0
 
-	for _, acct := range payload.Accounts {
+	for i, acct := range payload.Accounts {
 		institution := acct.Institution
 
 		btKey := acct.BalanceType + "::" + ownerID
@@ -645,7 +655,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			map[string]any{"name": acct.BalanceType, "owner": ownerID},
 		)
 		if err != nil {
-			log.Printf("[import] failed to find or create balanceTypes record (name=%q): %v", acct.BalanceType, err)
+			logImportError(session.Id, "balanceTypes", i, "findOrCreate", err)
 			errorCount++
 			continue
 		}
@@ -669,7 +679,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			"importSession":  session.Id,
 		})
 		if err != nil {
-			log.Printf("[import] failed to find or create accounts record (name=%q): %v", acct.Name, err)
+			logImportError(session.Id, "accounts", i, "findOrCreate", err)
 			errorCount++
 			continue
 		}
@@ -699,7 +709,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 				if err := app.Save(ab); err == nil {
 					result.AccountBalances.Created++
 				} else {
-					log.Printf("[import] failed to save accountBalances record (account=%s, asOf=%s): %v", rec.Id, acct.Balance.AsOf, err)
+					logImportError(session.Id, "accountBalances", i, "save", err)
 					errorCount++
 				}
 			} else {
@@ -708,7 +718,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		}
 	}
 
-	for _, asset := range payload.Assets {
+	for i, asset := range payload.Assets {
 		btKey := asset.BalanceType + "::" + ownerID
 		btID, err := cachedFindOrCreate(btCache, btKey, app,
 			"balanceTypes", "name = {:name} && owner = {:owner}",
@@ -716,7 +726,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			map[string]any{"name": asset.BalanceType, "owner": ownerID},
 		)
 		if err != nil {
-			log.Printf("[import] failed to find or create balanceTypes record (name=%q): %v", asset.BalanceType, err)
+			logImportError(session.Id, "balanceTypes", i, "findOrCreate", err)
 			errorCount++
 			continue
 		}
@@ -734,7 +744,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			"importSession": session.Id,
 		})
 		if err != nil {
-			log.Printf("[import] failed to find or create assets record (name=%q): %v", asset.Name, err)
+			logImportError(session.Id, "assets", i, "findOrCreate", err)
 			errorCount++
 			continue
 		}
@@ -764,7 +774,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 				if err := app.Save(asb); err == nil {
 					result.AssetBalances.Created++
 				} else {
-					log.Printf("[import] failed to save assetBalances record (asset=%s, asOf=%s): %v", rec.Id, asset.Balance.AsOf, err)
+					logImportError(session.Id, "assetBalances", i, "save", err)
 					errorCount++
 				}
 			} else {
@@ -773,18 +783,18 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		}
 	}
 
-	for _, security := range payload.Securities {
+	for i, security := range payload.Securities {
 		if _, err := findOrCreateImportSecurity(app, ownerID, securityCache, "", security.Name, security.Symbol, session.Id, &result.Securities); err != nil {
-			log.Printf("[import] failed to find or create securities record (name=%q, symbol=%q): %v", security.Name, security.Symbol, err)
+			logImportError(session.Id, "securities", i, "findOrCreate", err)
 			errorCount++
 			continue
 		}
 	}
 
-	for _, tx := range payload.Transactions {
+	for i, tx := range payload.Transactions {
 		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName, tx.Institution, tx.BalanceGroup)
 		if err != nil {
-			log.Printf("[import] failed to resolve account for transactions record (accountName=%q): %v", tx.AccountName, err)
+			logImportError(session.Id, "transactions", i, "resolveAccount", err)
 			errorCount++
 			continue
 		}
@@ -832,7 +842,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 			if err == nil {
 				labelIDs = append(labelIDs, lblID)
 			} else {
-				log.Printf("[import] failed to find or create transactionLabels record (name=%q): %v", lbl, err)
+				logImportError(session.Id, "transactionLabels", i, "findOrCreate", err)
 				errorCount++
 			}
 		}
@@ -851,21 +861,21 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		if err := app.Save(txRec); err == nil {
 			result.Transactions.Created++
 		} else {
-			log.Printf("[import] failed to save transactions record (account=%s, date=%s): %v", accountID, tx.Date, err)
+			logImportError(session.Id, "transactions", i, "save", err)
 			errorCount++
 		}
 	}
 
-	for _, balance := range payload.SecurityBalances {
+	for i, balance := range payload.SecurityBalances {
 		accountID, err := resolveImportAccount(app, ownerID, acctIndex, balance.AccountID, balance.AccountName, "", "")
 		if err != nil {
-			log.Printf("[import] failed to resolve account for securityBalances record (accountName=%q): %v", balance.AccountName, err)
+			logImportError(session.Id, "securityBalances", i, "resolveAccount", err)
 			errorCount++
 			continue
 		}
 		securityID, err := findOrCreateImportSecurity(app, ownerID, securityCache, balance.SecurityID, balance.SecurityName, balance.SecuritySymbol, session.Id, &result.Securities)
 		if err != nil {
-			log.Printf("[import] failed to find or create securities record for securityBalances (name=%q, symbol=%q): %v", balance.SecurityName, balance.SecuritySymbol, err)
+			logImportError(session.Id, "securityBalances", i, "findOrCreateSecurity", err)
 			errorCount++
 			continue
 		}
@@ -904,21 +914,21 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		if err := app.Save(rec); err == nil {
 			result.SecurityBalances.Created++
 		} else {
-			log.Printf("[import] failed to save securityBalances record (account=%s, security=%s, asOf=%s): %v", accountID, securityID, balance.AsOf, err)
+			logImportError(session.Id, "securityBalances", i, "save", err)
 			errorCount++
 		}
 	}
 
-	for _, tx := range payload.SecurityTransactions {
+	for i, tx := range payload.SecurityTransactions {
 		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName, "", "")
 		if err != nil {
-			log.Printf("[import] failed to resolve account for securityTransactions record (accountName=%q): %v", tx.AccountName, err)
+			logImportError(session.Id, "securityTransactions", i, "resolveAccount", err)
 			errorCount++
 			continue
 		}
 		securityID, err := findOrCreateImportSecurity(app, ownerID, securityCache, tx.SecurityID, tx.SecurityName, tx.SecuritySymbol, session.Id, &result.Securities)
 		if err != nil {
-			log.Printf("[import] failed to find or create securities record for securityTransactions (name=%q, symbol=%q): %v", tx.SecurityName, tx.SecuritySymbol, err)
+			logImportError(session.Id, "securityTransactions", i, "findOrCreateSecurity", err)
 			errorCount++
 			continue
 		}
@@ -967,7 +977,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		if err := app.Save(rec); err == nil {
 			result.SecurityTransactions.Created++
 		} else {
-			log.Printf("[import] failed to save securityTransactions record (account=%s, security=%s, date=%s): %v", accountID, securityID, tx.Date, err)
+			logImportError(session.Id, "securityTransactions", i, "save", err)
 			errorCount++
 		}
 	}

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"regexp"
@@ -436,7 +435,7 @@ type optionalImportNumber struct {
 func hasMatchingSecurityImportRecord(app core.App, collectionName string, filter string, params map[string]any, label string, fields []optionalImportNumber) bool {
 	candidates, err := app.FindRecordsByFilter(collectionName, filter, "", 0, 0, params)
 	if err != nil {
-		log.Printf("[import] failed to find duplicate %s records: %v", collectionName, err)
+		logEvent("import", fmt.Sprintf("failed to find duplicate %s records", collectionName), err)
 		return false
 	}
 
@@ -592,7 +591,7 @@ func findOrCreateImportSecurity(app core.App, ownerID string, securityCache map[
 // the format arguments and the error they pass: the resolver and the per-collection loops construct
 // errors that name only operational identifiers (record ids, dates) or generic failure classes.
 func logImportError(sessionID, collection string, rowIndex int, operation string, err error) {
-	log.Printf("[import] session=%s collection=%s row=%d op=%s: %v", sessionID, collection, rowIndex, operation, err)
+	logEvent("import", fmt.Sprintf("session=%s collection=%s row=%d op=%s", sessionID, collection, rowIndex, operation), err)
 }
 
 func handleImport(app core.App, re *core.RequestEvent) error {
@@ -1005,7 +1004,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	session.Set("recordsSkipped", totalSkipped)
 	session.Set("recordsFailed", errorCount)
 	if err := app.Save(session); err != nil {
-		log.Printf("[import] failed to save importSessions record (session=%s): %v", session.Id, err)
+		logEvent("import", fmt.Sprintf("failed to save importSessions record (session=%s)", session.Id), err)
 	}
 
 	return re.JSON(http.StatusOK, result)

--- a/pocketbase/logger.go
+++ b/pocketbase/logger.go
@@ -1,0 +1,15 @@
+package main
+
+import "log"
+
+// logEvent records an operational diagnostic with a stable bracket tag so PocketBase's Logs API can
+// filter by module. The operation string must describe only operational context — record ids,
+// collection names, dates, or generic failure classes — and never user-supplied finance metadata
+// (names, labels, symbols, descriptions, notes). Pass a nil err for lifecycle notices.
+func logEvent(tag, operation string, err error) {
+	if err != nil {
+		log.Printf("[%s] %s: %v", tag, operation, err)
+		return
+	}
+	log.Printf("[%s] %s", tag, operation)
+}

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -34,7 +34,7 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		log.Println("Shutting down balance worker...")
+		logEvent("server", "shutting down balance worker", nil)
 		cancel()
 	}()
 
@@ -174,6 +174,6 @@ func main() {
 	})
 
 	if err := app.Start(); err != nil {
-		log.Fatal(err)
+		log.Fatalf("[server] failed to start: %v", err)
 	}
 }

--- a/src/lib/account-cashflow.svelte.ts
+++ b/src/lib/account-cashflow.svelte.ts
@@ -7,6 +7,7 @@ import {
 	computeCashflowWindow,
 	type CashflowAverages
 } from './cashflow-utils';
+import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -94,7 +95,7 @@ class AccountCashflowContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accountCashflow', 'subscribe');
 				} else {
-					console.error('[accountCashflowStore] Stale subscription failed:', error);
+					logError('accountCashflowStore', 'stale_subscription', error);
 				}
 			});
 	}
@@ -117,7 +118,7 @@ class AccountCashflowContext {
 		this._debounceTimer = setTimeout(() => {
 			this._debounceTimer = null;
 			void this.recomputeAll().catch((error) => {
-				console.error('[accountCashflow:recompute_on_event]', error);
+				logError('accountCashflow', 'recompute_on_event', error);
 			});
 		}, DEBOUNCE_MS);
 	}

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -4,6 +4,7 @@ import { SvelteMap } from 'svelte/reactivity';
 
 import { getAuthContext } from './auth.svelte';
 import { setBalanceTypesContext } from './balance-types.svelte';
+import { logError } from './logger';
 import {
 	AccountSharesAccessRoleOptions,
 	AccountSharesPerspectiveOptions,
@@ -243,7 +244,7 @@ class AccountsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_accounts');
 				} else {
-					console.error('[accountsStore] Stale subscription failed:', error);
+					logError('accountsStore', 'stale_subscription', error);
 				}
 			});
 		this._pb.authedClient
@@ -259,7 +260,7 @@ class AccountsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_balances');
 				} else {
-					console.error('[accountsStore] Stale subscription failed:', error);
+					logError('accountsStore', 'stale_subscription', error);
 				}
 			});
 		this._pb.authedClient
@@ -269,7 +270,7 @@ class AccountsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_shares');
 				} else {
-					console.error('[accountsStore] Stale subscription failed:', error);
+					logError('accountsStore', 'stale_subscription', error);
 				}
 			});
 		this._isSubscribed = true;

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -4,6 +4,7 @@ import { SvelteMap } from 'svelte/reactivity';
 
 import { getAuthContext } from './auth.svelte';
 import { setBalanceTypesContext } from './balance-types.svelte';
+import { logError } from './logger';
 import {
 	AssetSharesAccessRoleOptions,
 	AssetSharesPerspectiveOptions,
@@ -222,7 +223,7 @@ class AssetsContext {
 					if (userId === this.currentUserId) {
 						this._pb.handleConnectionError(error, 'assets', 'asset_event');
 					} else {
-						console.error('[assetsStore] Stale event failed:', error);
+						logError('assetsStore', 'stale_event', error);
 					}
 				});
 			})
@@ -230,7 +231,7 @@ class AssetsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets');
 				} else {
-					console.error('[assetsStore] Stale subscription failed:', error);
+					logError('assetsStore', 'stale_subscription', error);
 				}
 			});
 		this._pb.authedClient
@@ -240,7 +241,7 @@ class AssetsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances');
 				} else {
-					console.error('[assetsStore] Stale subscription failed:', error);
+					logError('assetsStore', 'stale_subscription', error);
 				}
 			});
 		this._pb.authedClient
@@ -250,7 +251,7 @@ class AssetsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares');
 				} else {
-					console.error('[assetsStore] Stale subscription failed:', error);
+					logError('assetsStore', 'stale_subscription', error);
 				}
 			});
 		this._isSubscribed = true;
@@ -318,7 +319,7 @@ class AssetsContext {
 						if (userId === this.currentUserId) {
 							this._pb.handleConnectionError(error, 'assets', 'balance');
 						} else {
-							console.error('[assetsStore] Stale event failed:', error);
+							logError('assetsStore', 'stale_event', error);
 						}
 					});
 				return;
@@ -359,7 +360,7 @@ class AssetsContext {
 				if (userId === this.currentUserId) {
 					this._pb.handleConnectionError(error, 'assets', 'share');
 				} else {
-					console.error('[assetsStore] Stale event failed:', error);
+					logError('assetsStore', 'stale_event', error);
 				}
 			});
 	}
@@ -422,9 +423,9 @@ class AssetsContext {
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
 			if (userId === this.currentUserId) {
-				console.error('[assets:refetch_balance]', error);
+				logError('assets', 'refetch_balance', error);
 			} else {
-				console.error('[assetsStore] Stale event failed:', error);
+				logError('assetsStore', 'stale_event', error);
 			}
 		}
 	}

--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -7,6 +7,7 @@ import { getContext, setContext } from 'svelte';
 import { toast } from 'svelte-sonner';
 import { SvelteSet } from 'svelte/reactivity';
 
+import { logError } from '$lib/logger';
 import { m } from '$lib/paraglide/messages.js';
 import type { UsersResponse } from '$lib/pocketbase.schema';
 
@@ -61,7 +62,7 @@ export class AuthContext {
 		this._pb
 			.collection('users')
 			.subscribe(userId, this.onCurrentUserEvent.bind(this))
-			.catch((error) => console.error('[auth:subscribe]', error));
+			.catch((error) => logError('auth', 'subscribe', error));
 	}
 
 	private unsubscribeFromCurrentUser() {
@@ -71,7 +72,7 @@ export class AuthContext {
 		this._pb
 			.collection('users')
 			.unsubscribe(userId)
-			.catch((error) => console.error('[auth:unsubscribe]', error));
+			.catch((error) => logError('auth', 'unsubscribe', error));
 	}
 
 	private runRealtimeTeardowns() {
@@ -79,7 +80,7 @@ export class AuthContext {
 			try {
 				teardown();
 			} catch (error) {
-				console.error('[auth:teardown]', error);
+				logError('auth', 'teardown', error);
 			}
 		}
 	}

--- a/src/lib/balance-types.svelte.ts
+++ b/src/lib/balance-types.svelte.ts
@@ -2,6 +2,7 @@ import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
 import { getAuthContext } from './auth.svelte';
+import { logError } from './logger';
 import type { BalanceTypesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -61,7 +62,7 @@ class BalanceTypesContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'balance_types', 'subscribe');
 				} else {
-					console.error('[balanceTypesStore] Stale subscription failed:', error);
+					logError('balanceTypesStore', 'stale_subscription', error);
 				}
 			});
 	}
@@ -95,7 +96,7 @@ class BalanceTypesContext {
 				.getOne<BalanceTypesResponse>(id);
 			this.byId = { ...this.byId, [bt.id]: bt };
 		} catch (error) {
-			console.error('[balance_types:ensure_loaded]', error);
+			logError('balanceTypes', 'ensure_loaded', error);
 		}
 	}
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -11,6 +11,7 @@ import {
 	type CashflowPeriod,
 	type CashflowWindow
 } from './cashflow-utils';
+import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -144,7 +145,7 @@ class CashflowContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'cashflow', 'subscribe');
 				} else {
-					console.error('[cashflowStore] Stale subscription failed:', error);
+					logError('cashflowStore', 'stale_subscription', error);
 				}
 			});
 	}
@@ -215,7 +216,7 @@ class CashflowContext {
 		this._debounceTimer = setTimeout(() => {
 			this._debounceTimer = null;
 			void this.recomputeAll(this._accountsContext.accounts).catch((error) => {
-				console.error('[cashflow:recompute_on_event]', error);
+				logError('cashflow', 'recompute_on_event', error);
 			});
 		}, DEBOUNCE_MS);
 	}

--- a/src/lib/demo/demo.svelte.ts
+++ b/src/lib/demo/demo.svelte.ts
@@ -3,6 +3,7 @@ import { toast } from 'svelte-sonner';
 
 import { env } from '$env/dynamic/public';
 import type { AuthContext } from '$lib/auth.svelte';
+import { logError } from '$lib/logger';
 import { m } from '$lib/paraglide/messages.js';
 import type { TypedPocketBase } from '$lib/pocketbase.schema';
 
@@ -43,7 +44,7 @@ export class DemoContext {
 
 	async startDemo() {
 		if (!this.isEnabled) {
-			console.error('[demo] Demo mode is not enabled');
+			logError('demo', 'start', 'Demo mode is not enabled');
 			return { success: false };
 		}
 
@@ -66,7 +67,7 @@ export class DemoContext {
 
 				const loginResult = await this._auth.login(email, DEMO_PASSWORD);
 				if (!loginResult.success) {
-					console.error('[demo] Failed to login after user creation');
+					logError('demo', 'start', 'Failed to login after user creation');
 					toast.error(m.demo_seeding_failed());
 					return { success: false };
 				}
@@ -78,7 +79,7 @@ export class DemoContext {
 			}
 
 			if (!userId) {
-				console.error('[demo] No user ID after authentication');
+				logError('demo', 'start', 'No user ID after authentication');
 				toast.error(m.demo_seeding_failed());
 				return { success: false };
 			}
@@ -90,7 +91,7 @@ export class DemoContext {
 			await this.seed(userId);
 			return { success: true };
 		} catch (error) {
-			console.error('[demo] Failed to start demo:', error);
+			logError('demo', 'start', error);
 			toast.error(m.demo_seeding_failed());
 			return { success: false };
 		} finally {
@@ -107,7 +108,7 @@ export class DemoContext {
 			this.markAsSeeded(userId);
 			toast.success(m.demo_seeding_complete(), { id: TOAST_ID });
 		} catch (error) {
-			console.error('[demo:seed]', error);
+			logError('demo', 'seed', error);
 			toast.error(m.demo_seeding_failed(), { id: TOAST_ID });
 			throw error;
 		} finally {

--- a/src/lib/demo/seed.ts
+++ b/src/lib/demo/seed.ts
@@ -1,3 +1,4 @@
+import { logWarn } from '$lib/logger';
 import type { TypedPocketBase } from '$lib/pocketbase.schema';
 
 import {
@@ -204,7 +205,7 @@ async function waitForAutoCalculatedBalances(pb: TypedPocketBase, accountIds: st
 		await new Promise((resolve) => setTimeout(resolve, pollInterval));
 	}
 
-	console.warn('[demo:seed] Timed out waiting for auto-calculated balances to stabilize');
+	logWarn('demo', 'seed', 'Timed out waiting for auto-calculated balances to stabilize');
 }
 
 export async function seedDemoData(pb: TypedPocketBase, userId: string) {

--- a/src/lib/import-sessions.svelte.ts
+++ b/src/lib/import-sessions.svelte.ts
@@ -2,6 +2,7 @@ import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
 import { getAuthContext } from './auth.svelte';
+import { logError } from './logger';
 import type { ImportSessionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 
@@ -69,7 +70,7 @@ class ImportSessionsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'importSessions', 'subscribe');
 				} else {
-					console.error('[importSessionsStore] Stale subscription failed:', error);
+					logError('importSessionsStore', 'stale_subscription', error);
 				}
 			});
 		this._isSubscribed = true;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,11 @@
+function format(context: string, operation: string) {
+	return `[${context}:${operation}]`;
+}
+
+export function logError(context: string, operation: string, error: unknown) {
+	console.error(format(context, operation), error);
+}
+
+export function logWarn(context: string, operation: string, error: unknown) {
+	console.warn(format(context, operation), error);
+}

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -4,6 +4,7 @@ import { toast } from 'svelte-sonner';
 
 import { env } from '$env/dynamic/public';
 
+import { logError } from './logger';
 import { m } from './paraglide/messages';
 import type { TypedPocketBase } from './pocketbase.schema';
 
@@ -83,7 +84,7 @@ export class PocketBaseContext {
 	}
 
 	private captureError(error: unknown, context: string, operation: string) {
-		console.error(`[${context}:${operation}]`, error);
+		logError(context, operation, error);
 	}
 
 	private isTransientError(error: unknown) {

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -4,6 +4,7 @@ import { SvelteMap } from 'svelte/reactivity';
 
 import { getAccountsContext } from './accounts.svelte';
 import { getAuthContext } from './auth.svelte';
+import { logError } from './logger';
 import type { SecuritiesResponse, SecurityBalancesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 import {
@@ -232,7 +233,7 @@ class SecuritiesContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe');
 				} else {
-					console.error('[securitiesStore] Stale subscription failed:', error);
+					logError('securitiesStore', 'stale_subscription', error);
 				}
 			});
 		this._pb.authedClient
@@ -242,7 +243,7 @@ class SecuritiesContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe_balances');
 				} else {
-					console.error('[securitiesStore] Stale subscription failed:', error);
+					logError('securitiesStore', 'stale_subscription', error);
 				}
 			});
 		this._isSubscribed = true;

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -9,6 +9,7 @@ import { page } from '$app/state';
 
 import { getAccountsContext } from './accounts.svelte';
 import { getAuthContext } from './auth.svelte';
+import { logError } from './logger';
 import {
 	SecurityTransactionsTypeOptions,
 	type AccountsResponse,
@@ -423,7 +424,7 @@ class TradesContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securityTransactions', 'subscribe_transactions');
 				} else {
-					console.error('[tradesStore] Stale subscription failed:', error);
+					logError('tradesStore', 'stale_subscription', error);
 				}
 			});
 		this._isSubscribed = true;

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -9,6 +9,7 @@ import { page } from '$app/state';
 
 import { getAccountsContext } from './accounts.svelte';
 import { getAuthContext } from './auth.svelte';
+import { logError } from './logger';
 import type {
 	AccountsResponse,
 	TransactionLabelsResponse,
@@ -547,7 +548,7 @@ class TransactionsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'transactions', 'subscribe_transactions');
 				} else {
-					console.error('[transactionsStore] Stale transaction subscription failed:', error);
+					logError('transactionsStore', 'stale_transaction_subscription', error);
 				}
 			});
 		this._isSubscribed = true;
@@ -570,7 +571,7 @@ class TransactionsContext {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'transactionLabels', 'subscribe_labels');
 				} else {
-					console.error('[transactionsStore] Stale label subscription failed:', error);
+					logError('transactionsStore', 'stale_label_subscription', error);
 				}
 			});
 	}

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -32,6 +32,7 @@
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import * as Table from '$lib/components/ui/table/index';
 	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		AccountsBalanceGroupOptions,
@@ -286,7 +287,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('Failed to update balance:', error);
+			logError('accountDetail', 'update_balance', error);
 			toast.error(m.accounts_balance_failed());
 			syncState.justSaved = false;
 		}
@@ -330,7 +331,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('Failed to update account:', error);
+			logError('accountDetail', 'update', error);
 			toast.error(m.accounts_edit_failed());
 			syncState.justSaved = false;
 		}
@@ -345,7 +346,7 @@
 			toast.success(m.accounts_delete_success());
 			goto(resolve('/accounts'));
 		} catch (error) {
-			console.error('Failed to delete account:', error);
+			logError('accountDetail', 'delete', error);
 			toast.error(m.accounts_delete_failed());
 		}
 	}
@@ -359,7 +360,7 @@
 			sharePerspective = AccountSharesPerspectiveOptions.NORMAL;
 			toast.success(m.accounts_share_created());
 		} catch (error) {
-			console.error('Failed to create share:', error);
+			logError('accountDetail', 'create_share', error);
 			toast.error(error instanceof Error ? error.message : m.accounts_share_create_failed());
 		}
 	}
@@ -371,7 +372,7 @@
 			await accountsContext.updateShareIncludeInNetWorth(incomingShare.id, includeInNetWorth);
 			toast.success(m.accounts_share_preferences_updated());
 		} catch (error) {
-			console.error('Failed to update share preferences:', error);
+			logError('accountDetail', 'update_share_preferences', error);
 			toast.error(m.accounts_share_preferences_failed());
 		}
 	}
@@ -381,7 +382,7 @@
 			await accountsContext.revokeShare(shareId);
 			toast.success(m.accounts_share_removed());
 		} catch (error) {
-			console.error('Failed to revoke share:', error);
+			logError('accountDetail', 'revoke_share', error);
 			toast.error(m.accounts_share_remove_failed());
 		}
 	}
@@ -393,7 +394,7 @@
 			toast.success(m.accounts_share_left());
 			goto(resolve('/accounts'));
 		} catch (error) {
-			console.error('Failed to leave share:', error);
+			logError('accountDetail', 'leave_share', error);
 			toast.error(m.accounts_share_leave_failed());
 		}
 	}

--- a/src/routes/(app)/accounts/add/+page.svelte
+++ b/src/routes/(app)/accounts/add/+page.svelte
@@ -21,6 +21,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { AccountsBalanceGroupOptions } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -78,7 +79,7 @@
 			toast.success(m.accounts_add_success());
 			await goto(resolve('/accounts'));
 		} catch (error) {
-			console.error('Failed to create account:', error);
+			logError('addAccount', 'create', error);
 			toast.error(m.accounts_add_failed());
 		}
 	}

--- a/src/routes/(app)/assets/[id]/+page.svelte
+++ b/src/routes/(app)/assets/[id]/+page.svelte
@@ -24,6 +24,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { AssetsBalanceGroupOptions, AssetSharesPerspectiveOptions } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -185,7 +186,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('Failed to update balance:', error);
+			logError('assetDetail', 'update_balance', error);
 			toast.error(m.assets_balance_failed());
 			syncState.justSaved = false;
 		}
@@ -228,7 +229,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('Failed to update asset:', error);
+			logError('assetDetail', 'update', error);
 			toast.error(m.assets_edit_failed());
 			syncState.justSaved = false;
 		}
@@ -243,7 +244,7 @@
 			toast.success(m.assets_delete_success());
 			goto(resolve('/assets'));
 		} catch (error) {
-			console.error('Failed to delete asset:', error);
+			logError('assetDetail', 'delete', error);
 			toast.error(m.assets_delete_failed());
 		}
 	}
@@ -257,7 +258,7 @@
 			sharePerspective = AssetSharesPerspectiveOptions.NORMAL;
 			toast.success(m.assets_share_created());
 		} catch (error) {
-			console.error('Failed to create share:', error);
+			logError('assetDetail', 'create_share', error);
 			toast.error(error instanceof Error ? error.message : m.assets_share_create_failed());
 		}
 	}
@@ -269,7 +270,7 @@
 			await assetsContext.updateShareIncludeInNetWorth(incomingShare.id, includeInNetWorth);
 			toast.success(m.assets_share_preferences_updated());
 		} catch (error) {
-			console.error('Failed to update share preferences:', error);
+			logError('assetDetail', 'update_share_preferences', error);
 			toast.error(m.assets_share_preferences_failed());
 		}
 	}
@@ -279,7 +280,7 @@
 			await assetsContext.revokeShare(shareId);
 			toast.success(m.assets_share_removed());
 		} catch (error) {
-			console.error('Failed to revoke share:', error);
+			logError('assetDetail', 'revoke_share', error);
 			toast.error(m.assets_share_remove_failed());
 		}
 	}
@@ -291,7 +292,7 @@
 			toast.success(m.assets_share_left());
 			goto(resolve('/assets'));
 		} catch (error) {
-			console.error('Failed to leave share:', error);
+			logError('assetDetail', 'leave_share', error);
 			toast.error(m.assets_share_leave_failed());
 		}
 	}

--- a/src/routes/(app)/assets/add/+page.svelte
+++ b/src/routes/(app)/assets/add/+page.svelte
@@ -20,6 +20,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { AssetsBalanceGroupOptions } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -71,7 +72,7 @@
 			toast.success(m.assets_add_success());
 			await goto(resolve('/assets'));
 		} catch (error) {
-			console.error('[addAsset] Failed to create asset:', error);
+			logError('addAsset', 'create', error);
 			toast.error(m.assets_add_failed());
 		}
 	}

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -27,6 +27,7 @@
 		setInterfaceLocale,
 		type InterfaceThemeMode
 	} from '$lib/interface-preferences.svelte';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import type { ImportSessionsResponse } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -144,7 +145,7 @@
 			}
 			toast.success(m.settings_interface_success());
 		} catch (error) {
-			console.error('[settings] Failed to update interface preferences:', error);
+			logError('settings', 'update_interface_preferences', error);
 			toast.error(m.settings_interface_language_failed());
 		}
 	}
@@ -161,7 +162,7 @@
 
 			toast.success(m.settings_imports_revert_success());
 		} catch (error) {
-			console.error('Failed to revert import:', error);
+			logError('settings', 'revert_import', error);
 			toast.error(m.settings_imports_revert_failed());
 		} finally {
 			revertingSessionId = null;

--- a/src/routes/(app)/trades/[id]/+page.svelte
+++ b/src/routes/(app)/trades/[id]/+page.svelte
@@ -26,6 +26,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		SecurityTransactionsTypeOptions,
@@ -149,7 +150,7 @@
 				notes: result.notes ?? ''
 			};
 		} catch (error) {
-			console.error('[tradeDetail] Failed to load trade:', error);
+			logError('tradeDetail', 'load', error);
 			toast.error(m.trades_edit_error_loading());
 		} finally {
 			isLoading = false;
@@ -201,7 +202,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('[tradeDetail] Failed to update trade:', error);
+			logError('tradeDetail', 'update', error);
 			toast.error(m.trades_edit_failed());
 		}
 	}
@@ -215,7 +216,7 @@
 			toast.success(m.trades_delete_success());
 			goto(resolve('/trades'));
 		} catch (error) {
-			console.error('[tradeDetail] Failed to delete trade:', error);
+			logError('tradeDetail', 'delete', error);
 			toast.error(m.trades_delete_failed());
 		}
 	}

--- a/src/routes/(app)/trades/add/+page.svelte
+++ b/src/routes/(app)/trades/add/+page.svelte
@@ -21,6 +21,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { SecurityTransactionsTypeOptions } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -99,7 +100,7 @@
 			toast.success(m.trades_add_success());
 			await goto(resolve('/trades'));
 		} catch (error) {
-			console.error('[tradesAdd]', error);
+			logError('tradesAdd', 'create', error);
 			toast.error(m.trades_add_failed());
 		} finally {
 			isSaving = false;

--- a/src/routes/(app)/trades/securities/[id]/+page.svelte
+++ b/src/routes/(app)/trades/securities/[id]/+page.svelte
@@ -21,6 +21,7 @@
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import * as Table from '$lib/components/ui/table/index';
 	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { getSecuritiesContext, type SecurityAccountBalance } from '$lib/securities.svelte';
 	import {
@@ -189,7 +190,7 @@
 			});
 			toast.success(m.securities_edit_success());
 		} catch (error) {
-			console.error('[securityDetail]', error);
+			logError('securityDetail', 'update', error);
 			syncState.justSaved = false;
 			toast.error(m.securities_edit_failed());
 		}
@@ -213,7 +214,7 @@
 			balanceFormData = createSecurityBalanceFormData();
 			toast.success(m.securities_balance_updated());
 		} catch (error) {
-			console.error('[securityDetail]', error);
+			logError('securityDetail', 'add_balance', error);
 			toast.error(m.securities_balance_failed());
 		} finally {
 			isSavingBalance = false;

--- a/src/routes/(app)/trades/securities/add/+page.svelte
+++ b/src/routes/(app)/trades/securities/add/+page.svelte
@@ -18,6 +18,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { securityComboboxLabel } from '$lib/trade-display';
@@ -92,7 +93,7 @@
 			toast.success(m.securities_add_success());
 			await goto(resolve('/trades/securities'));
 		} catch (error) {
-			console.error('[securitiesAdd]', error);
+			logError('securitiesAdd', 'create', error);
 			toast.error(m.securities_add_failed());
 		} finally {
 			isSaving = false;

--- a/src/routes/(app)/transactions/[id]/+page.svelte
+++ b/src/routes/(app)/transactions/[id]/+page.svelte
@@ -25,6 +25,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import type { TransactionsResponse } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
@@ -93,7 +94,7 @@
 				excluded: Boolean(result.excluded)
 			};
 		} catch (error) {
-			console.error('Failed to load transaction:', error);
+			logError('transactionDetail', 'load', error);
 			toast.error(m.transactions_edit_error_loading());
 		} finally {
 			isLoading = false;
@@ -147,7 +148,7 @@
 				await goto(from);
 			}
 		} catch (error) {
-			console.error('Failed to update transaction:', error);
+			logError('transactionDetail', 'update', error);
 			toast.error(m.transactions_edit_failed());
 		}
 	}
@@ -161,7 +162,7 @@
 			toast.success(m.transactions_delete_success());
 			goto(resolve('/transactions'));
 		} catch (error) {
-			console.error('Failed to delete transaction:', error);
+			logError('transactionDetail', 'delete', error);
 			toast.error(m.transactions_delete_failed());
 		}
 	}

--- a/src/routes/(app)/transactions/add/+page.svelte
+++ b/src/routes/(app)/transactions/add/+page.svelte
@@ -20,6 +20,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
 
@@ -77,7 +78,7 @@
 			toast.success(m.transactions_add_success());
 			await goto(resolve('/transactions'));
 		} catch (error) {
-			console.error('Failed to create transaction:', error);
+			logError('addTransaction', 'create', error);
 			toast.error(m.transactions_add_failed());
 		}
 	}

--- a/src/routes/(app)/transactions/batch/+page.svelte
+++ b/src/routes/(app)/transactions/batch/+page.svelte
@@ -20,6 +20,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
 	import { getTransactionsContext, type TransactionRow } from '$lib/transactions.svelte';
@@ -175,7 +176,7 @@
 
 			goto(resolve('/transactions'));
 		} catch (error) {
-			console.error('Failed to batch update transactions:', error);
+			logError('transactionsBatch', 'update', error);
 			toast.dismiss(loadingToast);
 			toast.error(m.transactions_edit_failed());
 		} finally {
@@ -213,7 +214,7 @@
 
 			goto(resolve('/transactions'));
 		} catch (error) {
-			console.error('Failed to batch delete transactions:', error);
+			logError('transactionsBatch', 'delete', error);
 			toast.dismiss(loadingToast);
 			toast.error(m.transactions_delete_failed());
 		} finally {

--- a/src/routes/(guest)/auth/dev-auth-shortcuts.svelte
+++ b/src/routes/(guest)/auth/dev-auth-shortcuts.svelte
@@ -3,6 +3,7 @@
 
 	import { getAuthContext } from '$lib/auth.svelte';
 	import { Button } from '$lib/components/ui/button';
+	import { logError } from '$lib/logger';
 	import type { UsersResponse } from '$lib/pocketbase.schema';
 
 	const auth = getAuthContext();
@@ -44,15 +45,15 @@
 				adminPb
 					.collection('users')
 					.subscribe('*', onUserEvent)
-					.catch((error) => console.error('[dev-auth-shortcuts:subscribe]', error));
+					.catch((error) => logError('devAuthShortcuts', 'subscribe', error));
 			})
-			.catch((error) => console.error('[dev-auth-shortcuts:auth]', error));
+			.catch((error) => logError('devAuthShortcuts', 'auth', error));
 
 		return () => {
 			adminPb
 				.collection('users')
 				.unsubscribe('*')
-				.catch((error) => console.error('[dev-auth-shortcuts:unsubscribe]', error));
+				.catch((error) => logError('devAuthShortcuts', 'unsubscribe', error));
 		};
 	});
 


### PR DESCRIPTION
- Redact user-supplied finance metadata (account/security names, symbols, labels, descriptions, notes) from import server logs, keeping only session id, collection, row index, operation, and error class
- Sanitize import resolver error messages so they no longer embed raw account names/ids via the logged error, while the client's per-row diagnostics stay intact
- Normalize logging app-wide through shared tagged helpers — a backend logEvent and a frontend src/lib/logger.ts (logError/logWarn with [context:operation] tags) — routing previously ad-hoc and untagged log/console.error calls through them
- No behavior change in the normalization: same log moments and severity (process-fatal startup error preserved), no toast changes, no new frontend redaction

No linked issue (confirmed by user)