### PR TITLE
fix: document securities import semantics and prevent skill-reference drift

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -25,6 +25,7 @@ Do not rewrite the diff unless the orchestrator explicitly assigns implementatio
 - Edge cases are handled where the changed behavior requires them.
 - Failures are surfaced through the project failures-and-logs pattern.
 - No silent failures, swallowed promises, or user-visible raw error messages.
+- A change that alters behavior documented in a skill (`.agents/skills/`) or the served skill reference (`pocketbase/skill.go`) updates those docs in the same change set - flag it if the docs went stale.
 
 ## Conventions
 

--- a/.agents/skills/orchestrator/SKILL.md
+++ b/.agents/skills/orchestrator/SKILL.md
@@ -107,6 +107,8 @@ The `Conventions` list on a write template and the `Review lens` list on a revie
 
 A missing convention skill is the most common cause of executor work the user has to send back. When in doubt, include more.
 
+When a write concern's in-bounds files touch PocketBase custom routes, hooks, or import behavior, its `Done when` must include updating `pocketbase/skill.go`'s hand-maintained sections and any affected `.agents/skills/` doc. Those doc updates are part of the concern, not a follow-up.
+
 ## Acceptance gate
 
 Gate on the contract, not the substance. Substance review happens at milestones via review executors.

--- a/.agents/skills/pb-import/SKILL.md
+++ b/.agents/skills/pb-import/SKILL.md
@@ -3,7 +3,7 @@ name: pb-import
 description: Import data into Canutin via the PocketBase bulk import API, list import sessions, or revert a previous import. Use when the user asks to import bank data, check import history, or undo/rollback an import.
 ---
 
-Manage bulk data imports into Canutin through the PocketBase custom API routes. Supports importing accounts, assets, transactions, and balances with automatic deduplication, as well as listing and reverting import sessions.
+Manage bulk data imports into Canutin through the PocketBase custom API routes. Supports importing currencies, accounts, assets, securities, cash transactions, security holding snapshots, and security trade history with automatic deduplication, as well as listing and reverting import sessions.
 
 ## Prerequisites
 
