### PR TITLE
perf: load latest account and asset balances in bulk

### DIFF
--- a/e2e/ownership-security.test.ts
+++ b/e2e/ownership-security.test.ts
@@ -7,11 +7,22 @@ import {
 import {
 	getUserPB,
 	pbSend,
+	PB_URL,
 	seedAccount,
+	seedAccountBalance,
 	seedAsset,
+	seedAssetBalance,
 	seedTransaction,
 	seedUser
 } from './pocketbase.helpers';
+
+async function getLatestBalances(email: string, path: string) {
+	const pb = await getUserPB(email);
+	const response = await fetch(`${PB_URL}${path}`, {
+		headers: { Authorization: `Bearer ${pb.authStore.token}` }
+	});
+	return response.json() as Promise<Record<string, { id: string }>>;
+}
 
 async function latestAccountBalance(email: string, accountId: string) {
 	const pb = await getUserPB(email);
@@ -132,6 +143,71 @@ test('rejects reparenting a transaction to a foreign account or changing its own
 	await expect(changeOwner).rejects.toMatchObject({ status: 403 });
 
 	expect(await latestAccountBalance(carol.email, carolAccount.id)).toBe(balanceBeforeAttack);
+});
+
+test('bulk latest-balance endpoints never expose another owner balances', async () => {
+	const frank = await seedUser('frank');
+	const grace = await seedUser('grace');
+
+	const frankAccount = await seedAccount({
+		name: 'Frank Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: frank.id,
+		balanceType: 'Checking'
+	});
+	const frankAsset = await seedAsset({
+		name: 'Frank Collectible',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: frank.id,
+		balanceType: 'Collectible'
+	});
+	await seedAccountBalance({
+		account: frankAccount.id,
+		owner: frank.id,
+		asOf: new Date().toISOString(),
+		value: 4200
+	});
+	await seedAssetBalance({
+		asset: frankAsset.id,
+		owner: frank.id,
+		asOf: new Date().toISOString(),
+		bookValue: 1000,
+		marketValue: 1500
+	});
+
+	const graceAccount = await seedAccount({
+		name: 'Grace Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: grace.id,
+		balanceType: 'Checking'
+	});
+	const graceAsset = await seedAsset({
+		name: 'Grace Collectible',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: grace.id,
+		balanceType: 'Collectible'
+	});
+	await seedAccountBalance({
+		account: graceAccount.id,
+		owner: grace.id,
+		asOf: new Date().toISOString(),
+		value: 99
+	});
+	await seedAssetBalance({
+		asset: graceAsset.id,
+		owner: grace.id,
+		asOf: new Date().toISOString(),
+		bookValue: 50,
+		marketValue: 50
+	});
+
+	const accountBalances = await getLatestBalances(grace.email, '/api/balances/accounts/latest');
+	expect(accountBalances[graceAccount.id]).toBeDefined();
+	expect(accountBalances[frankAccount.id]).toBeUndefined();
+
+	const assetBalances = await getLatestBalances(grace.email, '/api/balances/assets/latest');
+	expect(assetBalances[graceAsset.id]).toBeDefined();
+	expect(assetBalances[frankAsset.id]).toBeUndefined();
 });
 
 test('owner can create a transaction on their own account', async () => {

--- a/pocketbase/balances.go
+++ b/pocketbase/balances.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// NOTE: FindRecordsByFilter does not auto-apply collection list rules, so each handler
+// replicates the matching balance collection's listRule to guarantee a user can never read
+// a balance for a parent they cannot see.
+const visibleAccountBalanceFilter = "owner = {:user} || account.accountShares_via_account.recipient ?= {:user}"
+const visibleAssetBalanceFilter = "owner = {:user} || asset.assetShares_via_asset.recipient ?= {:user}"
+
+const latestBalanceSort = "-asOf,-created,-id"
+
+type latestAccountBalance struct {
+	ID      string  `json:"id"`
+	Account string  `json:"account"`
+	Value   float64 `json:"value"`
+	AsOf    string  `json:"asOf"`
+	Created string  `json:"created"`
+}
+
+type latestAssetBalance struct {
+	ID          string  `json:"id"`
+	Asset       string  `json:"asset"`
+	MarketValue float64 `json:"marketValue"`
+	BookValue   float64 `json:"bookValue"`
+	AsOf        string  `json:"asOf"`
+	Created     string  `json:"created"`
+}
+
+func latestAccountBalancesHandler(app core.App) func(*core.RequestEvent) error {
+	return func(re *core.RequestEvent) error {
+		records, err := app.FindRecordsByFilter(
+			"accountBalances",
+			visibleAccountBalanceFilter,
+			latestBalanceSort,
+			0,
+			0,
+			map[string]any{"user": re.Auth.Id},
+		)
+		if err != nil {
+			return re.InternalServerError("Failed to load account balances", err)
+		}
+
+		latest := make(map[string]latestAccountBalance)
+		for _, record := range records {
+			account := record.GetString("account")
+			if _, seen := latest[account]; seen {
+				continue
+			}
+			latest[account] = latestAccountBalance{
+				ID:      record.Id,
+				Account: account,
+				Value:   record.GetFloat("value"),
+				AsOf:    record.GetString("asOf"),
+				Created: record.GetString("created"),
+			}
+		}
+
+		return re.JSON(http.StatusOK, latest)
+	}
+}
+
+func latestAssetBalancesHandler(app core.App) func(*core.RequestEvent) error {
+	return func(re *core.RequestEvent) error {
+		records, err := app.FindRecordsByFilter(
+			"assetBalances",
+			visibleAssetBalanceFilter,
+			latestBalanceSort,
+			0,
+			0,
+			map[string]any{"user": re.Auth.Id},
+		)
+		if err != nil {
+			return re.InternalServerError("Failed to load asset balances", err)
+		}
+
+		latest := make(map[string]latestAssetBalance)
+		for _, record := range records {
+			asset := record.GetString("asset")
+			if _, seen := latest[asset]; seen {
+				continue
+			}
+			latest[asset] = latestAssetBalance{
+				ID:          record.Id,
+				Asset:       asset,
+				MarketValue: record.GetFloat("marketValue"),
+				BookValue:   record.GetFloat("bookValue"),
+				AsOf:        record.GetString("asOf"),
+				Created:     record.GetString("created"),
+			}
+		}
+
+		return re.JSON(http.StatusOK, latest)
+	}
+}

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -83,6 +83,13 @@ func main() {
 			apis.RequireAuth("users"),
 		)
 
+		e.Router.GET("/api/balances/accounts/latest", latestAccountBalancesHandler(e.App)).Bind(
+			apis.RequireAuth("users"),
+		)
+		e.Router.GET("/api/balances/assets/latest", latestAssetBalancesHandler(e.App)).Bind(
+			apis.RequireAuth("users"),
+		)
+
 		return e.Next()
 	})
 

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -215,14 +215,15 @@ class AccountsContext {
 		for (const account of accounts) {
 			await this.balanceTypesContext.ensureLoaded(account.balanceType);
 		}
-		const latestBalances = await Promise.all(
-			accounts.map((account) => this.getLatestAccountBalance(account.id))
+		const latestBalances = await this._pb.getJson<Record<string, LatestAccountBalance>>(
+			'/api/balances/accounts/latest'
 		);
 		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 
 		this.latestCashByAccount.clear();
-		for (const balance of latestBalances) {
-			if (balance) this.latestCashByAccount.set(balance.account, balance);
+		for (const account of accounts) {
+			const balance = latestBalances[account.id];
+			if (balance) this.latestCashByAccount.set(account.id, balance);
 		}
 		this.rawAccounts = accounts;
 		this.accountsLoaded = true;

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -28,6 +28,15 @@ type LatestAssetBalance = AssetBalanceData & {
 	created: string;
 };
 
+type LatestAssetBalanceResponse = {
+	id: string;
+	asset: string;
+	marketValue: number;
+	bookValue: number;
+	asOf: string;
+	created: string;
+};
+
 const DEFAULT_BALANCE_DATA: AssetBalanceData = {
 	marketValue: 0,
 	bookValue: 0,
@@ -196,18 +205,18 @@ class AssetsContext {
 		const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
 			requestKey: null
 		});
-		const latestBalances = new SvelteMap<string, LatestAssetBalance>();
 		for (const asset of list) {
 			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
 			if (refreshId !== this._refreshAssetsSequence) return false;
-			const balanceData = await this.getLatestAssetBalance(asset.id);
-			if (refreshId !== this._refreshAssetsSequence) return false;
-			if (balanceData) latestBalances.set(asset.id, balanceData);
 		}
+		const latestBalances = await this._pb.getJson<Record<string, LatestAssetBalanceResponse>>(
+			'/api/balances/assets/latest'
+		);
 		if (refreshId !== this._refreshAssetsSequence) return false;
 		this.latestBalanceByAsset.clear();
-		for (const [assetId, balance] of latestBalances) {
-			this.latestBalanceByAsset.set(assetId, balance);
+		for (const asset of list) {
+			const balance = latestBalances[asset.id];
+			if (balance) this.latestBalanceByAsset.set(asset.id, this.toLatestAssetBalance(balance));
 		}
 		this.rawAssets = list;
 		return true;
@@ -472,7 +481,13 @@ class AssetsContext {
 		return balance ? this.toLatestAssetBalance(balance) : null;
 	}
 
-	private toLatestAssetBalance(balance: AssetBalancesResponse) {
+	private toLatestAssetBalance(balance: {
+		id: string;
+		marketValue?: number;
+		bookValue?: number;
+		asOf: string;
+		created: string;
+	}) {
 		return {
 			id: balance.id,
 			marketValue: balance.marketValue ?? 0,

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -60,6 +60,26 @@ export class PocketBaseContext {
 		return label.id;
 	}
 
+	async getJson<T>(path: string) {
+		const token = this.authedClient.authStore.token;
+		const response = await fetch(`${this.backendUrl}${path}`, {
+			headers: {
+				Authorization: `Bearer ${token}`
+			}
+		});
+
+		const data = (await response.json().catch(() => null)) as T | { message?: string } | null;
+		if (!response.ok) {
+			const message =
+				data && typeof data === 'object' && 'message' in data && typeof data.message === 'string'
+					? data.message
+					: `Request failed with status ${response.status}`;
+			throw new Error(message);
+		}
+
+		return data as T;
+	}
+
 	async postJson<T>(path: string, body: Record<string, unknown>) {
 		const token = this.authedClient.authStore.token;
 		const response = await fetch(`${this.backendUrl}${path}`, {


### PR DESCRIPTION
## What

The accounts and assets stores loaded latest balances with an N+1 — one `getList(1,1)` request per account (parallel) and one per asset (**serial**). This adds two authenticated bulk endpoints so each store's initial refresh makes a single request:

- `GET /api/balances/accounts/latest` — latest balance per visible account, keyed by account id
- `GET /api/balances/assets/latest` — latest balance per visible asset, keyed by asset id

## How

- New `pocketbase/balances.go`: each handler fetches the visible balances ordered `-asOf,-created,-id` and keeps the first row seen per parent (latest-per-parent reduce in Go — the codebase uses no SQL `GROUP BY`).
- Handlers replicate the exact `accountBalances`/`assetBalances` list rules (`FindRecordsByFilter` does not auto-apply collection rules), so a user can only receive balances for parents they can see.
- `getJson<T>` helper added to `pocketbase.svelte.ts` (mirrors `postJson`).
- `refreshAccounts` / `refreshAssets` call the bulk endpoint once and look up each parent's balance from the returned map. Single-record realtime refresh helpers and client-side perspective projection are unchanged — visible balances and totals are identical.

## Verification

- `go test -race ./...` — clean.
- `e2e/accounts.test.ts e2e/assets.test.ts e2e/ownership-security.test.ts --project=desktop` — 20 passed (includes a new cross-owner leak guard per endpoint).
- `bun run check` — 0/0; `eslint` — clean.

## Known tradeoff

The latest-per-parent reduce fetches a user's full balance history in one query. That's a clear win over N+1 today; at very large histories a windowed query would be better, but that would require raw SQL the codebase deliberately avoids. Deferred per plan 010 Step 4.