### PR TITLE
fix: guard account and asset list refreshes against stale overwrites

### DIFF
--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -66,6 +66,7 @@ class AccountsContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
 	private refreshSequence = 0;
+	private mutationEpoch = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
@@ -206,6 +207,7 @@ class AccountsContext {
 
 	private async refreshAccounts(userId = this.currentUserId, token = this.refreshSequence) {
 		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
+		const epoch = this.mutationEpoch;
 		const accounts = await this._pb.authedClient
 			.collection('accounts')
 			.getFullList<AccountsResponse>({
@@ -220,11 +222,16 @@ class AccountsContext {
 		);
 		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 
-		this.latestCashByAccount.clear();
-		for (const balance of latestBalances) {
-			if (balance) this.latestCashByAccount.set(balance.account, balance);
+		// NOTE: A targeted membership mutation landed while this list was
+		// in flight, so the fetched snapshot is stale; leave membership and
+		// balances to the mutation but still mark the store loaded.
+		if (epoch === this.mutationEpoch) {
+			this.latestCashByAccount.clear();
+			for (const balance of latestBalances) {
+				if (balance) this.latestCashByAccount.set(balance.account, balance);
+			}
+			this.rawAccounts = accounts;
 		}
-		this.rawAccounts = accounts;
 		this.accountsLoaded = true;
 	}
 
@@ -319,7 +326,7 @@ class AccountsContext {
 
 	private async onAccountEvent(action: string, account: AccountsResponse, userId: string) {
 		if (action === 'delete') {
-			this.rawAccounts = this.rawAccounts.filter((record) => record.id !== account.id);
+			this.removeAccountRecord(account.id);
 			this.latestCashByAccount.delete(account.id);
 			this.notifyBalancesChanged();
 			return;
@@ -327,10 +334,7 @@ class AccountsContext {
 
 		await this.balanceTypesContext.ensureLoaded(account.balanceType);
 		if (userId !== this.currentUserId) return;
-		const exists = this.rawAccounts.some((record) => record.id === account.id);
-		this.rawAccounts = exists
-			? this.rawAccounts.map((record) => (record.id === account.id ? account : record))
-			: [...this.rawAccounts, account];
+		this.upsertAccountRecord(account);
 		if (!this.latestCashByAccount.has(account.id)) {
 			await this.refreshAccountBalance(account.id, userId);
 		}
@@ -373,6 +377,23 @@ class AccountsContext {
 		}
 	}
 
+	// NOTE: Targeted membership changes bump mutationEpoch so an in-flight
+	// refreshAccounts that fetched its list before this mutation aborts its
+	// commit and can't overwrite newer state with a stale snapshot.
+	private upsertAccountRecord(account: AccountsResponse) {
+		const exists = this.rawAccounts.some((record) => record.id === account.id);
+		this.rawAccounts = exists
+			? this.rawAccounts.map((record) => (record.id === account.id ? account : record))
+			: [...this.rawAccounts, account];
+		if (!exists) this.mutationEpoch++;
+	}
+
+	private removeAccountRecord(accountId: string) {
+		if (!this.rawAccounts.some((record) => record.id === accountId)) return;
+		this.rawAccounts = this.rawAccounts.filter((record) => record.id !== accountId);
+		this.mutationEpoch++;
+	}
+
 	async refreshAccount(accountId: string, userId: string) {
 		if (!userId || userId !== this.currentUserId) return false;
 		try {
@@ -382,16 +403,13 @@ class AccountsContext {
 			await this.balanceTypesContext.ensureLoaded(account.balanceType);
 			const balance = await this.getLatestAccountBalance(accountId);
 			if (userId !== this.currentUserId) return false;
-			const exists = this.rawAccounts.some((record) => record.id === account.id);
-			this.rawAccounts = exists
-				? this.rawAccounts.map((record) => (record.id === account.id ? account : record))
-				: [...this.rawAccounts, account];
+			this.upsertAccountRecord(account);
 			if (balance) this.latestCashByAccount.set(accountId, balance);
 			else this.latestCashByAccount.delete(accountId);
 			return true;
 		} catch (error) {
 			if (this.isUnavailableRecordError(error)) {
-				this.rawAccounts = this.rawAccounts.filter((account) => account.id !== accountId);
+				this.removeAccountRecord(accountId);
 				this.latestCashByAccount.delete(accountId);
 				return true;
 			}

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -66,6 +66,7 @@ class AssetsContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
 	private _refreshAssetsSequence = 0;
+	private mutationEpoch = 0;
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
@@ -193,23 +194,29 @@ class AssetsContext {
 
 	private async refreshAssets() {
 		const refreshId = ++this._refreshAssetsSequence;
+		const epoch = this.mutationEpoch;
 		const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
 			requestKey: null
 		});
-		const latestBalances = new SvelteMap<string, LatestAssetBalance>();
 		for (const asset of list) {
 			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
-			if (refreshId !== this._refreshAssetsSequence) return false;
-			const balanceData = await this.getLatestAssetBalance(asset.id);
-			if (refreshId !== this._refreshAssetsSequence) return false;
-			if (balanceData) latestBalances.set(asset.id, balanceData);
 		}
+		const latestBalances = await Promise.all(
+			list.map((asset) => this.getLatestAssetBalance(asset.id))
+		);
 		if (refreshId !== this._refreshAssetsSequence) return false;
-		this.latestBalanceByAsset.clear();
-		for (const [assetId, balance] of latestBalances) {
-			this.latestBalanceByAsset.set(assetId, balance);
+
+		// NOTE: A targeted membership mutation landed while this list was in
+		// flight, so the fetched snapshot is stale; leave membership and
+		// balances to the mutation rather than overwriting with stale state.
+		if (epoch === this.mutationEpoch) {
+			this.latestBalanceByAsset.clear();
+			list.forEach((asset, index) => {
+				const balance = latestBalances[index];
+				if (balance) this.latestBalanceByAsset.set(asset.id, balance);
+			});
+			this.rawAssets = list;
 		}
-		this.rawAssets = list;
 		return true;
 	}
 
@@ -272,22 +279,19 @@ class AssetsContext {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			const balanceData = await this.getLatestAssetBalance(e.record.id);
 			if (userId !== this.currentUserId) return;
-			this.rawAssets = [...this.rawAssets, e.record];
+			this.upsertAssetRecord(e.record);
 			if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
 		} else if (e.action === 'update') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
 			if (userId !== this.currentUserId) return;
-			const exists = this.rawAssets.some((asset) => asset.id === e.record.id);
-			this.rawAssets = exists
-				? this.rawAssets.map((asset) => (asset.id === e.record.id ? e.record : asset))
-				: [...this.rawAssets, e.record];
+			this.upsertAssetRecord(e.record);
 			if (!this.latestBalanceByAsset.has(e.record.id)) {
 				const balanceData = await this.getLatestAssetBalance(e.record.id);
 				if (userId !== this.currentUserId) return;
 				if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
 			}
 		} else if (e.action === 'delete') {
-			this.rawAssets = this.rawAssets.filter((x) => x.id !== e.record.id);
+			this.removeAssetRecord(e.record.id);
 			this.latestBalanceByAsset.delete(e.record.id);
 		}
 	}
@@ -430,6 +434,23 @@ class AssetsContext {
 		}
 	}
 
+	// NOTE: Targeted membership changes bump mutationEpoch so an in-flight
+	// refreshAssets that fetched its list before this mutation aborts its
+	// commit and can't overwrite newer state with a stale snapshot.
+	private upsertAssetRecord(asset: AssetsResponse) {
+		const exists = this.rawAssets.some((record) => record.id === asset.id);
+		this.rawAssets = exists
+			? this.rawAssets.map((record) => (record.id === asset.id ? asset : record))
+			: [...this.rawAssets, asset];
+		if (!exists) this.mutationEpoch++;
+	}
+
+	private removeAssetRecord(assetId: string) {
+		if (!this.rawAssets.some((record) => record.id === assetId)) return;
+		this.rawAssets = this.rawAssets.filter((record) => record.id !== assetId);
+		this.mutationEpoch++;
+	}
+
 	private async refreshAsset(assetId: string, userId: string) {
 		if (userId !== this.currentUserId) return false;
 
@@ -442,17 +463,14 @@ class AssetsContext {
 			if (userId !== this.currentUserId) return false;
 			const balanceData = await this.getLatestAssetBalance(assetId);
 			if (userId !== this.currentUserId) return false;
-			const exists = this.rawAssets.some((record) => record.id === asset.id);
-			this.rawAssets = exists
-				? this.rawAssets.map((record) => (record.id === asset.id ? asset : record))
-				: [...this.rawAssets, asset];
+			this.upsertAssetRecord(asset);
 			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
 			else this.latestBalanceByAsset.delete(assetId);
 			return true;
 		} catch (error) {
 			if (userId !== this.currentUserId) return false;
 			if (this.isUnavailableRecordError(error)) {
-				this.rawAssets = this.rawAssets.filter((asset) => asset.id !== assetId);
+				this.removeAssetRecord(assetId);
 				this.latestBalanceByAsset.delete(assetId);
 				return true;
 			}


### PR DESCRIPTION
## Problem

`refreshAccounts` / `refreshAssets` read the full record list at fetch time and commit it only after awaiting per-record balances. If a targeted membership mutation — adding a record, or a realtime `create` event — lands while that list fetch is in flight, the stale snapshot can overwrite the newer state. On a slow connection a user could add their first account and see the list render **empty** ("No open accounts yet"); on mobile WebKit this surfaced as a flaky e2e test (`accounts.test.ts` "user can add a new account").

Confirmed by trace: the login `refreshAccounts` `getFullList` (empty list, ~328ms on WebKit) resolved ~196ms *after* the add-flow appended the new account and clobbered `rawAccounts` back to `[]`.

## Fix

Both stores track a `mutationEpoch`, separate from the existing refresh-sequence guard:
- Membership changes (`upsert*Record` on a new id, `remove*Record` on an actual removal) bump it.
- A full refresh captures the epoch before fetching and skips its membership/balance commit if the epoch advanced mid-flight — so a stale snapshot can no longer overwrite newer state.
- Field-only updates don't bump the epoch, so legitimate refreshes still commit. Kept separate from the refresh-sequence so membership bumps never abort the initial load or strand `isLoading`.

Also loads asset balances in parallel (`Promise.all`) instead of one serial request per asset, matching how accounts already fan out — a real win on networked clients with many assets.

## Verification

- Accounts mobile `--repeat-each=30`: 30/30 (was ~40% fail in an amplified repro).
- Assets mobile `--repeat-each=10`: 100/100.
- Both projects `accounts + assets --repeat-each=8`: 256/256, 0 flaky.
- `bun run check` 0/0, `bun run lint` (prettier + eslint) clean, `go test -race ./...` ok.