@@ -32,115 +32,235 @@ await pb.collection('users').authWithPassword(email, password);
 const token = pb.authStore.token;
 ```
 
+The owner of every imported record is the authenticated token's user.
+
 ## Bulk Import
 
 `POST /api/canutin/import`
 
-Imports accounts, assets, and transactions with automatic deduplication:
-
-- **Accounts**: deduplicated by `name + institution + balanceGroup`
-- **Assets**: deduplicated by `name + symbol`
-- **Transactions with `externalId`**: deduplicated by `account + externalId`
-- **Transactions without `externalId`**: deduplicated by `account + date + value + normalized description`
-- **Balances**: deduplicated by `account/asset + asOf + value`
-
-Dates can use either ISO format (`2025-08-25T00:00:00.000Z`) or PocketBase format (`2025-08-25 00:00:00.000Z`).
-
-### Payload
+The body is an import payload: a required `sessionLabel` plus any of seven optional arrays. At least one array must be non-empty.
 
 ```json
 {
 	"sessionLabel": "my-scraper-2025-08-25",
-	"accounts": [
-		{
-			"name": "Checking",
-			"institution": "Bank of America",
-			"balanceGroup": "CASH",
-			"balanceType": "Checking",
-			"autoCalculated": true,
-			"balance": { "value": 5000, "asOf": "2025-08-25 00:00:00.000Z" }
-		}
-	],
-	"assets": [
-		{
-			"name": "SPDR S&P 500",
-			"symbol": "SPY",
-			"balanceGroup": "INVESTMENT",
-			"balanceType": "ETF",
-			"type": "SHARES",
-			"balance": {
-				"quantity": 10,
-				"marketPrice": 550,
-				"bookPrice": 450,
-				"marketValue": 5500,
-				"bookValue": 4500,
-				"asOf": "2025-08-25 00:00:00.000Z"
-			}
-		}
-	],
-	"transactions": [
-		{
-			"accountName": "Checking",
-			"date": "2025-08-20 00:00:00.000Z",
-			"description": "GROCERY STORE",
-			"value": -85.5,
-			"externalId": "txn-abc123",
-			"labels": ["Groceries"]
-		}
-	]
+	"currencies": [ ... ],
+	"accounts": [ ... ],
+	"assets": [ ... ],
+	"securities": [ ... ],
+	"transactions": [ ... ],
+	"securityBalances": [ ... ],
+	"securityTransactions": [ ... ]
 }
 ```
 
-### Fields reference
+- `sessionLabel` is **required**, must be non-empty, and is capped at 256 runes.
+- Dates accept either ISO format (`2025-08-25T00:00:00.000Z`) or PocketBase format (`2025-08-25 00:00:00.000Z`). Only the date part is used unless noted.
+- **Unknown or extra JSON fields are silently dropped** by the decoder — no error is raised. Only the fields listed below are read.
 
-**Account fields:**
+### How the data model works (read before building a payload)
+
+Canutin computes an investment account's total value as **cash + positions**, summed in the UI, never in a single stored column:
+
+- **Cash** comes from the account's latest `accountBalances` snapshot (an `accounts[].balance`, or a derived recompute — see `autoCalculated` below).
+- **Positions** come **exclusively** from `securityBalances` holding snapshots.
+
+Consequences you must design for:
+
+- **`securityTransactions` are display-only trade history.** They never affect holdings or balances. Buying a security does not change the account's value — you must also post a `securityBalances` snapshot to reflect the new holding.
+- **Do not write portfolio/holding value into an account's cash balance.** Putting security value into `accounts[].balance.value` (or a manual `accountBalances` row) double-counts it on top of the `securityBalances`-derived positions value. Cash snapshots should carry only cash.
+
+### Nullable numbers on securities (carry-forward)
+
+`securityBalances` and `securityTransactions` number fields (`quantity`, `price`, `value`, `costBasis`, `amount`, `fees`) are **nullable**, and the distinction is load-bearing:
+
+- **`null` (or omitted) = unknown.** The frontend carries the value forward from the most recent prior snapshot that had a known value.
+- **`0` = a known zero**, not carried forward.
+- **`quantity: 0` closes a position.** Value and cost basis resolve to 0 and carry-forward **stops** at that row (a later re-buy with no fresh value stays unknown, not the old lot's value).
+
+Rule of thumb: send `value`/`price`/`costBasis` explicitly on every snapshot you actually know; leave them `null` only when genuinely unknown. **Never emit `0` for an unknown value** — it will be read as a real zero. Post a `quantity: 0` snapshot to close out a holding.
+
+### currencies[]
+
+Declares currencies and their exchange-rate quotes. Each quote is stored as an owner-scoped manual `exchangeRates` row.
+
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `name` | string | yes | |
-| `institution` | string | no | Used in dedup key |
-| `balanceGroup` | `CASH\|DEBT\|INVESTMENT\|OTHER` | yes | |
-| `balanceType` | string | yes | e.g. "Checking", "Credit Card", "ETF" |
-| `autoCalculated` | boolean | no | |
-| `closed` | boolean | no | |
-| `excluded` | boolean | no | |
-| `balance.value` | number | no | |
-| `balance.asOf` | string | no | ISO or PB date format |
+| `code` | string | yes | Uppercase, must match `^[A-Z0-9]{2,10}$` |
+| `name` | string | no | ≤256 runes |
+| `autoUpdate` | boolean | no | Default false. On import it is stored but not fetch-validated — a bogus code won't fail the import; the daily 5am rate cron attempts the fetch later |
+| `quotes` | array | **yes** | At least one quote required per declared currency |
+| `quotes[].date` | string | yes | ISO or PB date; the date part must parse |
+| `quotes[].rate` | number | yes | Must be finite and **> 0** |
 
-**Asset fields:**
+**Quote direction:** a rate is **units of the foreign currency per 1 USD** (USD is the pivot and is never stored as a fetched rate — but the import loop doesn't skip it, so declaring USD in `currencies[]` with quotes writes inert owner-scoped manual `exchangeRates` rows). Manual import quotes are stored verbatim, so they must follow this direction to convert correctly. Manual quotes override same-day fetched rates.
+
+Quotes dedup on `owner + currency + day`.
+
+### accounts[]
+
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `name` | string | yes | |
-| `symbol` | string | no | Used in dedup key |
-| `balanceGroup` | `CASH\|DEBT\|INVESTMENT\|OTHER` | yes | |
-| `balanceType` | string | yes | |
-| `type` | `WHOLE\|SHARES` | yes | |
-| `sold` | boolean | no | |
-| `excluded` | boolean | no | |
-| `balance.*` | various | no | marketValue, bookValue, quantity, marketPrice, bookPrice, asOf |
+| `name` | string | yes | ≤256 |
+| `institution` | string | no | Part of the dedup key when present |
+| `balanceGroup` | string | no | `CASH\|DEBT\|INVESTMENT\|OTHER` — stored raw, not validated. Part of the dedup key |
+| `balanceType` | string | no | Free-form; find-or-created in `balanceTypes` by name. NOT part of the dedup key |
+| `currency` | string | no | `^[A-Z0-9]{2,10}$`; defaults to `USD`. Immutable once set |
+| `autoCalculated` | boolean | no | Stored as a timestamp — see warning below |
+| `closed` | boolean | no | Stored as a timestamp |
+| `excluded` | boolean | no | Stored as a timestamp |
+| `balance` | object | no | `{ "value": number, "asOf": string }` — a single `accountBalances` cash snapshot |
 
-**Transaction fields:**
+There is no `notes` field on account import (the schema has one; the importer omits it).
+
+**`autoCalculated` clobbers imported snapshots.** When set, the backend recomputes the account's latest cash balance by summing its non-excluded cash transactions into a new `accountBalances` row stamped `source="derived"` with `asOf = now()`. Because that derived row is stamped now, it becomes the latest cash balance and overrides any imported `balance` snapshot. It runs synchronously at import for any account that got ≥1 transaction this import, and re-fires later on any transaction create/update/delete on that account. So importing an `autoCalculated` account with a balance snapshot but only a partial slice of its cash transactions produces a derived recompute over that incomplete history that overrides the snapshot. (A snapshot-only account — no transactions this import — keeps its imported snapshot until a later transaction edit triggers a recompute.) To preserve an imported cash snapshot, leave `autoCalculated` false — or import the full transaction history that reconstructs it.
+
+Accounts dedup on `name + balanceGroup + owner`, plus `institution` when present. Account cash snapshots (`accountBalances`) dedup on `account + day(asOf) + value + owner`.
+
+### assets[]
+
+Assets are the legacy "whole asset" concept (a house, a collectible), distinct from securities.
+
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `accountName` | string | yes | Must match an account name in the payload or an existing account |
-| `date` | string | yes | ISO or PB date format |
-| `description` | string | no | Normalized (trimmed, collapsed whitespace, lowercased) for dedup |
-| `value` | number | no | |
-| `externalId` | string | no | Primary dedup key when present |
-| `labels` | string[] | no | Created if they don't exist |
-| `excluded` | boolean | no | |
+| `name` | string | yes | ≤256 |
+| `balanceGroup` | string | no | Stored raw |
+| `balanceType` | string | no | Find-or-created by name |
+| `currency` | string | no | Defaults to `USD`. Immutable once set |
+| `sold` | boolean | no | Stored as a timestamp |
+| `excluded` | boolean | no | Stored as a timestamp |
+| `balance` | object | no | `{ "marketValue": number, "bookValue": number, "asOf": string }` |
+
+**Assets have no `symbol`, `type`, `quantity`, `marketPrice`, or `bookPrice` fields** — any such fields are silently dropped. Only `marketValue`, `bookValue`, and `asOf` exist on an asset balance.
+
+Assets dedup on `name + owner` only (not symbol). Asset balances dedup on `asset + day(asOf) + marketValue + owner`.
+
+### securities[]
+
+Declares a security so you can set its currency. Securities are also auto-created on demand when a `securityBalances` or `securityTransactions` row references one by name/symbol — but those auto-created securities are always `USD`. List a security here to give it a non-USD currency.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | ≤256; trimmed, internal whitespace collapsed, unique per owner case-insensitively |
+| `symbol` | string | no | ≤32; upper-cased and trimmed |
+| `currency` | string | no | Defaults to `USD`. Immutable once set |
+
+Securities dedup on `(symbol OR normalized name) + owner`.
+
+### transactions[] (cash transactions)
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `accountId` | string | no | Preferred reference; accepted only if owned |
+| `accountName` | string | yes | ≤256 |
+| `institution` | string | no | Used for tuple account resolution |
+| `balanceGroup` | string | no | Used for tuple account resolution |
+| `date` | string | yes | ISO or PB date |
+| `description` | string | no | ≤2000; normalized (trim / collapse whitespace / lowercase) for dedup |
+| `value` | number | no | Finite; defaults to 0 if omitted |
+| `externalId` | string | no | **Honored only here**; primary dedup key when present |
+| `labels` | string[] | no | Each ≤256; find-or-created in `transactionLabels` |
+| `excluded` | boolean | no | Stored as a timestamp |
+
+`externalId` is the only place it is honored — it does not exist on securities, security balances, security transactions, accounts, or assets, and is dropped if supplied there.
+
+Transactions with an `externalId` dedup on `account + externalId + owner`. Without one, they dedup on `account + day(date) + value + owner`, then match on normalized description.
+
+### securityBalances[] (holding snapshots)
+
+The **only** source of holdings and positions value. Number fields are nullable — see the carry-forward section above.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `accountId` OR `accountName` | string | one required | Resolved by accountId or unique bare name only (no institution/group tuple here) |
+| `securityId` / `securityName` / `securitySymbol` | string | unenforced | Not server-validated. Resolves an existing security or auto-creates one (USD); omitting all three creates a junk empty-named USD security |
+| `asOf` | string | yes | Normalized to `<day> 00:00:00.000Z` |
+| `quantity` | number\|null | no | Nullable; `0` closes the position |
+| `price` | number\|null | no | Nullable |
+| `value` | number\|null | no | Nullable — the position's total value |
+| `costBasis` | number\|null | no | Nullable |
+
+Dedup on `account + security + exact-day(asOf) + owner`, then all non-null numbers must match.
+
+### securityTransactions[] (trade history)
+
+Display-only history. **Never affects holdings or balances** — post a `securityBalances` snapshot to change the actual holding.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `accountId` OR `accountName` | string | one required | accountId or unique bare name only |
+| `securityId` / `securityName` / `securitySymbol` | string | unenforced | Not server-validated. Resolves or auto-creates a security (USD); omitting all three creates a junk empty-named USD security |
+| `date` | string | yes | Normalized to the day |
+| `type` | string | no | Schema select `buy\|sell\|cancel\|cash\|fee\|transfer` (not enforced by the importer) |
+| `subtype` | string | no | |
+| `name` | string | no | ≤256; used as the dedup label when present |
+| `description` | string | no | ≤2000; dedup label fallback |
+| `quantity` / `price` / `amount` / `fees` | number\|null | no | Nullable |
+| `notes` | string | no | ≤5000. `notes` is accepted only here, not on cash transactions or accounts |
+
+There is **no `externalId`** on securityTransactions — any supplied is dropped. Dedup on `account + security + day(date) + type + owner`, then the label (normalized `name`, else `description`) and all non-null numbers must match.
+
+### Account reference resolution
+
+Cash transactions can reference an account three ways, tried in order:
+
+1. `accountId` — accepted **only if owned**; a foreign or missing id is a row error.
+2. `name + institution + balanceGroup` tuple — only when institution or balanceGroup is provided.
+3. Bare `accountName` — succeeds **only if exactly one** owned account matches; ambiguous matches are a row error.
+
+`securityBalances` and `securityTransactions` resolve accounts with empty institution/group, so they can use only `accountId` or a **unique** bare `accountName`.
+
+### Currency rules
+
+- Any `currency` referenced on accounts/assets/securities must already exist in the user's currency registry OR be declared in this payload's `currencies[]` with ≥1 quote. Otherwise the whole request fails with `400 Missing currencies`.
+- Every user is seeded a `USD` currency, so USD always resolves. Account/asset/security currency defaults to `USD` and is immutable once set.
+- Securities auto-created from balances/transactions are always `USD` — declare them in `securities[]` to choose a currency.
+
+### Partial success
+
+`handleImport` does **not** run inside a database transaction. Rows are saved independently: a failed row is logged, increments `recordsFailed`, and the loop continues. Whatever succeeded persists. Duplicate rows count as `existing`/`skipped`, not failures. Only **revert** is atomic.
+
+Whole-request rejections (nothing is written):
+
+- Body > 64 MiB → `413`
+- Invalid JSON → `400`
+- Structural validation errors → `400` with `{ error, errors: [{ field, message }] }`
+- Missing currency references → `400` with `{ error: "Missing currencies", missingCurrencies: [...] }`
+
+### Payload limits
+
+- Body ≤ **64 MiB**.
+- Total records across all collections ≤ **200,000** (exchange-rate count = the sum of all `quotes`).
+- Any single collection ≤ **100,000**.
+- String caps (runes): `sessionLabel` / `name` / label 256, symbol 32, description 2,000, notes 5,000.
 
 ### Response
+
+HTTP 200. Every collection reports the same `{ created, existing, skipped }` triple (accounts/assets/securities/currencies/exchangeRates use created + existing; transactions/balances use created + skipped).
 
 ```json
 {
 	"sessionId": "abc123def456ghi",
-	"accounts": { "created": 1, "existing": 0 },
-	"assets": { "created": 1, "existing": 0 },
-	"transactions": { "created": 5, "skipped": 2 },
-	"accountBalances": { "created": 1, "skipped": 0 },
-	"assetBalances": { "created": 1, "skipped": 0 }
+	"status": "completed",
+	"recordsFailed": 0,
+	"currencies": { "created": 0, "existing": 1, "skipped": 0 },
+	"exchangeRates": { "created": 1, "existing": 0, "skipped": 0 },
+	"accounts": { "created": 1, "existing": 0, "skipped": 0 },
+	"assets": { "created": 1, "existing": 0, "skipped": 0 },
+	"securities": { "created": 1, "existing": 0, "skipped": 0 },
+	"transactions": { "created": 5, "existing": 0, "skipped": 2 },
+	"accountBalances": { "created": 1, "existing": 0, "skipped": 0 },
+	"assetBalances": { "created": 1, "existing": 0, "skipped": 0 },
+	"securityBalances": { "created": 1, "existing": 0, "skipped": 0 },
+	"securityTransactions": { "created": 1, "existing": 0, "skipped": 0 }
 }
 ```
+
+The response `status` is one of `completed` | `completed_with_errors` | `failed` (`rolled_back` is set later by revert). `pending` is a transient session status only and is never returned by the import endpoint:
+
+- `completed` — no row errors.
+- `completed_with_errors` — some rows failed but at least one record was created.
+- `failed` — rows failed and nothing was created.
+- `rolled_back` — set by revert.
 
 ### Example with curl
 
@@ -170,13 +290,15 @@ curl -s "http://127.0.0.1:42070/api/collections/importSessions/records?sort=-cre
   -H "Authorization: Bearer $TOKEN"
 ```
 
