### PR TITLE
fix: serialize and bound auto-balance recalculation

### DIFF
--- a/e2e/import.test.ts
+++ b/e2e/import.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 
-import type { TypedPocketBase } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
 	getUserPB,
+	listAccountBalances,
 	PB_URL,
 	pbSend,
 	seedAccount,
@@ -811,13 +811,6 @@ test('import accepts security and cryptocurrency balance types in assets payload
 	});
 	expect(securities.length).toBe(0);
 });
-
-async function listAccountBalances(pb: TypedPocketBase, account: string) {
-	return pb.collection('accountBalances').getFullList({
-		filter: `account = "${account}"`,
-		sort: '-asOf,-created,-id'
-	});
-}
 
 test('reverting an import into an existing account leaves no stale derived balance', async () => {
 	const user = await seedUser('sabrina');

--- a/e2e/pocketbase.helpers.ts
+++ b/e2e/pocketbase.helpers.ts
@@ -346,3 +346,10 @@ export async function getTransactionLabelsByName(owner: string, name: string) {
 		filter: `owner = "${owner}" && name = "${name}"`
 	});
 }
+
+export async function listAccountBalances(pb: TypedPocketBase, account: string) {
+	return pb.collection('accountBalances').getFullList({
+		filter: `account = "${account}"`,
+		sort: '-asOf,-created,-id'
+	});
+}

--- a/e2e/transactions.crud.test.ts
+++ b/e2e/transactions.crud.test.ts
@@ -2,10 +2,12 @@ import { UTCDate } from '@date-fns/utc';
 import { expect, test, type Page } from '@playwright/test';
 import { setHours, subDays } from 'date-fns';
 
-import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
+import { AccountsBalanceGroupOptions, type TypedPocketBase } from '../src/lib/pocketbase.schema';
 import { formatDateForInput, goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
 	getTransactionLabelsByName,
+	getUserPB,
+	listAccountBalances,
 	seedAccount,
 	seedAccountBalance,
 	seedAccountShare,
@@ -539,4 +541,65 @@ test('reuses existing labels instead of creating duplicates', async ({ page }) =
 
 	expect(await getTransactionLabelsByName(user.id, 'Groceries')).toHaveLength(1);
 	expect(await getTransactionLabelsByName(user.id, 'Dining')).toHaveLength(1);
+});
+
+async function latestBalanceValue(pb: TypedPocketBase, account: string) {
+	return (await listAccountBalances(pb, account))[0]?.value;
+}
+
+test('derived balance updates across the transaction lifecycle', async () => {
+	const user = await seedUser('gemma');
+	const accountA = await seedAccount({
+		name: 'Gemma Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		balanceType: 'Checking',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+	const accountB = await seedAccount({
+		name: 'Gemma Savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		balanceType: 'Savings',
+		owner: user.id,
+		autoCalculated: new Date().toISOString()
+	});
+
+	const pb = await getUserPB(user.email);
+
+	const transaction = await seedTransaction({
+		account: accountA.id,
+		owner: user.id,
+		date: '2025-06-01T00:00:00.000Z',
+		description: 'Opening deposit',
+		value: 100
+	});
+	await expect
+		.poll(async () => latestBalanceValue(pb, accountA.id), { message: 'create' })
+		.toBe(100);
+
+	await pb.collection('transactions').update(transaction.id, { value: 250 });
+	await expect.poll(async () => latestBalanceValue(pb, accountA.id), { message: 'edit' }).toBe(250);
+
+	await pb
+		.collection('transactions')
+		.update(transaction.id, { excluded: new Date().toISOString() });
+	await expect
+		.poll(async () => latestBalanceValue(pb, accountA.id), { message: 'exclude on' })
+		.toBe(0);
+
+	await pb.collection('transactions').update(transaction.id, { excluded: '' });
+	await expect
+		.poll(async () => latestBalanceValue(pb, accountA.id), { message: 'exclude off' })
+		.toBe(250);
+
+	await pb.collection('transactions').update(transaction.id, { account: accountB.id });
+	await expect
+		.poll(async () => latestBalanceValue(pb, accountA.id), { message: 'reassign source' })
+		.toBe(0);
+	await expect
+		.poll(async () => latestBalanceValue(pb, accountB.id), { message: 'reassign target' })
+		.toBe(250);
+
+	await pb.collection('transactions').delete(transaction.id);
+	await expect.poll(async () => latestBalanceValue(pb, accountB.id), { message: 'delete' }).toBe(0);
 });

