### PR TITLE
fix: clean up orphaned derived balances when reverting an import

### DIFF
--- a/e2e/import.test.ts
+++ b/e2e/import.test.ts
@@ -876,6 +876,65 @@ test('reverting an import into an existing account leaves no stale derived balan
 	expect(balances.map((balance) => balance.value)).toEqual(balances.map(() => 100));
 });
 
+test('deleting a single imported transaction outside revert recomputes the derived balance', async () => {
+	const user = await seedUser('seamus');
+	const account = await seedAccount({
+		name: 'Seamus Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+
+	const pb = await getUserPB(user.email);
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: '2025-06-01T00:00:00.000Z',
+		description: 'Pre-existing deposit',
+		value: 100
+	});
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(100);
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'seamus-into-existing',
+				transactions: [
+					{
+						accountId: account.id,
+						accountName: 'Seamus Checking',
+						date: '2025-06-10T00:00:00.000Z',
+						description: 'Imported deposit',
+						value: 900,
+						externalId: 'seamus-txn-001'
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.transactions.created).toBe(1);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(1000);
+
+	const imported = await pb
+		.collection('transactions')
+		.getFirstListItem(`externalId = "seamus-txn-001" && owner = "${user.id}"`);
+	await pb.collection('transactions').delete(imported.id);
+
+	const remainingTransactions = await pb.collection('transactions').getFullList({
+		filter: `account = "${account.id}"`
+	});
+	expect(remainingTransactions.map((tx) => tx.description)).toEqual(['Pre-existing deposit']);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(100);
+});
+
 test('reverting an import preserves a manual balance on the account', async () => {
 	const user = await seedUser('serena');
 	const account = await seedAccount({

--- a/e2e/import.test.ts
+++ b/e2e/import.test.ts
@@ -1,7 +1,16 @@
 import { expect, test } from '@playwright/test';
 
+import type { TypedPocketBase } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
-import { getUserPB, PB_URL, pbSend, seedAccount, seedUser } from './pocketbase.helpers';
+import {
+	getUserPB,
+	PB_URL,
+	pbSend,
+	seedAccount,
+	seedAccountBalance,
+	seedTransaction,
+	seedUser
+} from './pocketbase.helpers';
 
 function importPayload(sessionLabel: string) {
 	return {
@@ -801,4 +810,218 @@ test('import accepts security and cryptocurrency balance types in assets payload
 		filter: `owner = "${user.id}"`
 	});
 	expect(securities.length).toBe(0);
+});
+
+async function listAccountBalances(pb: TypedPocketBase, account: string) {
+	return pb.collection('accountBalances').getFullList({
+		filter: `account = "${account}"`,
+		sort: '-asOf,-created,-id'
+	});
+}
+
+test('reverting an import into an existing account leaves no stale derived balance', async () => {
+	const user = await seedUser('sabrina');
+	const account = await seedAccount({
+		name: 'Sabrina Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: '2025-06-01T00:00:00.000Z',
+		description: 'Pre-existing deposit',
+		value: 100
+	});
+
+	const pb = await getUserPB(user.email);
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'sabrina-into-existing',
+				transactions: [
+					{
+						accountId: account.id,
+						accountName: 'Sabrina Checking',
+						date: '2025-06-10T00:00:00.000Z',
+						description: 'Imported deposit',
+						value: 900,
+						externalId: 'sabrina-txn-001'
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.transactions.created).toBe(1);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(1000);
+
+	await pbSend('/api/canutin/import/revert', { sessionId: result.sessionId }, user.email);
+
+	const remainingTransactions = await pb.collection('transactions').getFullList({
+		filter: `account = "${account.id}"`
+	});
+	expect(remainingTransactions.map((tx) => tx.description)).toEqual(['Pre-existing deposit']);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(100);
+
+	const balances = await listAccountBalances(pb, account.id);
+	expect(balances.map((balance) => balance.value)).toEqual(balances.map(() => 100));
+});
+
+test('reverting an import preserves a manual balance on the account', async () => {
+	const user = await seedUser('serena');
+	const account = await seedAccount({
+		name: 'Serena Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: '2025-06-01T00:00:00.000Z',
+		description: 'Pre-existing deposit',
+		value: 100
+	});
+
+	const manualBalance = await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: '2025-05-01T00:00:00.000Z',
+		value: 777
+	});
+
+	const pb = await getUserPB(user.email);
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'serena-into-existing',
+				transactions: [
+					{
+						accountId: account.id,
+						accountName: 'Serena Checking',
+						date: '2025-06-10T00:00:00.000Z',
+						description: 'Imported deposit',
+						value: 900,
+						externalId: 'serena-txn-001'
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.transactions.created).toBe(1);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(1000);
+
+	await pbSend('/api/canutin/import/revert', { sessionId: result.sessionId }, user.email);
+
+	const remainingTransactions = await pb.collection('transactions').getFullList({
+		filter: `account = "${account.id}"`
+	});
+	expect(remainingTransactions.map((tx) => tx.description)).toEqual(['Pre-existing deposit']);
+
+	await expect
+		.poll(async () =>
+			(await listAccountBalances(pb, account.id))
+				.filter((balance) => balance.source === 'derived')
+				.map((balance) => balance.value)
+		)
+		.toEqual(expect.arrayContaining([100]));
+
+	const derivedBalances = (await listAccountBalances(pb, account.id)).filter(
+		(balance) => balance.source === 'derived'
+	);
+	expect(derivedBalances.map((balance) => balance.value)).toEqual(derivedBalances.map(() => 100));
+
+	const preservedManual = await pb.collection('accountBalances').getOne(manualBalance.id);
+	expect(preservedManual.source).toBe('manual');
+	expect(preservedManual.value).toBe(777);
+});
+
+test('reverting an import preserves pre-existing derived balance history', async () => {
+	const user = await seedUser('sienna');
+	const account = await seedAccount({
+		name: 'Sienna Checking',
+		balanceGroup: 'CASH',
+		balanceType: 'Checking',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+
+	const pb = await getUserPB(user.email);
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: '2025-04-01T00:00:00.000Z',
+		description: 'First pre-existing deposit',
+		value: 250
+	});
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(250);
+	const historicalSnapshot = (await listAccountBalances(pb, account.id)).find(
+		(balance) => balance.source === 'derived' && balance.value === 250
+	)!;
+
+	await seedTransaction({
+		account: account.id,
+		owner: user.id,
+		date: '2025-05-01T00:00:00.000Z',
+		description: 'Second pre-existing deposit',
+		value: 100
+	});
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(350);
+
+	const result = await (
+		await pbSend(
+			IMPORT_PATH,
+			{
+				sessionLabel: 'sienna-into-existing',
+				transactions: [
+					{
+						accountId: account.id,
+						accountName: 'Sienna Checking',
+						date: '2025-06-10T00:00:00.000Z',
+						description: 'Imported deposit',
+						value: 900,
+						externalId: 'sienna-txn-001'
+					}
+				]
+			},
+			user.email
+		)
+	).json();
+	expect(result.status).toBe('completed');
+	expect(result.transactions.created).toBe(1);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(1250);
+
+	await pbSend('/api/canutin/import/revert', { sessionId: result.sessionId }, user.email);
+
+	const remainingTransactions = await pb.collection('transactions').getFullList({
+		filter: `account = "${account.id}"`
+	});
+	expect(remainingTransactions.map((tx) => tx.description)).toEqual([
+		'First pre-existing deposit',
+		'Second pre-existing deposit'
+	]);
+
+	const preservedHistory = await pb.collection('accountBalances').getOne(historicalSnapshot.id);
+	expect(preservedHistory.source).toBe('derived');
+	expect(preservedHistory.value).toBe(250);
+
+	await expect.poll(async () => (await listAccountBalances(pb, account.id))[0]?.value).toBe(350);
 });

--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -55,6 +57,11 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 func recomputeDerivedBalance(app core.App, accountID string, importSession string) error {
 	account, err := app.FindRecordById("accounts", accountID)
 	if err != nil {
+		// NOTE: a cascade-deleted account (e.g. an import-created account removed during revert)
+		// has no balance to compute, so a missing record is a quiet no-op rather than a failure.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
 		return fmt.Errorf("find account: %w", err)
 	}
 

--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -47,14 +47,19 @@ func balanceWorker(ctx context.Context, app *pocketbase.PocketBase) {
 }
 
 func calculateBalance(app *pocketbase.PocketBase, accountID string) {
+	if err := recomputeDerivedBalance(app, accountID, ""); err != nil {
+		logEvent("balance", fmt.Sprintf("failed to recompute balance for account %s", accountID), err)
+	}
+}
+
+func recomputeDerivedBalance(app core.App, accountID string, importSession string) error {
 	account, err := app.FindRecordById("accounts", accountID)
 	if err != nil {
-		logEvent("balance", fmt.Sprintf("failed to find account %s", accountID), err)
-		return
+		return fmt.Errorf("find account: %w", err)
 	}
 
 	if account.GetDateTime("autoCalculated").IsZero() {
-		return
+		return nil
 	}
 
 	owner := account.GetString("owner")
@@ -63,8 +68,7 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 		map[string]any{"aid": accountID, "owner": owner},
 	)
 	if err != nil {
-		logEvent("balance", fmt.Sprintf("failed to fetch transactions for account %s", accountID), err)
-		return
+		return fmt.Errorf("fetch transactions: %w", err)
 	}
 
 	var sum float64
@@ -77,17 +81,21 @@ func calculateBalance(app *pocketbase.PocketBase, accountID string) {
 
 	collection, err := app.FindCollectionByNameOrId("accountBalances")
 	if err != nil {
-		logEvent("balance", "failed to find accountBalances collection", err)
-		return
+		return fmt.Errorf("find accountBalances collection: %w", err)
 	}
 
 	balance := core.NewRecord(collection)
 	balance.Set("account", accountID)
 	balance.Set("value", sum)
 	balance.Set("asOf", time.Now().UTC())
-	balance.Set("owner", account.GetString("owner"))
+	balance.Set("owner", owner)
+	balance.Set("source", "derived")
+	if importSession != "" {
+		balance.Set("importSession", importSession)
+	}
 
 	if err := app.Save(balance); err != nil {
-		logEvent("balance", fmt.Sprintf("failed to save balance for account %s", accountID), err)
+		return fmt.Errorf("save balance: %w", err)
 	}
+	return nil
 }

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -705,6 +705,7 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 				ab.Set("asOf", acct.Balance.AsOf)
 				ab.Set("owner", ownerID)
 				ab.Set("importSession", session.Id)
+				ab.Set("source", "import")
 				if err := app.Save(ab); err == nil {
 					result.AccountBalances.Created++
 				} else {
@@ -790,6 +791,8 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		}
 	}
 
+	accountsWithImportedTransactions := map[string]struct{}{}
+
 	for i, tx := range payload.Transactions {
 		accountID, err := resolveImportAccount(app, ownerID, acctIndex, tx.AccountID, tx.AccountName, tx.Institution, tx.BalanceGroup)
 		if err != nil {
@@ -859,8 +862,16 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 		txRec.Set("importSession", session.Id)
 		if err := app.Save(txRec); err == nil {
 			result.Transactions.Created++
+			accountsWithImportedTransactions[accountID] = struct{}{}
 		} else {
 			logImportError(session.Id, "transactions", i, "save", err)
+			errorCount++
+		}
+	}
+
+	for accountID := range accountsWithImportedTransactions {
+		if err := recomputeDerivedBalance(app, accountID, session.Id); err != nil {
+			logEvent("import", fmt.Sprintf("failed to recompute derived balance for account %s (session=%s)", accountID, session.Id), err)
 			errorCount++
 		}
 	}
@@ -1039,6 +1050,30 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 	totalDeleted := 0
 
 	err = app.RunInTransaction(func(txApp core.App) error {
+		affectedAccounts := map[string]struct{}{}
+		importedTransactions, err := txApp.FindRecordsByFilter("transactions",
+			"importSession = {:sid} && owner = {:owner}",
+			"", 0, 0,
+			map[string]any{"sid": body.SessionID, "owner": auth.Id},
+		)
+		if err != nil {
+			return err
+		}
+		for _, tx := range importedTransactions {
+			accountID := tx.GetString("account")
+			if accountID == "" {
+				continue
+			}
+			account, err := txApp.FindRecordById("accounts", accountID)
+			if err != nil || account.GetString("importSession") == body.SessionID {
+				continue
+			}
+			if account.GetDateTime("autoCalculated").IsZero() {
+				continue
+			}
+			affectedAccounts[accountID] = struct{}{}
+		}
+
 		for _, coll := range collections {
 			for {
 				records, err := txApp.FindRecordsByFilter(coll,
@@ -1055,6 +1090,12 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 					}
 					totalDeleted++
 				}
+			}
+		}
+
+		for accountID := range affectedAccounts {
+			if err := recomputeDerivedBalance(txApp, accountID, ""); err != nil {
+				return err
 			}
 		}
 

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -8,12 +8,28 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
 )
 
 var spaceRe = regexp.MustCompile(`\s+`)
+
+var revertingSessions sync.Map
+
+func markSessionReverting(sessionID string) {
+	revertingSessions.Store(sessionID, struct{}{})
+}
+
+func unmarkSessionReverting(sessionID string) {
+	revertingSessions.Delete(sessionID)
+}
+
+func isSessionReverting(sessionID string) bool {
+	_, ok := revertingSessions.Load(sessionID)
+	return ok
+}
 
 type importPayload struct {
 	SessionLabel         string                      `json:"sessionLabel"`
@@ -1045,6 +1061,9 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 	if session.GetString("status") == "rolled_back" {
 		return re.JSON(http.StatusBadRequest, map[string]string{"error": "Session already reverted"})
 	}
+
+	markSessionReverting(body.SessionID)
+	defer unmarkSessionReverting(body.SessionID)
 
 	collections := []string{"transactions", "securityTransactions", "accountBalances", "assetBalances", "securityBalances", "accounts", "assets", "securities"}
 	totalDeleted := 0

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -134,6 +134,13 @@ func main() {
 		if err := validateParentOwner(e.App, e.Record, "accounts", "account"); err != nil {
 			return err
 		}
+		// NOTE: the only programmatic creator that tags a balance derived is the balance worker;
+		// imports tag import. Any other write (the manual balance form, ad-hoc API clients) is
+		// user-entered, so an untagged accountBalances row defaults to manual rather than being
+		// mistaken for a worker-derived snapshot that revert cleanup may delete.
+		if e.Record.Collection().Name == "accountBalances" && e.Record.GetString("source") == "" {
+			e.Record.Set("source", "manual")
+		}
 		return e.Next()
 	})
 
@@ -148,6 +155,12 @@ func main() {
 	})
 
 	app.OnRecordAfterCreateSuccess("transactions").BindFunc(func(e *core.RecordEvent) error {
+		// NOTE: imported transactions skip the async enqueue because the import writes its own derived
+		// snapshot synchronously (tagged with the import session) once all rows are saved. Letting the
+		// worker fire too would append an untagged orphan that revert cannot identify and clean up.
+		if e.Record.GetString("importSession") != "" {
+			return e.Next()
+		}
 		if aid := e.Record.GetString("account"); aid != "" {
 			enqueueBalance(aid)
 		}

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -180,6 +180,14 @@ func main() {
 	})
 
 	app.OnRecordAfterDeleteSuccess("transactions").BindFunc(func(e *core.RecordEvent) error {
+		// NOTE: skip the async enqueue only for deletes that belong to an in-flight import revert,
+		// which recomputes affected accounts synchronously inside its transaction; letting the worker
+		// also fire would race that recompute (appending a duplicate snapshot) and run against
+		// import-created accounts cascade-deleted in the same revert. importSession alone is permanent,
+		// so a user deleting a single imported transaction outside revert must still enqueue.
+		if isSessionReverting(e.Record.GetString("importSession")) {
+			return e.Next()
+		}
 		if aid := e.Record.GetString("account"); aid != "" {
 			enqueueBalance(aid)
 		}

--- a/pocketbase/pb_migrations/1782063123_updated_accountBalances.js
+++ b/pocketbase/pb_migrations/1782063123_updated_accountBalances.js
@@ -1,0 +1,30 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // add field
+  collection.fields.addAt(8, new Field({
+    "hidden": false,
+    "id": "select1602912115",
+    "maxSelect": 1,
+    "name": "source",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "derived",
+      "manual",
+      "import"
+    ]
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1811848958")
+
+  // remove field
+  collection.fields.removeById("select1602912115")
+
+  return app.save(collection)
+})

--- a/src/lib/pocketbase.schema.ts
+++ b/src/lib/pocketbase.schema.ts
@@ -105,6 +105,11 @@ export type SuperusersRecord = {
 	verified?: boolean
 }
 
+export enum AccountBalancesSourceOptions {
+	"derived" = "derived",
+	"manual" = "manual",
+	"import" = "import",
+}
 export type AccountBalancesRecord = {
 	account: RecordIdString
 	asOf: IsoDateString
@@ -112,6 +117,7 @@ export type AccountBalancesRecord = {
 	id: string
 	importSession?: RecordIdString
 	owner: RecordIdString
+	source?: AccountBalancesSourceOptions
 	updated: IsoAutoDateString
 	value?: number
 }

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -35,6 +35,7 @@
 	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import {
+		AccountBalancesSourceOptions,
 		AccountsBalanceGroupOptions,
 		AccountSharesPerspectiveOptions
 	} from '$lib/pocketbase.schema';
@@ -270,7 +271,8 @@
 				account: currentAccountId,
 				owner: currentOwnerId,
 				asOf: new Date().toISOString(),
-				value: formData.value ? parseFloat(formData.value) : undefined
+				value: formData.value ? parseFloat(formData.value) : undefined,
+				source: AccountBalancesSourceOptions.manual
 			};
 
 			syncState.justSaved = true;


### PR DESCRIPTION
- Add an accountBalances source field (derived/manual/import) so balance provenance is explicit: the worker tags derived, imports tag import, the manual balance form tags manual, and untagged writes default to manual
- The import writes its own importSession-tagged derived snapshot per affected account and skips the async balance worker for its transactions, so the revert's session-scoped delete removes exactly that snapshot
- Reverting an import into an existing auto-calculated account no longer leaves a stale derived balance; prior derived history (which the Trends charts render) and user-entered manual balances are both preserved
- Add regression tests for the stale balance, manual-balance preservation, and historical-snapshot survival

No linked issue (confirmed by user)