-Session fields: `id`, `label`, `owner`, `recordsCreated`, `recordsSkipped`, `status` (`pending`|`completed`|`rolled_back`), `created`, `updated`.
+Session fields: `id`, `label`, `owner`, `recordsCreated`, `recordsSkipped`, `recordsFailed`, `status` (`pending` | `completed` | `completed_with_errors` | `failed` | `rolled_back`), `created`, `updated`.
 
 ## Revert an Import
 
 `POST /api/canutin/import/revert`
 
-Atomically deletes all records created by an import session (transactions, balances, accounts, assets) and cleans up orphaned labels and balance types. The operation runs inside a database transaction -- either everything is reverted or nothing is.
+Atomically deletes all financial records created by an import session — cash transactions, security transactions, account balances, asset balances, security balances, accounts, assets, and securities — and cleans up orphaned labels and balance types. It also recomputes derived balances for any pre-existing `autoCalculated` accounts that the reverted transactions touched. The operation runs inside a database transaction: either everything is reverted or nothing is.
+
+Revert does **not** delete import-created `currencies` rows or their manual `exchangeRates` quotes — those rows carry no `importSession` tag.
 
 ### Payload
 
@@ -203,6 +325,6 @@ curl -s http://127.0.0.1:42070/api/canutin/import/revert \
 ## Important
 
 - The `sessionId` must be a valid 15-character PocketBase record ID (`^[a-z0-9]{15}$`)