--- a/pocketbase/balance.go
+++ b/pocketbase/balance.go
@@ -15,9 +15,24 @@ import (
 const debounceMs = 250
 const tickerMs = 50
 
+// NOTE: caps how many full-history balance recalculations run at once so a large import burst
+// can't spawn one unbounded goroutine per affected account.
+const maxConcurrentCalcs = 4
+
+// NOTE: each saved accountBalances row's asOf is stamped at save time, so an older calculation that
+// finishes after a newer one would become the stale "latest" balance. This state guarantees at most
+// one calculation runs per account at a time, so the last to finish is always the freshest.
 var (
-	pending   = make(map[string]time.Time)
 	pendingMu sync.Mutex
+	pending   = make(map[string]time.Time)
+	inFlight  = make(map[string]bool)
+	dirty     = make(map[string]time.Time)
+	calcSem   = make(chan struct{}, maxConcurrentCalcs)
+
+	// NOTE: assign recompute only before balanceWorker and app.Start() launch (or under pendingMu in
+	// tests). It is read from request-path goroutines (the deferred go runCalc), so a later
+	// unsynchronized write would be a data race.
+	recompute func(accountID string)
 )
 
 func enqueueBalance(accountID string) {
@@ -38,20 +53,111 @@ func balanceWorker(ctx context.Context, app *pocketbase.PocketBase) {
 			pendingMu.Lock()
 			now := time.Now()
 			for accountID, queuedAt := range pending {
-				if now.Sub(queuedAt) >= debounceMs*time.Millisecond {
-					delete(pending, accountID)
-					go calculateBalance(app, accountID)
+				if now.Sub(queuedAt) < debounceMs*time.Millisecond {
+					continue
 				}
+				delete(pending, accountID)
+				if inFlight[accountID] {
+					dirty[accountID] = now
+					continue
+				}
+				inFlight[accountID] = true
+				go runCalc(accountID)
 			}
 			pendingMu.Unlock()
 		}
 	}
 }
 
-func calculateBalance(app *pocketbase.PocketBase, accountID string) {
-	if err := recomputeDerivedBalance(app, accountID, ""); err != nil {
-		logEvent("balance", fmt.Sprintf("failed to recompute balance for account %s", accountID), err)
+func runCalc(accountID string) {
+	// NOTE: release the inFlight slot even if recompute panics, so a panicking calculation can't
+	// permanently strand the account in flight and block every future recalculation for it.
+	defer releaseInFlight(accountID)
+	for {
+		if boundedRecompute(accountID) {
+			return
+		}
 	}
+}
+
+func boundedRecompute(accountID string) bool {
+	calcSem <- struct{}{}
+	defer func() { <-calcSem }()
+	recompute(accountID)
+
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	if _, ok := dirty[accountID]; ok {
+		delete(dirty, accountID)
+		return false
+	}
+	return true
+}
+
+func releaseInFlight(accountID string) {
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	delete(inFlight, accountID)
+}
+
+func acquireInFlight(accountID string) {
+	for {
+		pendingMu.Lock()
+		if !inFlight[accountID] {
+			inFlight[accountID] = true
+			// NOTE: drop any debounce-pending worker calc queued before this lock (e.g. by a
+			// pre-existing transaction added moments before an import). Once the lock holder writes
+			// its authoritative snapshot, that stale pending calc — which would recompute against
+			// the lock's just-written transactions and append an untagged orphan revert can't clean
+			// up — must not fire. A genuine edit to a surviving transaction during the lock re-adds
+			// pending after this point, so the worker still recomputes that case post-lock.
+			delete(pending, accountID)
+			pendingMu.Unlock()
+			return
+		}
+		pendingMu.Unlock()
+		time.Sleep(tickerMs * time.Millisecond)
+	}
+}
+
+// NOTE: use this only for inline recomputes NOT inside an open transaction (the import-create path);
+// for recomputes inside a transaction use withAccountCalcLockReportDirty and re-enqueue post-commit.
+func withAccountCalcLock(accountID string, fn func() error) error {
+	acquireInFlight(accountID)
+
+	defer func() {
+		pendingMu.Lock()
+		if _, ok := dirty[accountID]; ok {
+			// NOTE: hand the still-held slot to the worker without releasing inFlight; keeping it held
+			// closes the window where a worker tick could launch a second runCalc.
+			delete(dirty, accountID)
+			pendingMu.Unlock()
+			go runCalc(accountID)
+			return
+		}
+		delete(inFlight, accountID)
+		pendingMu.Unlock()
+	}()
+
+	return fn()
+}
+
+// NOTE: unlike withAccountCalcLock this never launches the follow-up and fully releases the slot, so a
+// caller running fn inside an open transaction must re-enqueue the reported-dirty accounts after commit
+// — the worker then recomputes against committed state, not the transaction's uncommitted rows.
+func withAccountCalcLockReportDirty(accountID string, fn func() error) (wentDirty bool, err error) {
+	acquireInFlight(accountID)
+	defer func() {
+		pendingMu.Lock()
+		defer pendingMu.Unlock()
+		if _, ok := dirty[accountID]; ok {
+			delete(dirty, accountID)
+			wentDirty = true
+		}
+		delete(inFlight, accountID)
+	}()
+
+	return false, fn()
 }
 
 func recomputeDerivedBalance(app core.App, accountID string, importSession string) error {

--- a/pocketbase/balance_test.go
+++ b/pocketbase/balance_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func resetBalanceState() {
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	pending = make(map[string]time.Time)
+	inFlight = make(map[string]bool)
+	dirty = make(map[string]time.Time)
+	calcSem = make(chan struct{}, maxConcurrentCalcs)
+}
+
+func startCalc(accountID string) bool {
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	if inFlight[accountID] {
+		dirty[accountID] = time.Now()
+		return false
+	}
+	inFlight[accountID] = true
+	go runCalc(accountID)
+	return true
+}
+
+// NOTE: guards that overlapping recomputes serialize so the newest enqueued value is recorded last,
+// even when the older calculation is slower and would otherwise save after it.
+func TestSerializedRecomputeKeepsNewestValue(t *testing.T) {
+	resetBalanceState()
+	defer resetBalanceState()
+	originalRecompute := recompute
+	defer func() { recompute = originalRecompute }()
+
+	const accountID = "acct"
+
+	var mu sync.Mutex
+	var saves []int // ordered record of "saved" values, newest balance is the last entry
+	calls := 0
+	finished := make(chan struct{}, 8)
+
+	recompute = func(id string) {
+		mu.Lock()
+		n := calls
+		calls++
+		mu.Unlock()
+
+		if n == 0 {
+			time.Sleep(80 * time.Millisecond)
+		}
+
+		mu.Lock()
+		saves = append(saves, n)
+		mu.Unlock()
+		finished <- struct{}{}
+	}
+
+	if !startCalc(accountID) {
+		t.Fatal("first startCalc should launch a calculation")
+	}
+	if startCalc(accountID) {
+		t.Fatal("second startCalc should coalesce into dirty, not launch a parallel calculation")
+	}
+	if startCalc(accountID) {
+		t.Fatal("third startCalc should also coalesce, not launch a parallel calculation")
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-finished:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected calculation %d to finish", i)
+		}
+	}
+
+	select {
+	case <-finished:
+		t.Fatal("a third calculation ran; follow-ups were not coalesced into exactly one")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(saves) != 2 {
+		t.Fatalf("expected exactly 2 saves, got %d: %v", len(saves), saves)
+	}
+	if saves[len(saves)-1] != 1 {
+		t.Fatalf("newest calculation must save last; got order %v", saves)
+	}
+	if saves[0] != 0 {
+		t.Fatalf("older calculation must save first; got order %v", saves)
+	}
+
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	if inFlight[accountID] {
+		t.Fatal("inFlight should be cleared after the follow-up calculation")
+	}
+	if _, ok := dirty[accountID]; ok {
+		t.Fatal("dirty should be cleared after the follow-up calculation")
+	}
+}
+
+// NOTE: guards that an inline recompute under withAccountCalcLock never overlaps a worker calc for the
+// same account, and that a worker enqueue arriving mid-lock coalesces into a single follow-up.
+func TestInlineLockSerializesWithWorker(t *testing.T) {
+	resetBalanceState()
+	defer resetBalanceState()
+	originalRecompute := recompute
+	defer func() { recompute = originalRecompute }()
+
+	const accountID = "acct"
+
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	workerRan := make(chan struct{}, 1)
+
+	enter := func() {
+		mu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+	}
+	leave := func() {
+		mu.Lock()
+		active--
+		mu.Unlock()
+	}
+
+	recompute = func(id string) {
+		enter()
+		time.Sleep(40 * time.Millisecond)
+		leave()
+		select {
+		case workerRan <- struct{}{}:
+		default:
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = withAccountCalcLock(accountID, func() error {
+			enter()
+			startCalc(accountID)
+			time.Sleep(40 * time.Millisecond)
+			leave()
+			return nil
+		})
+	}()
+
+	wg.Wait()
+
+	select {
+	case <-workerRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker follow-up never ran after inline recompute released the lock")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxActive != 1 {
+		t.Fatalf("inline and worker recompute overlapped (maxActive=%d); must be serialized", maxActive)
+	}
+}
+
+// NOTE: guards that the report-dirty variant releases the slot and defers the follow-up (no inline
+// runCalc), leaving the account clean so the revert handler re-enqueues it post-commit.
+func TestReportDirtyDefersFollowUp(t *testing.T) {
+	resetBalanceState()
+	defer resetBalanceState()
+	originalRecompute := recompute
+	defer func() { recompute = originalRecompute }()
+
+	const accountID = "acct"
+
+	var mu sync.Mutex
+	calls := 0
+	recompute = func(id string) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	wentDirty, err := withAccountCalcLockReportDirty(accountID, func() error {
+		if startCalc(accountID) {
+			t.Error("enqueue during the inline lock should coalesce into dirty, not launch a calculation")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wentDirty {
+		t.Fatal("an enqueue landed during the inline recompute; wentDirty must be true")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	pendingMu.Lock()
+	stillInFlight := inFlight[accountID]
+	_, stillDirty := dirty[accountID]
+	pendingMu.Unlock()
+	if stillInFlight {
+		t.Fatal("report-dirty variant must release the in-flight slot; the follow-up is deferred to post-commit")
+	}
+	if stillDirty {
+		t.Fatal("the dirty flag must be consumed by the report so the caller owns the re-enqueue")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("no follow-up recompute may run inline; the worker recomputes post-commit (calls=%d)", calls)
+	}
+}
+
+// drainPendingOnce mirrors a single balanceWorker tick's pending-drain loop, ignoring the debounce
+// window so a test can deterministically force the worker to act on queued accounts.
+func drainPendingOnce() {
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	now := time.Now()
+	for accountID := range pending {
+		delete(pending, accountID)
+		if inFlight[accountID] {
+			dirty[accountID] = now
+			continue
+		}
+		inFlight[accountID] = true
+		go runCalc(accountID)
+	}
+}
+
+// NOTE: guards that claiming the per-account calc lock drops a debounce-pending worker calc queued
+// before the lock (e.g. a pre-existing transaction added moments before an import). Were it left
+// queued, it would fire after the lock writes its authoritative snapshot, recompute against the
+// lock's just-written transactions, and append an untagged derived orphan that import-revert — which
+// deletes only session-tagged rows — cannot clean up.
+func TestInlineLockDropsPendingWorkerCalc(t *testing.T) {
+	resetBalanceState()
+	defer resetBalanceState()
+	originalRecompute := recompute
+	defer func() { recompute = originalRecompute }()
+
+	const accountID = "acct"
+
+	var mu sync.Mutex
+	calls := 0
+	recompute = func(id string) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	enqueueBalance(accountID)
+
+	_ = withAccountCalcLock(accountID, func() error { return nil })
+
+	drainPendingOnce()
+	time.Sleep(80 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("a worker calc fired after the lock and would write an untagged stale snapshot (calls=%d)", calls)
+	}
+}
+
+// NOTE: complements TestInlineLockDropsPendingWorkerCalc for the revert path: the report-dirty lock
+// variant must likewise drop a pre-lock pending worker calc so revert's recompute is the only
+// untagged derived snapshot left for the account.
+func TestReportDirtyLockDropsPendingWorkerCalc(t *testing.T) {
+	resetBalanceState()
+	defer resetBalanceState()
+	originalRecompute := recompute
+	defer func() { recompute = originalRecompute }()
+
+	const accountID = "acct"
+
+	var mu sync.Mutex
+	calls := 0
+	recompute = func(id string) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}
+
+	enqueueBalance(accountID)
+
+	wentDirty, err := withAccountCalcLockReportDirty(accountID, func() error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wentDirty {
+		t.Fatal("a pre-lock pending entry must be dropped, not reported as dirty")
+	}
+
+	drainPendingOnce()
+	time.Sleep(80 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("a worker calc fired after the report-dirty lock (calls=%d)", calls)
+	}
+}

--- a/pocketbase/import.go
+++ b/pocketbase/import.go
@@ -886,7 +886,11 @@ func handleImport(app core.App, re *core.RequestEvent) error {
 	}
 
 	for accountID := range accountsWithImportedTransactions {
-		if err := recomputeDerivedBalance(app, accountID, session.Id); err != nil {
+		// NOTE: serialize with the async balance worker so a concurrent edit on the same account
+		// can't overlap this inline snapshot and clobber it with a stale value.
+		if err := withAccountCalcLock(accountID, func() error {
+			return recomputeDerivedBalance(app, accountID, session.Id)
+		}); err != nil {
 			logEvent("import", fmt.Sprintf("failed to recompute derived balance for account %s (session=%s)", accountID, session.Id), err)
 			errorCount++
 		}
@@ -1068,6 +1072,11 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 	collections := []string{"transactions", "securityTransactions", "accountBalances", "assetBalances", "securityBalances", "accounts", "assets", "securities"}
 	totalDeleted := 0
 
+	// NOTE: accounts re-dirtied during the inline revert recompute; their follow-up is deferred until
+	// after commit so the worker recomputes against committed state, not the transaction's uncommitted
+	// rows.
+	var reenqueueAfterCommit []string
+
 	err = app.RunInTransaction(func(txApp core.App) error {
 		affectedAccounts := map[string]struct{}{}
 		importedTransactions, err := txApp.FindRecordsByFilter("transactions",
@@ -1113,8 +1122,16 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 		}
 
 		for accountID := range affectedAccounts {
-			if err := recomputeDerivedBalance(txApp, accountID, ""); err != nil {
+			// NOTE: serialize with the async balance worker so a concurrent edit can't overlap this
+			// revert recompute and clobber it with a stale value.
+			wentDirty, err := withAccountCalcLockReportDirty(accountID, func() error {
+				return recomputeDerivedBalance(txApp, accountID, "")
+			})
+			if err != nil {
 				return err
+			}
+			if wentDirty {
+				reenqueueAfterCommit = append(reenqueueAfterCommit, accountID)
 			}
 		}
 
@@ -1160,6 +1177,10 @@ func handleRevert(app core.App, re *core.RequestEvent) error {
 
 	if err != nil {
 		return re.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Revert failed: %v", err)})
+	}
+
+	for _, accountID := range reenqueueAfterCommit {
+		enqueueBalance(accountID)
 	}
 
 	return re.JSON(http.StatusOK, map[string]any{"sessionId": body.SessionID, "deleted": totalDeleted})

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -37,6 +38,14 @@ func main() {
 		logEvent("server", "shutting down balance worker", nil)
 		cancel()
 	}()
+
+	// NOTE: publish recompute here, before balanceWorker and the request-path goroutines that read it
+	// start; assigning it later would be an unsynchronized write racing those readers.
+	recompute = func(accountID string) {
+		if err := recomputeDerivedBalance(app, accountID, ""); err != nil {
+			logEvent("balance", fmt.Sprintf("failed to recompute balance for account %s", accountID), err)
+		}
+	}
 
 	go balanceWorker(ctx, app)
 


### PR DESCRIPTION
## What

Serializes the auto-balance recalculation worker so only one calculation runs per account at a time, bounds global concurrency, and stops a stale worker recompute from racing an import/revert.

## Why

The worker could launch multiple concurrent recalculations for the same account. Because each `accountBalances` row stamps `asOf` at save time, a slow older calculation could finish after a newer one and become the stale "latest" balance. Large imports also spawned an unbounded full-history scan per affected account.

A remaining race surfaced only under parallel load: a debounce-pending worker calc (e.g. from a pre-existing transaction added moments before an import) could fire *after* the import wrote its authoritative snapshot, recompute against the import's transactions, and append an **untagged** derived balance that import-revert — which deletes only session-tagged rows — could not clean up, leaving a stale derived value after revert.

## How

- Per-account serialization (`inFlight`/`dirty`): one calc at a time, concurrent enqueues coalesce into a single follow-up.
- Bounded global concurrency via a `maxConcurrentCalcs` semaphore.
- `acquireInFlight` drops any debounce-pending worker calc when an import/revert claims the per-account lock, so a stale recompute can't append an orphan snapshot.
- `withAccountCalcLockReportDirty` lets in-transaction callers re-enqueue post-commit so the worker recomputes against committed state.

## Verification

- `go test -race -count=3 ./...` — clean (includes new concurrency guard tests).
- `bun run test -- e2e/transactions.crud.test.ts e2e/import.test.ts --repeat-each=10` across both projects — **700 passed, 0 failed, 0 flaky**.
- `bun run check`, `bun run lint` — clean.