### PR TITLE
ci: simplify WebKit CI flake workaround to xvfb + headed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,9 @@ jobs:
         run: bunx playwright install --with-deps chromium webkit
 
       - name: Run Playwright tests
-        run: xvfb-run -a bun run test
+        run: xvfb-run -a bun run test -- --project=mobile e2e/transactions.filtering.test.ts e2e/transactions.crud.test.ts e2e/securities.sorting.test.ts e2e/assets.sorting.test.ts --repeat-each=8
         env:
           CI: true
-          LIBGL_ALWAYS_SOFTWARE: '1'
-          GALLIUM_DRIVER: llvmpipe
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
         run: bunx playwright install --with-deps chromium webkit
 
       - name: Run Playwright tests
-        run: xvfb-run -a bun run test -- --project=mobile e2e/transactions.filtering.test.ts e2e/transactions.crud.test.ts e2e/securities.sorting.test.ts --repeat-each=3
+        # xvfb-run provides the virtual display WebKit needs to run headed on Linux CI;
+        # headless WebKit crashes here (EGL_NOT_INITIALIZED at page.goto). See playwright.config.ts.
+        run: xvfb-run -a bun run test
         env:
           CI: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: bunx playwright install --with-deps chromium webkit
 
       - name: Run Playwright tests
-        run: xvfb-run -a bun run test -- --project=mobile e2e/transactions.filtering.test.ts e2e/transactions.crud.test.ts e2e/securities.sorting.test.ts e2e/assets.sorting.test.ts --repeat-each=8
+        run: xvfb-run -a bun run test -- --project=mobile e2e/transactions.filtering.test.ts e2e/transactions.crud.test.ts e2e/securities.sorting.test.ts --repeat-each=3
         env:
           CI: true
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,8 +46,7 @@ export default defineConfig({
 			use: {
 				...devices['iPhone 13'],
 				baseURL: BASE_URL,
-				trace: 'retain-on-failure',
-				headless: !isCI
+				trace: 'retain-on-failure'
 			}
 		}
 	]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,6 +47,8 @@ export default defineConfig({
 				...devices['iPhone 13'],
 				baseURL: BASE_URL,
 				trace: 'retain-on-failure',
+				// WebKit crashes on headless Linux CI (EGL_NOT_INITIALIZED at page.goto); run it
+				// headed under xvfb instead (see .github/workflows/test.yml).
 				headless: !isCI
 			}
 		}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,8 @@ export default defineConfig({
 			use: {
 				...devices['iPhone 13'],
 				baseURL: BASE_URL,
-				trace: 'retain-on-failure'
+				trace: 'retain-on-failure',
+				headless: !isCI
 			}
 		}
 	]


### PR DESCRIPTION
## What

Trims the WebKit CI flake workaround (from #383) down to only what's load-bearing, and documents it.

The mobile (WebKit) e2e job intermittently red-flagged otherwise-green runs with `page.goto: WebKit encountered an internal error` — headless Linux WebKit failing its GPU/EGL init.

## Benchmarked the actual cause

Temporarily ran mobile-only navigation-heavy specs at high repeat-count to isolate each variable:

| Config | `WebKit encountered an internal error` |
|---|---|
| `xvfb` + **headless** + no driver vars | **16** |
| `xvfb` + **headed** + no driver vars | **0** |
| full suite, final config | **0** (396 tests, green) |

→ **`xvfb-run` + running WebKit headed is the fix; the `LIBGL_ALWAYS_SOFTWARE` / `GALLIUM_DRIVER` driver vars made no difference and are removed.**

## Changes (net vs `next`)

- `.github/workflows/test.yml`: removed the `LIBGL_ALWAYS_SOFTWARE` / `GALLIUM_DRIVER` driver vars (dead weight); kept `xvfb-run`, now with a comment explaining why.
- `playwright.config.ts`: kept `headless: !isCI` (proven load-bearing) with a comment explaining the headless-Linux-WebKit crash.

CI-only change (no app code) — won't cut a release.