-- Running the same import payload twice is safe -- duplicates are skipped
+- Running the same import payload twice is safe — duplicates are skipped
 - Reverted sessions are marked as `rolled_back` and cannot be reverted again
 - The import session is visible in the Canutin UI at `/settings`

--- a/.agents/skills/pb-import/SKILL.md
+++ b/.agents/skills/pb-import/SKILL.md
@@ -83,14 +83,14 @@ Rule of thumb: send `value`/`price`/`costBasis` explicitly on every snapshot you
 
 Declares currencies and their exchange-rate quotes. Each quote is stored as an owner-scoped manual `exchangeRates` row.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `code` | string | yes | Uppercase, must match `^[A-Z0-9]{2,10}$` |
-| `name` | string | no | ≤256 runes |
-| `autoUpdate` | boolean | no | Default false. On import it is stored but not fetch-validated — a bogus code won't fail the import; the daily 5am rate cron attempts the fetch later |
-| `quotes` | array | **yes** | At least one quote required per declared currency |
-| `quotes[].date` | string | yes | ISO or PB date; the date part must parse |
-| `quotes[].rate` | number | yes | Must be finite and **> 0** |
+| Field           | Type    | Required | Notes                                                                                                                                                |
+| --------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code`          | string  | yes      | Uppercase, must match `^[A-Z0-9]{2,10}$`                                                                                                             |
+| `name`          | string  | no       | ≤256 runes                                                                                                                                           |
+| `autoUpdate`    | boolean | no       | Default false. On import it is stored but not fetch-validated — a bogus code won't fail the import; the daily 5am rate cron attempts the fetch later |
+| `quotes`        | array   | **yes**  | At least one quote required per declared currency                                                                                                    |
+| `quotes[].date` | string  | yes      | ISO or PB date; the date part must parse                                                                                                             |
+| `quotes[].rate` | number  | yes      | Must be finite and **> 0**                                                                                                                           |
 
 **Quote direction:** a rate is **units of the foreign currency per 1 USD** (USD is the pivot and is never stored as a fetched rate — but the import loop doesn't skip it, so declaring USD in `currencies[]` with quotes writes inert owner-scoped manual `exchangeRates` rows). Manual import quotes are stored verbatim, so they must follow this direction to convert correctly. Manual quotes override same-day fetched rates.
 
@@ -98,17 +98,17 @@ Quotes dedup on `owner + currency + day`.
 
 ### accounts[]
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `name` | string | yes | ≤256 |
-| `institution` | string | no | Part of the dedup key when present |
-| `balanceGroup` | string | no | `CASH\|DEBT\|INVESTMENT\|OTHER` — stored raw, not validated. Part of the dedup key |
-| `balanceType` | string | no | Free-form; find-or-created in `balanceTypes` by name. NOT part of the dedup key |
-| `currency` | string | no | `^[A-Z0-9]{2,10}$`; defaults to `USD`. Immutable once set |
-| `autoCalculated` | boolean | no | Stored as a timestamp — see warning below |
-| `closed` | boolean | no | Stored as a timestamp |
-| `excluded` | boolean | no | Stored as a timestamp |
-| `balance` | object | no | `{ "value": number, "asOf": string }` — a single `accountBalances` cash snapshot |
+| Field            | Type    | Required | Notes                                                                              |
+| ---------------- | ------- | -------- | ---------------------------------------------------------------------------------- |
+| `name`           | string  | yes      | ≤256                                                                               |
+| `institution`    | string  | no       | Part of the dedup key when present                                                 |
+| `balanceGroup`   | string  | no       | `CASH\|DEBT\|INVESTMENT\|OTHER` — stored raw, not validated. Part of the dedup key |
+| `balanceType`    | string  | no       | Free-form; find-or-created in `balanceTypes` by name. NOT part of the dedup key    |
+| `currency`       | string  | no       | `^[A-Z0-9]{2,10}$`; defaults to `USD`. Immutable once set                          |
+| `autoCalculated` | boolean | no       | Stored as a timestamp — see warning below                                          |
+| `closed`         | boolean | no       | Stored as a timestamp                                                              |
+| `excluded`       | boolean | no       | Stored as a timestamp                                                              |
+| `balance`        | object  | no       | `{ "value": number, "asOf": string }` — a single `accountBalances` cash snapshot   |
 
 There is no `notes` field on account import (the schema has one; the importer omits it).
 
@@ -120,15 +120,15 @@ Accounts dedup on `name + balanceGroup + owner`, plus `institution` when present
 
 Assets are the legacy "whole asset" concept (a house, a collectible), distinct from securities.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `name` | string | yes | ≤256 |
-| `balanceGroup` | string | no | Stored raw |
-| `balanceType` | string | no | Find-or-created by name |
-| `currency` | string | no | Defaults to `USD`. Immutable once set |
-| `sold` | boolean | no | Stored as a timestamp |
-| `excluded` | boolean | no | Stored as a timestamp |
-| `balance` | object | no | `{ "marketValue": number, "bookValue": number, "asOf": string }` |
+| Field          | Type    | Required | Notes                                                            |
+| -------------- | ------- | -------- | ---------------------------------------------------------------- |
+| `name`         | string  | yes      | ≤256                                                             |
+| `balanceGroup` | string  | no       | Stored raw                                                       |
+| `balanceType`  | string  | no       | Find-or-created by name                                          |
+| `currency`     | string  | no       | Defaults to `USD`. Immutable once set                            |
+| `sold`         | boolean | no       | Stored as a timestamp                                            |
+| `excluded`     | boolean | no       | Stored as a timestamp                                            |
+| `balance`      | object  | no       | `{ "marketValue": number, "bookValue": number, "asOf": string }` |
 
 **Assets have no `symbol`, `type`, `quantity`, `marketPrice`, or `bookPrice` fields** — any such fields are silently dropped. Only `marketValue`, `bookValue`, and `asOf` exist on an asset balance.
 
@@ -138,28 +138,28 @@ Assets dedup on `name + owner` only (not symbol). Asset balances dedup on `asset
 
 Declares a security so you can set its currency. Securities are also auto-created on demand when a `securityBalances` or `securityTransactions` row references one by name/symbol — but those auto-created securities are always `USD`. List a security here to give it a non-USD currency.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `name` | string | yes | ≤256; trimmed, internal whitespace collapsed, unique per owner case-insensitively |
