### PR TITLE
fix: close mobile sidebar drawer on navigation

### DIFF
--- a/e2e/sidebar.test.ts
+++ b/e2e/sidebar.test.ts
@@ -9,13 +9,18 @@ import { seedUser } from './pocketbase.helpers';
 // The mobile sheet stays mounted (data-state="closed") for its close transition
 // before unmounting, so a plain visibility check would catch it mid-animation -
 // check data-state too, since accounts stays visible until the transition ends.
+// Read existence and data-state in a single evaluateAll call: unlike
+// getAttribute, evaluateAll never waits for a match, so a sheet that finishes
+// unmounting between a separate existence check and state read can't hang the
+// test waiting for a locator that will never rematch.
 async function ensureSidebarOpen(page: Page) {
 	const sidebar = page.getByLabel('Sidebar');
 	const accounts = sidebar.getByRole('link', { name: 'Accounts' });
-	if (await sidebar.count()) {
-		const state = await sidebar.getAttribute('data-state');
-		if (state !== 'closed' && (await accounts.isVisible())) return;
-	}
+	const [state] = await sidebar.evaluateAll((elements) =>
+		elements.map((element) => element.getAttribute('data-state'))
+	);
+	if (state !== undefined && state !== 'closed' && (await accounts.isVisible())) return;
+
 	await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
 	await expect(accounts).toBeVisible();
 }

--- a/e2e/sidebar.test.ts
+++ b/e2e/sidebar.test.ts
@@ -6,16 +6,23 @@ import { seedUser } from './pocketbase.helpers';
 // On desktop the sidebar is expanded by default; on mobile it is a Sheet that
 // stays closed until "Toggle Sidebar" is clicked, and navigating closes it
 // again. Reopen it before each interaction so the test runs on both projects.
+// The mobile sheet stays mounted (data-state="closed") for its close transition
+// before unmounting, so a plain visibility check would catch it mid-animation -
+// check data-state too, since accounts stays visible until the transition ends.
 async function ensureSidebarOpen(page: Page) {
 	const sidebar = page.getByLabel('Sidebar');
 	const accounts = sidebar.getByRole('link', { name: 'Accounts' });
-	if (await accounts.isVisible()) return;
+	if (await sidebar.count()) {
+		const state = await sidebar.getAttribute('data-state');
+		if (state !== 'closed' && (await accounts.isVisible())) return;
+	}
 	await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
 	await expect(accounts).toBeVisible();
 }
 
 test('sidebar shows pillars before subordinate records and highlights the active item', async ({
-	page
+	page,
+	isMobile
 }) => {
 	const user = await seedUser('wallace');
 
@@ -53,6 +60,8 @@ test('sidebar shows pillars before subordinate records and highlights the active
 
 	await trades.click();
 	await expect(page).toHaveURL(/\/trades$/);
+	// Navigating on mobile closes the sheet; desktop leaves it expanded.
+	if (isMobile) await expect(sidebar).toBeHidden();
 	await ensureSidebarOpen(page);
 	await expect(sidebar.getByRole('link', { name: 'Trades' })).toHaveAttribute(
 		'data-active',

--- a/src/routes/(app)/app-sidebar.svelte
+++ b/src/routes/(app)/app-sidebar.svelte
@@ -11,6 +11,7 @@
 	import WalletCardsIcon from '@lucide/svelte/icons/wallet-cards';
 	import type { ComponentProps } from 'svelte';
 
+	import { afterNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import CanutinIcon from '$lib/components/canutin-icon.svelte';
@@ -22,6 +23,15 @@
 	import NavUser from './nav-user.svelte';
 
 	let { ref = $bindable(null), ...restProps }: ComponentProps<typeof Sidebar.Root> = $props();
+
+	const sidebar = Sidebar.useSidebar();
+
+	// The mobile sidebar is a Sheet that only closes explicitly - navigating to a
+	// new route doesn't close it on its own. Close it after every navigation so
+	// tapping a link on mobile both navigates and dismisses the drawer.
+	afterNavigate(() => {
+		if (sidebar.isMobile) sidebar.setOpenMobile(false);
+	});
 
 	const insights = $derived([
 		{


### PR DESCRIPTION
- The mobile sidebar is a Sheet that stays open after tapping a nav link, leaving it covering the newly navigated page until manually dismissed.
- Close it after every completed navigation while on a mobile viewport, so tapping a link both navigates and dismisses the drawer.
- Tightened the sidebar e2e test's `ensureSidebarOpen` helper to check the sheet's `data-state` in addition to link visibility, since the sheet stays mounted mid close-transition and a plain visibility check could catch it mid-animation; added an explicit assertion that the drawer closes on mobile after a link click.

Refs #391