-| `symbol` | string | no | ≤32; upper-cased and trimmed |
-| `currency` | string | no | Defaults to `USD`. Immutable once set |
+| Field      | Type   | Required | Notes                                                                             |
+| ---------- | ------ | -------- | --------------------------------------------------------------------------------- |
+| `name`     | string | yes      | ≤256; trimmed, internal whitespace collapsed, unique per owner case-insensitively |
+| `symbol`   | string | no       | ≤32; upper-cased and trimmed                                                      |
+| `currency` | string | no       | Defaults to `USD`. Immutable once set                                             |
 
 Securities dedup on `(symbol OR normalized name) + owner`.
 
 ### transactions[] (cash transactions)
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `accountId` | string | no | Preferred reference; accepted only if owned |
-| `accountName` | string | yes | ≤256 |
-| `institution` | string | no | Used for tuple account resolution |
-| `balanceGroup` | string | no | Used for tuple account resolution |
-| `date` | string | yes | ISO or PB date |
-| `description` | string | no | ≤2000; normalized (trim / collapse whitespace / lowercase) for dedup |
-| `value` | number | no | Finite; defaults to 0 if omitted |
-| `externalId` | string | no | **Honored only here**; primary dedup key when present |
-| `labels` | string[] | no | Each ≤256; find-or-created in `transactionLabels` |
-| `excluded` | boolean | no | Stored as a timestamp |
+| Field          | Type     | Required | Notes                                                                |
+| -------------- | -------- | -------- | -------------------------------------------------------------------- |
+| `accountId`    | string   | no       | Preferred reference; accepted only if owned                          |
+| `accountName`  | string   | yes      | ≤256                                                                 |
+| `institution`  | string   | no       | Used for tuple account resolution                                    |
+| `balanceGroup` | string   | no       | Used for tuple account resolution                                    |
+| `date`         | string   | yes      | ISO or PB date                                                       |
+| `description`  | string   | no       | ≤2000; normalized (trim / collapse whitespace / lowercase) for dedup |
+| `value`        | number   | no       | Finite; defaults to 0 if omitted                                     |
+| `externalId`   | string   | no       | **Honored only here**; primary dedup key when present                |
+| `labels`       | string[] | no       | Each ≤256; find-or-created in `transactionLabels`                    |
+| `excluded`     | boolean  | no       | Stored as a timestamp                                                |
 
 `externalId` is the only place it is honored — it does not exist on securities, security balances, security transactions, accounts, or assets, and is dropped if supplied there.
 
@@ -169,15 +169,15 @@ Transactions with an `externalId` dedup on `account + externalId + owner`. Witho
 
 The **only** source of holdings and positions value. Number fields are nullable — see the carry-forward section above.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `accountId` OR `accountName` | string | one required | Resolved by accountId or unique bare name only (no institution/group tuple here) |
-| `securityId` / `securityName` / `securitySymbol` | string | unenforced | Not server-validated. Resolves an existing security or auto-creates one (USD); omitting all three creates a junk empty-named USD security |
-| `asOf` | string | yes | Normalized to `<day> 00:00:00.000Z` |
-| `quantity` | number\|null | no | Nullable; `0` closes the position |
-| `price` | number\|null | no | Nullable |
-| `value` | number\|null | no | Nullable — the position's total value |
-| `costBasis` | number\|null | no | Nullable |
+| Field                                            | Type         | Required     | Notes                                                                                                                                     |
+| ------------------------------------------------ | ------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `accountId` OR `accountName`                     | string       | one required | Resolved by accountId or unique bare name only (no institution/group tuple here)                                                          |
+| `securityId` / `securityName` / `securitySymbol` | string       | unenforced   | Not server-validated. Resolves an existing security or auto-creates one (USD); omitting all three creates a junk empty-named USD security |
+| `asOf`                                           | string       | yes          | Normalized to `<day> 00:00:00.000Z`                                                                                                       |
+| `quantity`                                       | number\|null | no           | Nullable; `0` closes the position                                                                                                         |
+| `price`                                          | number\|null | no           | Nullable                                                                                                                                  |
+| `value`                                          | number\|null | no           | Nullable — the position's total value                                                                                                     |
+| `costBasis`                                      | number\|null | no           | Nullable                                                                                                                                  |
 
 Dedup on `account + security + exact-day(asOf) + owner`, then all non-null numbers must match.
 
@@ -185,17 +185,17 @@ Dedup on `account + security + exact-day(asOf) + owner`, then all non-null numbe
 
 Display-only history. **Never affects holdings or balances** — post a `securityBalances` snapshot to change the actual holding.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `accountId` OR `accountName` | string | one required | accountId or unique bare name only |
-| `securityId` / `securityName` / `securitySymbol` | string | unenforced | Not server-validated. Resolves or auto-creates a security (USD); omitting all three creates a junk empty-named USD security |
-| `date` | string | yes | Normalized to the day |
-| `type` | string | no | Schema select `buy\|sell\|cancel\|cash\|fee\|transfer` (not enforced by the importer) |
-| `subtype` | string | no | |
-| `name` | string | no | ≤256; used as the dedup label when present |
-| `description` | string | no | ≤2000; dedup label fallback |
-| `quantity` / `price` / `amount` / `fees` | number\|null | no | Nullable |
-| `notes` | string | no | ≤5000. `notes` is accepted only here, not on cash transactions or accounts |
+| Field                                            | Type         | Required     | Notes                                                                                                                       |
+| ------------------------------------------------ | ------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `accountId` OR `accountName`                     | string       | one required | accountId or unique bare name only                                                                                          |
+| `securityId` / `securityName` / `securitySymbol` | string       | unenforced   | Not server-validated. Resolves or auto-creates a security (USD); omitting all three creates a junk empty-named USD security |
+| `date`                                           | string       | yes          | Normalized to the day                                                                                                       |
+| `type`                                           | string       | no           | Schema select `buy\|sell\|cancel\|cash\|fee\|transfer` (not enforced by the importer)                                       |
+| `subtype`                                        | string       | no           |                                                                                                                             |
+| `name`                                           | string       | no           | ≤256; used as the dedup label when present                                                                                  |
+| `description`                                    | string       | no           | ≤2000; dedup label fallback                                                                                                 |
+| `quantity` / `price` / `amount` / `fees`         | number\|null | no           | Nullable                                                                                                                    |
+| `notes`                                          | string       | no           | ≤5000. `notes` is accepted only here, not on cash transactions or accounts                                                  |
 
 There is **no `externalId`** on securityTransactions — any supplied is dropped. Dedup on `account + security + day(date) + type + owner`, then the label (normalized `name`, else `description`) and all non-null numbers must match.
 

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,49 @@
+name: Skill drift
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  skill-drift:
+    name: Check skill reference drift
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure backend changes update skill docs
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-skill-check') }}
+        run: |
+          changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
+
+          backend_changed=$(echo "$changed" | grep -E '^pocketbase/.*\.go$' | grep -vxF 'pocketbase/skill.go' || true)
+          if [ -z "$backend_changed" ]; then
+            echo "No PocketBase Go changes outside pocketbase/skill.go; nothing to guard."
+            exit 0
+          fi
+
+          docs_changed=$(echo "$changed" | grep -E '^pocketbase/skill\.go$|^\.agents/skills/' || true)
+          if [ -n "$docs_changed" ]; then
+            echo "Backend behavior changed and skill docs were updated."
+            exit 0
+          fi
+
+          if [ "$HAS_SKIP_LABEL" = "true" ]; then
+            echo "Backend behavior changed without doc updates, bypassed by the 'skip-skill-check' label."
+            exit 0
+          fi
+
+          echo "::error::PocketBase backend behavior changed but no skill docs were updated."
+          echo "Changes to PocketBase Go code (excluding pocketbase/skill.go) must also update the served"
+          echo "skill reference (pocketbase/skill.go) or the relevant doc under .agents/skills/."
+          echo "If this change has no doc impact, add the 'skip-skill-check' label to the PR to bypass."
+          echo ""
+          echo "Backend files changed without a matching doc update:"
+          echo "$backend_changed"
+          exit 1

--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,3 +1,10 @@
+# Deliberately conservative: a shape-only change to the import payload structs trips
+# this check even though the served /api/canutin/skill shape section is generated from
+# those structs. That is intentional — a new field still needs its semantics documented
+# by a human (meaning, nullability, dedup, carry-forward), and the hand-maintained
+# field tables in .agents/skills/pb-import/SKILL.md don't self-update. A false trip
+# costs one `skip-skill-check` label; a false exemption recreates the silent doc drift
+# of #396. If false trips become common, generate more of the docs — don't weaken this guard.
 name: Skill drift
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Load when your tool list matches the harness. The agent must check tool availabi
 | Harness-specific quirks for Codex sessions - spawn_agent rules and validation gotchas    | codex    |
 | Harness-specific quirks for opencode sessions - plan mode rules and delegation reminders | opencode |
 
-> `pocketbase/skill.go` hand-maintains the custom endpoints, behavioral constraints, and auth
-> sections of the `/api/canutin/skill` reference. Update them whenever custom routes or
-> backend hooks change - nothing enforces this automatically.
+> `pocketbase/skill.go` hand-maintains the behavioral semantics - custom endpoints, behavioral
+> constraints, and auth - of the `/api/canutin/skill` reference; the import payload shape is
+> generated from the Go structs. Update the hand-maintained sections whenever custom routes or
+> backend hooks change. CI enforces this: a change under `pocketbase/**/*.go` without a matching
+> `pocketbase/skill.go` or `.agents/skills/` update fails the PR unless labeled `skip-skill-check`.

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -96,12 +97,11 @@ const skillCustomEndpointsSection = "## Custom endpoints\n\n" +
 	"- `GET /api/setup-status` — public, no body. Returns `{ \"ready\": bool }` indicating " +
 	"whether a superuser account has been provisioned.\n" +
 	"- `POST /api/canutin/import` — requires any authenticated token. Body is an import " +
-	"payload: `sessionLabel` plus optional arrays `currencies`, `accounts`, `assets`, `securities`, " +
-	"`transactions`, `securityBalances`, and `securityTransactions`. Each `currencies` object is " +
-	"`{ code, name?, autoUpdate?, quotes: [{ date, rate }] }`; at least one quote is required and " +
-	"quotes are stored as owner-scoped manual `exchangeRates` rows. Each `accounts`, `assets`, " +
-	"and `securities` object accepts an optional `currency` (uppercase code matching " +
-	"`^[A-Z0-9]{2,10}$`, defaults to `USD`); the code must already exist in the importer's " +
+	"payload with a required `sessionLabel` and optional per-collection arrays; the exact field " +
+	"shape of each array is generated under **Import payload shape** below. At least one quote is " +
+	"required per `currencies` object and quotes are stored as owner-scoped manual `exchangeRates` " +
+	"rows. The optional `currency` on `accounts`, `assets`, and `securities` is an uppercase code " +
+	"matching `^[A-Z0-9]{2,10}$` and defaults to `USD`; the code must already exist in the importer's " +
 	"`currencies` registry or be declared in `currencies` with a quote. Transactions and balances " +
 	"inherit their parent's currency. Import exchange-rate quotes follow the standard direction " +
 	"(units of the currency per 1 USD). Unknown JSON fields are silently dropped, and `externalId` " +
@@ -223,6 +223,11 @@ func canutinSkillHandler(app core.App) func(*core.RequestEvent) error {
 		doc.WriteString("\n")
 		doc.WriteString(skillCustomEndpointsSection)
 		doc.WriteString("\n")
+		doc.WriteString("### Import payload shape\n\n")
+		doc.WriteString("These field lists are generated from the server's import payload definitions, so they " +
+			"always match the accepted shape. `sessionLabel` is required and every array is optional; a field " +
+			"marked `(nullable)` may be omitted or sent as `null`.\n\n")
+		writeImportShape(&doc, "", reflect.TypeOf(importPayload{}))
 		doc.WriteString(skillConstraintsSection)
 
 		return re.Blob(200, "text/markdown; charset=utf-8", []byte(doc.String()))
@@ -316,4 +321,86 @@ func asString(value any) string {
 func asBool(value any) bool {
 	b, ok := value.(bool)
 	return ok && b
+}
+
+// writeImportShape renders the JSON shape of an import payload struct as a markdown table, then
+// recurses into any nested element structs (slice elements, pointer-to-struct fields). Field names,
+// types, and nullability come from the struct's `json` tags and Go types via reflection, so the
+// served shape can never drift from the structs the import endpoint actually decodes. path is the
+// dotted JSON path to the current struct ("" for the top-level payload); it prefixes the labels of
+// nested sub-structs so a reader can locate each object in the payload.
+func writeImportShape(doc *strings.Builder, path string, typ reflect.Type) {
+	label := "Payload"
+	if path != "" {
+		label = path
+	}
+	fmt.Fprintf(doc, "**%s**\n\n", label)
+	doc.WriteString("| Field | Type |\n| --- | --- |\n")
+
+	type nestedStruct struct {
+		path string
+		typ  reflect.Type
+	}
+	var nested []nestedStruct
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+
+		fieldType := field.Type
+		nullable := ""
+		if fieldType.Kind() == reflect.Ptr {
+			nullable = " (nullable)"
+			fieldType = fieldType.Elem()
+		}
+
+		childPath := name
+		if path != "" {
+			childPath = path + "." + name
+		}
+
+		switch fieldType.Kind() {
+		case reflect.Slice:
+			element := fieldType.Elem()
+			if element.Kind() == reflect.Struct {
+				fmt.Fprintf(doc, "| %s | array of objects%s |\n", name, nullable)
+				nested = append(nested, nestedStruct{childPath + "[]", element})
+			} else {
+				fmt.Fprintf(doc, "| %s | array of %ss%s |\n", name, simpleImportType(element, ""), nullable)
+			}
+		case reflect.Struct:
+			fmt.Fprintf(doc, "| %s | object%s |\n", name, nullable)
+			nested = append(nested, nestedStruct{childPath, fieldType})
+		default:
+			fmt.Fprintf(doc, "| %s | %s%s |\n", name, simpleImportType(fieldType, name), nullable)
+		}
+	}
+	doc.WriteString("\n")
+
+	for _, child := range nested {
+		writeImportShape(doc, child.path, child.typ)
+	}
+}
+
+// simpleImportType maps a scalar Go kind to the type label used in the import shape tables. String
+// fields whose JSON name is a date carry a `date-string` label because the import validator parses
+// them as dates, a distinction Go's string type cannot express.
+func simpleImportType(typ reflect.Type, name string) string {
+	switch typ.Kind() {
+	case reflect.String:
+		if name == "date" || name == "asOf" {
+			return "date-string"
+		}
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "number"
+	}
+	return typ.Kind().String()
 }

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -103,8 +103,18 @@ const skillCustomEndpointsSection = "## Custom endpoints\n\n" +
 	"and `securities` object accepts an optional `currency` (uppercase code matching " +
 	"`^[A-Z0-9]{2,10}$`, defaults to `USD`); the code must already exist in the importer's " +
 	"`currencies` registry or be declared in `currencies` with a quote. Transactions and balances " +
-	"inherit their parent's currency. Returns " +
-	"`{ sessionId, status, recordsFailed, … }` with per-collection `{ created, existing, skipped }` counts.\n" +
+	"inherit their parent's currency. Import exchange-rate quotes follow the standard direction " +
+	"(units of the currency per 1 USD). Unknown JSON fields are silently dropped, and `externalId` " +
+	"is honored only on cash `transactions`. Records are deduplicated per collection (accounts by " +
+	"name+institution+balanceGroup, cash transactions by externalId or account+date+value+description, " +
+	"assets by name only, securityBalances by account+security+day plus matching non-null numbers); an " +
+	"account is resolved by owned `accountId`, then a name+institution+balanceGroup tuple, then a unique " +
+	"bare name (ambiguous names error the row), while securityBalances/securityTransactions resolve " +
+	"accounts by accountId or unique bare name only. The import is not wrapped in a transaction: rows " +
+	"fail independently, are counted in `recordsFailed`, and partial results persist — only revert is " +
+	"atomic. Limits: 64 MiB body, 200k total records, 100k per collection. Returns " +
+	"`{ sessionId, status, recordsFailed, … }` with per-collection `{ created, existing, skipped }` " +
+	"counts; `status` is `completed`, `completed_with_errors`, `failed`, or `rolled_back`.\n" +
 	"- `POST /api/canutin/import/revert` — requires an authenticated token. Body is " +
 	"`{ sessionId }`. Returns `{ sessionId, deleted }`. Revert deletes import-session-tagged " +
 	"financial rows, but does not remove import-created `currencies` rows or their manual " +
@@ -129,6 +139,19 @@ Backend hooks enforce invariants that are not visible in the access rules:
   ` + "`security_name_exists`" + ` on the ` + "`name`" + ` field.
 - Writing a ` + "`securityBalances`" + ` or ` + "`securityTransactions`" + ` record whose account is
   closed is rejected. (Imports are exempt so they can restore a closed account's history.)
+- An account's displayed value is cash plus security positions, summed in the UI rather than stored
+  in one column: cash comes from the latest ` + "`accountBalances`" + ` snapshot, positions from
+  ` + "`securityBalances`" + ` holding snapshots. Holdings come exclusively from ` + "`securityBalances`" + `;
+  ` + "`securityTransactions`" + ` are display-only trade history that never affect balances. Writing
+  portfolio value into an account balance double-counts it.
+- Number fields on ` + "`securityBalances`" + ` and ` + "`securityTransactions`" + ` are nullable and the
+  distinction matters: ` + "`null`" + ` (or an omitted field) means unknown and is carried forward from the
+  last known snapshot, ` + "`0`" + ` is a known zero, and ` + "`quantity = 0`" + ` closes a position and stops
+  carry-forward. Never send ` + "`0`" + ` for a value you do not know.
+- Setting ` + "`autoCalculated`" + ` on an account makes the engine recompute its latest cash balance by
+  summing imported cash transactions into a new ` + "`source = derived`" + ` row stamped with the current
+  time, which overrides any imported cash snapshot and re-fires on later transaction edits. Leave it
+  off to preserve an imported snapshot.
 - Share records (` + "`accountShares`" + `, ` + "`assetShares`" + `) can only be updated by the recipient,
   and only the ` + "`includeInNetWorth`" + ` field may change. The sharer must revoke and recreate
   a share to change anything else.


### PR DESCRIPTION
- Rewrites the `pb-import` skill, which predated the securities and multi-currency work: all seven payload arrays documented with per-field types, defaults, and dedup keys, replacing stale asset fields (`symbol`, `type`, `quantity`, `marketPrice`, `bookPrice`) with the real ones.
- Documents the derived-balance model (holdings come exclusively from `securityBalances`, trades are display-only, account value is cash plus positions summed in the UI), null-vs-0 carry-forward semantics, the `autoCalculated` snapshot-clobber behavior, silently-dropped fields and `externalId` scoping, reference resolution, partial-success semantics, payload limits, and exchange-rate quote direction — in both the skill and the served `/api/canutin/skill` reference.
- The served reference now generates its import payload shape section from the Go payload structs via reflection at request time, so adding a field to `import.go` appears in the served doc automatically; only behavioral semantics remain hand-maintained.
- Adds a `skill-drift` CI check: PRs changing `pocketbase/**/*.go` (excluding `skill.go`) must also update `pocketbase/skill.go` or a `.agents/skills/` doc, bypassable with the `skip-skill-check` label; the check is checkout-only, no toolchains.
- Encodes the same duty in the agent contracts: a staleness check in the code-review skill, doc-updates-as-part-of-the-concern in the orchestrator skill, and a refreshed enforcement note in `AGENTS.md`.
- Every doc claim was adversarially verified against `pocketbase/import.go` and the balance/rates code; `go build`, `go vet`, and the existing `e2e/skill.test.ts` assertions all hold.

Closes #396