### PR TITLE
fix: rewrite realtime stores to invalidation-only sync and recover after silent disconnects

### DIFF
--- a/.agents/skills/realtime/SKILL.md
+++ b/.agents/skills/realtime/SKILL.md
@@ -7,51 +7,89 @@ description: PocketBase realtime subscriptions, debouncing, subscription lifecyc
 
 ## Overview
 
-PocketBase realtime subscriptions for live data updates. Context stores in `src/lib/*.svelte.ts` subscribe to collection changes and update UI state accordingly.
+PocketBase realtime subscriptions drive live data updates. Context stores in `src/lib/*.svelte.ts`
+subscribe to collection changes and refresh UI state accordingly. Every realtime store follows one
+model: **realtime events and reconnects are pure invalidation signals** — each schedules a debounced,
+latest-request-wins full refetch, and the fresh snapshot replaces the whole cache. Events are never
+patched into local state.
 
-## Patterns
+## Store sync contract
 
-### Client-Side Debouncing
+### Sync vs projection
 
-When handling realtime events that trigger expensive operations (API calls, recomputation), debounce to batch rapid-fire events:
+Each store has two layers, and only the first is governed by this contract:
 
-Reference: `src/lib/cashflow.svelte.ts`
+- **Sync layer** — how server truth reaches the store's in-memory cache. Subscriptions, reconnects,
+  fetches, and cache commits live here. This is what "invalidation-only" governs: the sync layer never
+  reads an event payload; it only discards its cache and refetches.
+- **Projection layer** — `$derived` work over the cache: perspective/currency conversion, aggregation,
+  sorting, filtering, pagination slicing. Fully reactive, incremental, network-free, and **out of the
+  contract's scope**.
 
-- Store debounce timer as private class property
-- Clear existing timer on each event
-- Set new timer with 200ms delay
-- Clean up timer in `dispose()`
+Confusing the two is the main way to misread this. Canonical example: cashflow's `accounts`-driven
+effect (`cashflow.svelte.ts`) recomputes averages from the _already-cached_ transaction map when
+balances or perspective change — no network. That is projection and MUST stay incremental; converting
+it to a refetch reintroduces the regression that gated it. Only cashflow's transaction-event path is
+sync, and only it invalidates.
 
-### Disable Auto-Cancellation
+### The seven obligations
 
-PocketBase SDK auto-cancels in-flight requests when a new request with the same key is made. During bulk operations, this causes data to disappear temporarily.
+Every realtime store must satisfy all seven. `src/lib/securities.svelte.ts` is the reference shape;
+`src/lib/realtime-sync.ts` holds the two canonical helpers (`RequestSequence`, `Debouncer`).
 
-Reference: `src/lib/cashflow.svelte.ts`
+1. **Subscribe before the initial fetch.** Subscribe in the `init()` effect _before_ issuing the first
+   refresh, so no event is missed during the fetch window. The initial fetch is guarded by `userId`.
+2. **Event → debounced invalidate.** A realtime event calls `invalidate()`, which schedules the
+   refetch through the shared `Debouncer` (200ms trailing). Bursts coalesce to one refetch.
+3. **Reconnect → same invalidate.** Register one `registerRealtimeReconnect(() => this.invalidate())`
+   callback per store so a dropped-and-restored socket triggers the identical corrective refetch.
+4. **Latest-request-wins commit.** Take a `RequestSequence` token with `sequence.next()` before the
+   await; on _every_ path that touches state — the success commit, `catch`, and `finally` — re-check
+   both `sequence.isCurrent(token)` and `userId === auth.currentUserId` and bail if either fails. This
+   is what makes an event arriving mid-fetch safe: the stale in-flight fetch is discarded and the
+   follow-up refetch wins.
+5. **Whole-cache replace, never event-payload patching.** A refresh replaces the entire cache from the
+   fresh snapshot. Never upsert, merge, or read `e.record` into state. Deletes and cascades are handled
+   for free — the removed rows are simply absent from the next snapshot.
+6. **Complete dispose.** `dispose()` must: cancel the debounce, unregister _both_ the teardown and the
+   reconnect callback, unsubscribe the specific collection topics (never `realtime.unsubscribe()`), and
+   bump the sequence to supersede any in-flight refresh.
+7. **`isLoading` lives only in `init()`.** Set it `true` when the effect starts loading for a user and
+   `false` on the guarded commit; invalidations refetch silently.
 
-- Use `requestKey: null` in `getFullList()` options
-- Only needed for queries that may run during bulk operations
+### Auth is the sole exemption
 
-### Server-Side Debouncing (Go Hooks)
+`auth.svelte.ts` subscribes to a **single own-user record** and reacts only to `delete`
+(→ session teardown). It holds no list, is self-correcting, and is the **teardown coordinator** every
+other store registers into via `registerRealtimeTeardown`. It is not a data-sync store — do not force
+it into the contract.
 
-Balance calculations are debounced server-side to batch rapid transaction mutations:
+## Server-side debouncing (Go hooks)
 
-Reference: `pocketbase/main.go`
+Balance calculations are debounced server-side to batch rapid transaction mutations, so a bulk import
+of N transactions across A accounts produces ~A balance writes, not N:
+
+Reference: `pocketbase/main.go`, `pocketbase/balance.go`
 
 - 250ms trailing-edge debounce per account
-- Worker checks pending queue every 50ms
-- Prevents N balance records for N transactions in bulk import
+- Worker checks the pending queue every 50ms
+- Prevents N balance records for N transactions in a bulk import
 
-## Subscription Lifecycle
-
-1. Subscribe in `init()` **before** the initial data fetch (avoids missing events during the fetch window)
-2. Handle events with a debounced callback
-3. Unsubscribe in `dispose()` using the specific collection + filter — never `realtime.unsubscribe()`
+This is what keeps the client's per-store debounced refetch cheap: a burst settles into a handful of
+refetches, not one per row.
 
 ## Anti-patterns
 
-- **No debouncing** - Causes UI flicker and excessive API calls during bulk operations
-- **Forgetting `requestKey: null`** - Causes data to disappear mid-operation
-- **`realtime.unsubscribe()`** - Kills ALL subscriptions; use collection-specific unsubscribe
+- **Patching state from an event payload** — reintroduces snapshot-clobber and delete-resurrection; the
+  whole-cache replace exists to make those impossible, not merely guarded
+- **Forgetting `requestKey: null`** on a `getFullList`/`getList` that may run during a bulk operation —
+  the SDK auto-cancels the in-flight request and data disappears mid-operation
+- **Converting a `$derived` projection into a refetch** — projection is network-free by design; see
+  the sync/projection split above
+- **Dropping a mid-flight event as "already fetching"** — obligations 2 and 4 together require a
+  follow-up refetch so the newer server state wins
+- **`realtime.unsubscribe()`** — kills ALL subscriptions; unsubscribe the specific collection topics
+- **No debouncing** — causes UI flicker and excessive API calls during bulk operations
 
 ## See Also
 

--- a/.agents/skills/realtime/SKILL.md
+++ b/.agents/skills/realtime/SKILL.md
@@ -44,7 +44,8 @@ Every realtime store must satisfy all seven. `src/lib/securities.svelte.ts` is t
 2. **Event → debounced invalidate.** A realtime event calls `invalidate()`, which schedules the
    refetch through the shared `Debouncer` (200ms trailing). Bursts coalesce to one refetch.
 3. **Reconnect → same invalidate.** Register one `registerRealtimeReconnect(() => this.invalidate())`
-   callback per store so a dropped-and-restored socket triggers the identical corrective refetch.
+   callback per store so a restored connection triggers the identical corrective refetch. The
+   registry decides _when_ that fires — see "Connection recovery" below.
 4. **Latest-request-wins commit.** Take a `RequestSequence` token with `sequence.next()` before the
    await; on _every_ path that touches state — the success commit, `catch`, and `finally` — re-check
    both `sequence.isCurrent(token)` and `userId === auth.currentUserId` and bail if either fails. This
@@ -65,6 +66,40 @@ Every realtime store must satisfy all seven. `src/lib/securities.svelte.ts` is t
 (→ session teardown). It holds no list, is self-correcting, and is the **teardown coordinator** every
 other store registers into via `registerRealtimeTeardown`. It is not a data-sync store — do not force
 it into the contract.
+
+## Connection recovery
+
+Reference: `src/lib/pocketbase.svelte.ts` (`registerRealtimeReconnect`, `recoverRealtime`).
+
+**EventSource has no liveness detection.** A dropped network or a slept laptop routinely leaves the
+socket in `readyState === OPEN` forever: no `error` event, no `onDisconnect`, no `PB_CONNECT`, and
+therefore no reconnect from the SDK — which only reconnects on a transport error. The socket can even
+keep delivering events while the network is down, and every refetch they schedule fails and is
+discarded (stores have no retry). A session in that state stays stale indefinitely. The SDK's
+reconnect path is real but covers only the cases where the transport actually errors.
+
+So recovery has **three triggers**, all funneled through the registry:
+
+1. `PB_CONNECT` after an `onDisconnect` with active subscriptions — the SDK's own path.
+2. `window` `online` — the network came back.
+3. `document` `visibilitychange` → visible — covers sleep/wake and long-backgrounded tabs, which
+   `online` alone misses. A hidden tab is deliberately left alone; this trigger picks it up when the
+   user returns.
+
+Triggers 2 and 3 are browser-only, so they are registered behind `browser` from `$app/environment`.
+
+Recovery is **latched, not fire-and-forget**. A refetch issued the instant a trigger fires can still
+hit an unusable network (`online` precedes real connectivity), and a store's failed refetch vanishes.
+So the registry probes `health.check()` on a bounded backoff and fires the registered callbacks only
+once the backend actually answers; after the last delay it gives up and waits for the next trigger,
+so an hour offline costs a handful of probes rather than a hot loop. A single `_recovering` flag
+coalesces the burst — SDK reconnect, `online`, and `visibilitychange` usually arrive together — into
+one round of invalidations.
+
+Testing this: dispatching an `error` event on the EventSource only exercises trigger 1 — it injects
+the very signal whose absence is the real-world failure. A genuine offline needs CDP
+(`Network.emulateNetworkConditions`); Playwright's `context.setOffline()` tears the socket down and
+so exercises trigger 1 as well. Both cases are covered in `e2e/shared-records.test.ts`.
 
 ## Server-side debouncing (Go hooks)
 
@@ -90,6 +125,8 @@ refetches, not one per row.
   the sync/projection split above
 - **Dropping a mid-flight event as "already fetching"** — obligations 2 and 4 together require a
   follow-up refetch so the newer server state wins
+- **Treating the SDK's reconnect as the whole recovery story** — it never fires when the socket stays
+  OPEN, which is the common real-world drop; the browser triggers are part of the contract
 - **`realtime.unsubscribe()`** — kills ALL subscriptions; unsubscribe the specific collection topics
 - **No debouncing** — causes UI flicker and excessive API calls during bulk operations
 

--- a/.agents/skills/realtime/SKILL.md
+++ b/.agents/skills/realtime/SKILL.md
@@ -21,7 +21,9 @@ Each store has two layers, and only the first is governed by this contract:
 
 - **Sync layer** — how server truth reaches the store's in-memory cache. Subscriptions, reconnects,
   fetches, and cache commits live here. This is what "invalidation-only" governs: the sync layer never
-  reads an event payload; it only discards its cache and refetches.
+  reads an event payload into state; it only discards its cache and refetches. (Inspecting the payload
+  to decide relevance is fine — account-cashflow filters transaction events to its mounted account —
+  but never to patch state.)
 - **Projection layer** — `$derived` work over the cache: perspective/currency conversion, aggregation,
   sorting, filtering, pagination slicing. Fully reactive, incremental, network-free, and **out of the
   contract's scope**.

--- a/e2e/realtime-refresh-race.test.ts
+++ b/e2e/realtime-refresh-race.test.ts
@@ -1,0 +1,235 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+import {
+	AccountsBalanceGroupOptions,
+	AssetsBalanceGroupOptions
+} from '../src/lib/pocketbase.schema';
+import { goToPageViaSidebar, signIn } from './playwright.helpers';
+import {
+	seedAccount,
+	seedAccountBalance,
+	seedAccountShare,
+	seedAsset,
+	seedAssetBalance,
+	seedAssetShare,
+	seedUser,
+	updateAccount,
+	updateAsset
+} from './pocketbase.helpers';
+
+// Holds the first request matching `pattern`, runs `mutate` while it is in flight, then delivers the
+// now-stale snapshot the server read before the mutation. This forces a realtime event to land inside
+// the store's initial fetch window - the race that used to clobber the event with the older snapshot.
+async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise<unknown>) {
+	let intercepted = false;
+	await page.route(pattern, async (route: Route) => {
+		if (intercepted) return route.continue();
+		intercepted = true;
+		const response = await route.fetch();
+		await mutate();
+		// HACK: a buffered realtime event has no UI signal to wait on, so a bounded delay is the only
+		// lever to guarantee the event reaches the browser before the stale snapshot resolves.
+		await new Promise((resolve) => setTimeout(resolve, 750));
+		await route.fulfill({ response });
+	});
+}
+
+test('accounts store keeps a realtime rename that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const user = await seedUser('mira');
+	const account = await seedAccount({
+		name: 'Original Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 2500
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/accounts/records**', () =>
+		updateAccount(account.id, { name: 'Renamed Checking' })
+	);
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Accounts');
+	await expect(page.getByRole('row', { name: 'Original Checking' })).not.toBeVisible();
+
+	await expect(page.getByRole('row', { name: 'Renamed Checking' })).toBeVisible();
+});
+
+test('accounts store keeps a realtime balance that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const user = await seedUser('noor');
+	const account = await seedAccount({
+		name: 'Everyday Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: '2025-01-01T00:00:00.000Z',
+		value: 2500
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/accountBalances/records**', () =>
+		seedAccountBalance({
+			account: account.id,
+			owner: user.id,
+			asOf: new Date().toISOString(),
+			value: 9999
+		})
+	);
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Accounts');
+
+	const row = page.getByRole('row', { name: 'Everyday Checking' });
+	await expect(row).toBeVisible();
+	await expect(row.locator('td').nth(6)).toContainText('$9,999.00');
+});
+
+test('accounts store keeps a realtime share that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const owner = await seedUser('opal');
+	const recipient = await seedUser('quinn');
+	const account = await seedAccount({
+		name: 'Joint Savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: owner.id,
+		balanceType: 'Savings'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 4000
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/accountShares/records**', () =>
+		seedAccountShare({
+			account: account.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		})
+	);
+	await signIn(page, owner.email);
+	await goToPageViaSidebar(page, 'Accounts');
+
+	const row = page.getByRole('row', { name: 'Joint Savings' });
+	await expect(row).toBeVisible();
+	await expect(row.getByLabel('Shared account')).toBeVisible();
+});
+
+test('assets store keeps a realtime rename that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const user = await seedUser('rune');
+	const asset = await seedAsset({
+		name: 'Vintage Watch',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: user.id,
+		balanceType: 'Collectible'
+	});
+	await seedAssetBalance({
+		asset: asset.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		marketValue: 3000
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/assets/records**', () =>
+		updateAsset(asset.id, { name: 'Rare Timepiece' })
+	);
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Assets');
+	await expect(page.getByRole('row', { name: 'Vintage Watch' })).not.toBeVisible();
+
+	await expect(page.getByRole('row', { name: 'Rare Timepiece' })).toBeVisible();
+});
+
+test('assets store keeps a realtime balance that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const user = await seedUser('sable');
+	const asset = await seedAsset({
+		name: 'Gold Bars',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: user.id,
+		balanceType: 'Precious metals'
+	});
+	await seedAssetBalance({
+		asset: asset.id,
+		owner: user.id,
+		asOf: '2025-01-01T00:00:00.000Z',
+		marketValue: 3000
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/assetBalances/records**', () =>
+		seedAssetBalance({
+			asset: asset.id,
+			owner: user.id,
+			asOf: new Date().toISOString(),
+			marketValue: 8888
+		})
+	);
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Assets');
+
+	const row = page.getByRole('row', { name: 'Gold Bars' });
+	await expect(row).toBeVisible();
+	await expect(row.locator('td').nth(7)).toContainText('$8,888.00');
+});
+
+test('assets store keeps a realtime share that lands during the initial snapshot fetch', async ({
+	page
+}) => {
+	const owner = await seedUser('tomas');
+	const recipient = await seedUser('vera');
+	const asset = await seedAsset({
+		name: 'Family Cabin',
+		balanceGroup: AssetsBalanceGroupOptions.OTHER,
+		owner: owner.id,
+		balanceType: 'Property'
+	});
+	await seedAssetBalance({
+		asset: asset.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		marketValue: 250000
+	});
+
+	await page.goto('/');
+	await holdFirstFetch(page, '**/api/collections/assetShares/records**', () =>
+		seedAssetShare({
+			asset: asset.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		})
+	);
+	await signIn(page, owner.email);
+	await goToPageViaSidebar(page, 'Assets');
+
+	const row = page.getByRole('row', { name: 'Family Cabin' });
+	await expect(row).toBeVisible();
+	await expect(row.getByLabel('Shared asset')).toBeVisible();
+});

--- a/e2e/realtime-refresh-race.test.ts
+++ b/e2e/realtime-refresh-race.test.ts
@@ -6,20 +6,25 @@ import {
 } from '../src/lib/pocketbase.schema';
 import { goToPageViaSidebar, signIn } from './playwright.helpers';
 import {
+	getUserPB,
 	seedAccount,
 	seedAccountBalance,
 	seedAccountShare,
 	seedAsset,
 	seedAssetBalance,
 	seedAssetShare,
+	seedPortfolio,
 	seedUser,
 	updateAccount,
 	updateAsset
 } from './pocketbase.helpers';
 
-// Holds the first request matching `pattern`, runs `mutate` while it is in flight, then delivers the
-// now-stale snapshot the server read before the mutation. This forces a realtime event to land inside
-// the store's initial fetch window - the race that used to clobber the event with the older snapshot.
+// Holds the store's first fetch matching `pattern`, runs `mutate` while it is in flight, then
+// releases the now-stale snapshot the server read before the mutation. Under the invalidation-only
+// model the mutation fires a realtime event that schedules a debounced follow-up refetch, which reads
+// the post-mutation state and commits under a newer request token. The held first fetch then resolves
+// with pre-mutation data under its older token and is discarded by the latest-wins guard, so the
+// mutation is the state that survives.
 async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise<unknown>) {
 	let intercepted = false;
 	await page.route(pattern, async (route: Route) => {
@@ -27,8 +32,8 @@ async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise
 		intercepted = true;
 		const response = await route.fetch();
 		await mutate();
-		// HACK: a buffered realtime event has no UI signal to wait on, so a bounded delay is the only
-		// lever to guarantee the event reaches the browser before the stale snapshot resolves.
+		// HACK: the event-triggered follow-up refetch has no UI signal to wait on, so a bounded delay
+		// is the only lever to let it commit before the stale first fetch resolves.
 		await new Promise((resolve) => setTimeout(resolve, 750));
 		await route.fulfill({ response });
 	});
@@ -232,4 +237,61 @@ test('assets store keeps a realtime share that lands during the initial snapshot
 	const row = page.getByRole('row', { name: 'Family Cabin' });
 	await expect(row).toBeVisible();
 	await expect(row.getByLabel('Shared asset')).toBeVisible();
+});
+
+test('securities store keeps a security delete that lands during the initial snapshot fetch removed', async ({
+	page
+}) => {
+	const user = await seedUser('wynn');
+	const {
+		securities: [doomed]
+	} = await seedPortfolio(user.id, {
+		accounts: ['Wynn Brokerage'],
+		securities: [
+			{ name: 'Doomed Holding', symbol: 'DOOM' },
+			{ name: 'Steady Holding', symbol: 'STDY' }
+		],
+		balances: [
+			{
+				account: 'Wynn Brokerage',
+				security: 'Doomed Holding',
+				quantity: 5,
+				price: 100,
+				value: 500,
+				costBasis: 400
+			},
+			{
+				account: 'Wynn Brokerage',
+				security: 'Steady Holding',
+				quantity: 3,
+				price: 259,
+				value: 777,
+				costBasis: 600
+			}
+		],
+		asOf: new Date().toISOString()
+	});
+
+	await page.goto('/');
+	// Deleting the security cascades to its securityBalances server-side and fires a realtime event
+	// that lands while the store's initial securities snapshot is still held in flight. That event
+	// schedules a fresh full refetch (which reads the post-delete state), while the held pre-delete
+	// snapshot resolves later under an older token and is discarded by the latest-wins guard.
+	await holdFirstFetch(page, '**/api/collections/securities/records**', async () => {
+		const userPb = await getUserPB(user.email);
+		await userPb.collection('securities').delete(doomed.id);
+	});
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Portfolio');
+
+	// Anchor on the surviving position first: its row (and intact balance) proves the store committed a
+	// real post-delete snapshot, so the absence check below runs against rendered data rather than an
+	// unloaded skeleton - otherwise a leading absence assertion would pass trivially before any commit.
+	const survivingRow = page.getByRole('row', { name: /Steady Holding/ });
+	await expect(survivingRow).toContainText('STDY');
+	await expect(survivingRow.locator('td').last()).toHaveText('$777.00');
+
+	// The deleted security and its cascaded balances stay gone: the stale in-flight snapshot never
+	// resurrects them once the latest-wins token discards it.
+	await expect(page.getByRole('row', { name: /Doomed Holding/ })).toHaveCount(0);
 });

--- a/e2e/realtime-refresh-race.test.ts
+++ b/e2e/realtime-refresh-race.test.ts
@@ -19,13 +19,25 @@ import {
 	updateAsset
 } from './pocketbase.helpers';
 
-// Holds the store's first fetch matching `pattern`, runs `mutate` while it is in flight, then
-// releases the now-stale snapshot the server read before the mutation. Under the invalidation-only
-// model the mutation fires a realtime event that schedules a debounced follow-up refetch, which reads
-// the post-mutation state and commits under a newer request token. The held first fetch then resolves
-// with pre-mutation data under its older token and is discarded by the latest-wins guard, so the
-// mutation is the state that survives.
+// Holds the store's first fetch matching `pattern`, runs `mutate` while it is in flight, then releases
+// the now-stale snapshot the server read before the mutation. The mutation fires a realtime event that
+// schedules a debounced refetch reading the post-mutation state.
+//
+// These tests assert CONVERGENCE, not the latest-wins token guard. The intercepted first fetch belongs
+// to the (app)-layout store instance that mounts right after sign-in redirects to /big-picture;
+// `goToPageViaSidebar` then does a full `page.goto()` reload (and the root `{#key locale}` block re-keys
+// on async locale resolution), so that document - and its held request - is discarded before the delayed
+// fulfill lands. The freshly loaded page mounts a new store instance that issues its own initial fetch
+// reading post-mutation state. The stale snapshot never commits into the rendered store: it dies with
+// its document, not via a token comparison, so a broken guard is not observable here. The `settled`
+// promise and the post-`settled` re-assertions anchor that the store lands on and holds the
+// post-mutation state through the release - convergence - rather than probing the guard, which this
+// mechanism cannot exercise (that needs a two-token race within one live store instance).
 async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise<unknown>) {
+	let resolveSettled!: () => void;
+	const settled = new Promise<void>((resolve) => {
+		resolveSettled = resolve;
+	});
 	let intercepted = false;
 	await page.route(pattern, async (route: Route) => {
 		if (intercepted) return route.continue();
@@ -33,11 +45,110 @@ async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise
 		const response = await route.fetch();
 		await mutate();
 		// HACK: the event-triggered follow-up refetch has no UI signal to wait on, so a bounded delay
-		// is the only lever to let it commit before the stale first fetch resolves.
+		// is the only lever to let the reloaded page's fetch commit before the stale first fetch resolves.
 		await new Promise((resolve) => setTimeout(resolve, 750));
 		await route.fulfill({ response });
+		// HACK: releasing the stale snapshot has no UI signal to wait on either. Hop a frame plus a
+		// macrotask in the page so any effect of the release has quiesced before `settled` resolves -
+		// same spirit as the delay above, kept harness-internal rather than a waitForTimeout at the
+		// assertion level.
+		await page.evaluate(
+			() => new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)))
+		);
+		resolveSettled();
 	});
+	return { settled };
 }
+
+// Probes the latest-wins token guard within ONE live store instance, so a stale commit is observable
+// (unlike holdFirstFetch, which reloads the page and discards the held request with its document before
+// it can commit). Installed AFTER the store's initial fetch has rendered: the first intercepted refetch
+// is R1 (older token), captured post-mutation-1 and held in flight; the second is R2 (newer token),
+// let through so it reads post-mutation-2 state and commits. Releasing the now-stale R1 must be dropped
+// by the guard. `r1Dispatched` fires once R1's body is captured (so mutation 2 lands strictly after,
+// keeping the two debounce windows from coalescing); `r2Seen` fires once R2 reaches the network.
+async function holdRefetchForTokenRace(page: Page, pattern: string) {
+	let resolveR1Dispatched!: () => void;
+	const r1Dispatched = new Promise<void>((resolve) => (resolveR1Dispatched = resolve));
+	let resolveR2Seen!: () => void;
+	const r2Seen = new Promise<void>((resolve) => (resolveR2Seen = resolve));
+	let releaseR1!: () => void;
+	const r1Released = new Promise<void>((resolve) => (releaseR1 = resolve));
+	let resolveSettled!: () => void;
+	const settled = new Promise<void>((resolve) => (resolveSettled = resolve));
+
+	let matchCount = 0;
+	await page.route(pattern, async (route: Route) => {
+		matchCount++;
+		if (matchCount === 1) {
+			const response = await route.fetch();
+			resolveR1Dispatched();
+			await r1Released;
+			await route.fulfill({ response });
+			// HACK: releasing the stale snapshot has no UI signal to wait on, so hop a frame plus a
+			// macrotask in the page so any (broken-guard) commit of the stale response has flushed to the
+			// DOM before `settled` resolves - kept harness-internal rather than a waitForTimeout at the
+			// assertion level.
+			await page.evaluate(
+				() => new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)))
+			);
+			resolveSettled();
+			return;
+		}
+		if (matchCount === 2) resolveR2Seen();
+		return route.continue();
+	});
+	return { r1Dispatched, r2Seen, releaseR1, settled };
+}
+
+test('accounts store discards a stale realtime refetch resolving under an older token', async ({
+	page
+}) => {
+	const user = await seedUser('zephyr');
+	const account = await seedAccount({
+		name: 'Starting Checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 2500
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Accounts');
+	// The store instance is alive from here on - no further navigation or reload - so a stale refetch that
+	// commits would corrupt the rendered store rather than dying with a discarded document.
+	await expect(page.getByRole('row', { name: 'Starting Checking' })).toBeVisible();
+
+	const { r1Dispatched, r2Seen, releaseR1, settled } = await holdRefetchForTokenRace(
+		page,
+		'**/api/collections/accounts/records**'
+	);
+
+	// Mutation 1 -> realtime event -> debounced refetch R1 (older token) reads 'First Rename' and is held
+	// in flight before it can commit.
+	await updateAccount(account.id, { name: 'First Rename' });
+	await r1Dispatched;
+
+	// Mutation 2 while R1 is held -> refetch R2 (newer token) reads 'Final Name', passes through and
+	// commits. Awaiting the rendered rename proves R2 landed before the stale R1 is released.
+	await updateAccount(account.id, { name: 'Final Name' });
+	await r2Seen;
+	await expect(page.getByRole('row', { name: 'Final Name' })).toBeVisible();
+
+	// Releasing the stale R1: the guard drops it because its token is no longer current, so the UI keeps
+	// 'Final Name'. A broken guard would commit 'First Rename' here, and with no further realtime events
+	// nothing would ever re-correct it.
+	releaseR1();
+	await settled;
+	await expect(page.getByRole('row', { name: 'Final Name' })).toBeVisible();
+	await expect(page.getByRole('row', { name: 'First Rename' })).toHaveCount(0);
+});
 
 test('accounts store keeps a realtime rename that lands during the initial snapshot fetch', async ({
 	page
@@ -57,13 +168,17 @@ test('accounts store keeps a realtime rename that lands during the initial snaps
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/accounts/records**', () =>
+	const { settled } = await holdFirstFetch(page, '**/api/collections/accounts/records**', () =>
 		updateAccount(account.id, { name: 'Renamed Checking' })
 	);
 	await signIn(page, user.email);
 	await goToPageViaSidebar(page, 'Accounts');
 	await expect(page.getByRole('row', { name: 'Original Checking' })).not.toBeVisible();
+	await expect(page.getByRole('row', { name: 'Renamed Checking' })).toBeVisible();
 
+	// After the held pre-rename snapshot is released, the store must still show the realtime rename: it
+	// converged on the post-mutation state during load and holds it through the stale release.
+	await settled;
 	await expect(page.getByRole('row', { name: 'Renamed Checking' })).toBeVisible();
 });
 
@@ -85,19 +200,27 @@ test('accounts store keeps a realtime balance that lands during the initial snap
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/accountBalances/records**', () =>
-		seedAccountBalance({
-			account: account.id,
-			owner: user.id,
-			asOf: new Date().toISOString(),
-			value: 9999
-		})
+	const { settled } = await holdFirstFetch(
+		page,
+		'**/api/collections/accountBalances/records**',
+		() =>
+			seedAccountBalance({
+				account: account.id,
+				owner: user.id,
+				asOf: new Date().toISOString(),
+				value: 9999
+			})
 	);
 	await signIn(page, user.email);
 	await goToPageViaSidebar(page, 'Accounts');
 
 	const row = page.getByRole('row', { name: 'Everyday Checking' });
 	await expect(row).toBeVisible();
+	await expect(row.locator('td').nth(6)).toContainText('$9,999.00');
+
+	// After the held pre-update snapshot is released, the new balance must still be rendered: the store
+	// converged on the post-mutation value during load and holds it through the stale release.
+	await settled;
 	await expect(row.locator('td').nth(6)).toContainText('$9,999.00');
 });
 
@@ -120,7 +243,7 @@ test('accounts store keeps a realtime share that lands during the initial snapsh
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/accountShares/records**', () =>
+	const { settled } = await holdFirstFetch(page, '**/api/collections/accountShares/records**', () =>
 		seedAccountShare({
 			account: account.id,
 			recipient: recipient.id,
@@ -136,6 +259,11 @@ test('accounts store keeps a realtime share that lands during the initial snapsh
 
 	const row = page.getByRole('row', { name: 'Joint Savings' });
 	await expect(row).toBeVisible();
+	await expect(row.getByLabel('Shared account')).toBeVisible();
+
+	// After the held pre-share snapshot is released, the shared badge must still be rendered: the store
+	// converged on the post-share state during load and holds it through the stale release.
+	await settled;
 	await expect(row.getByLabel('Shared account')).toBeVisible();
 });
 
@@ -157,13 +285,17 @@ test('assets store keeps a realtime rename that lands during the initial snapsho
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/assets/records**', () =>
+	const { settled } = await holdFirstFetch(page, '**/api/collections/assets/records**', () =>
 		updateAsset(asset.id, { name: 'Rare Timepiece' })
 	);
 	await signIn(page, user.email);
 	await goToPageViaSidebar(page, 'Assets');
 	await expect(page.getByRole('row', { name: 'Vintage Watch' })).not.toBeVisible();
+	await expect(page.getByRole('row', { name: 'Rare Timepiece' })).toBeVisible();
 
+	// After the held pre-rename snapshot is released, the store must still show the realtime rename: it
+	// converged on the post-mutation state during load and holds it through the stale release.
+	await settled;
 	await expect(page.getByRole('row', { name: 'Rare Timepiece' })).toBeVisible();
 });
 
@@ -185,7 +317,7 @@ test('assets store keeps a realtime balance that lands during the initial snapsh
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/assetBalances/records**', () =>
+	const { settled } = await holdFirstFetch(page, '**/api/collections/assetBalances/records**', () =>
 		seedAssetBalance({
 			asset: asset.id,
 			owner: user.id,
@@ -198,6 +330,11 @@ test('assets store keeps a realtime balance that lands during the initial snapsh
 
 	const row = page.getByRole('row', { name: 'Gold Bars' });
 	await expect(row).toBeVisible();
+	await expect(row.locator('td').nth(7)).toContainText('$8,888.00');
+
+	// After the held pre-update snapshot is released, the new balance must still be rendered: the store
+	// converged on the post-mutation value during load and holds it through the stale release.
+	await settled;
 	await expect(row.locator('td').nth(7)).toContainText('$8,888.00');
 });
 
@@ -220,7 +357,7 @@ test('assets store keeps a realtime share that lands during the initial snapshot
 	});
 
 	await page.goto('/');
-	await holdFirstFetch(page, '**/api/collections/assetShares/records**', () =>
+	const { settled } = await holdFirstFetch(page, '**/api/collections/assetShares/records**', () =>
 		seedAssetShare({
 			asset: asset.id,
 			recipient: recipient.id,
@@ -236,6 +373,11 @@ test('assets store keeps a realtime share that lands during the initial snapshot
 
 	const row = page.getByRole('row', { name: 'Family Cabin' });
 	await expect(row).toBeVisible();
+	await expect(row.getByLabel('Shared asset')).toBeVisible();
+
+	// After the held pre-share snapshot is released, the shared badge must still be rendered: the store
+	// converged on the post-share state during load and holds it through the stale release.
+	await settled;
 	await expect(row.getByLabel('Shared asset')).toBeVisible();
 });
 
@@ -277,10 +419,14 @@ test('securities store keeps a security delete that lands during the initial sna
 	// that lands while the store's initial securities snapshot is still held in flight. That event
 	// schedules a fresh full refetch (which reads the post-delete state), while the held pre-delete
 	// snapshot resolves later under an older token and is discarded by the latest-wins guard.
-	await holdFirstFetch(page, '**/api/collections/securities/records**', async () => {
-		const userPb = await getUserPB(user.email);
-		await userPb.collection('securities').delete(doomed.id);
-	});
+	const { settled } = await holdFirstFetch(
+		page,
+		'**/api/collections/securities/records**',
+		async () => {
+			const userPb = await getUserPB(user.email);
+			await userPb.collection('securities').delete(doomed.id);
+		}
+	);
 	await signIn(page, user.email);
 	await goToPageViaSidebar(page, 'Portfolio');
 
@@ -294,4 +440,11 @@ test('securities store keeps a security delete that lands during the initial sna
 	// The deleted security and its cascaded balances stay gone: the stale in-flight snapshot never
 	// resurrects them once the latest-wins token discards it.
 	await expect(page.getByRole('row', { name: /Doomed Holding/ })).toHaveCount(0);
+
+	// After the held pre-delete snapshot is released, the positions total must reflect only the surviving
+	// holding ($777.00). The per-row $777.00 above survives in both states, but the net market value total
+	// discriminates: it confirms the store converged on the post-delete snapshot (total $777.00, not
+	// $1,277.00) during load and holds it through the stale release.
+	await settled;
+	await expect(page.getByRole('region', { name: 'Net market value' })).toContainText('$777.00');
 });

--- a/e2e/realtime-refresh-race.test.ts
+++ b/e2e/realtime-refresh-race.test.ts
@@ -47,14 +47,22 @@ async function holdFirstFetch(page: Page, pattern: string, mutate: () => Promise
 		// HACK: the event-triggered follow-up refetch has no UI signal to wait on, so a bounded delay
 		// is the only lever to let the reloaded page's fetch commit before the stale first fetch resolves.
 		await new Promise((resolve) => setTimeout(resolve, 750));
-		await route.fulfill({ response });
-		// HACK: releasing the stale snapshot has no UI signal to wait on either. Hop a frame plus a
-		// macrotask in the page so any effect of the release has quiesced before `settled` resolves -
-		// same spirit as the delay above, kept harness-internal rather than a waitForTimeout at the
-		// assertion level.
-		await page.evaluate(
-			() => new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)))
-		);
+		try {
+			await route.fulfill({ response });
+			// HACK: releasing the stale snapshot has no UI signal to wait on either. Hop a frame plus a
+			// macrotask in the page so any effect of the release has quiesced before `settled` resolves -
+			// same spirit as the delay above, kept harness-internal rather than a waitForTimeout at the
+			// assertion level.
+			await page.evaluate(
+				() => new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)))
+			);
+		} catch {
+			// HACK: `goToPageViaSidebar` does a full page.goto that discards this document (and its held
+			// request) before the delayed fulfill lands, so on a slow machine the fulfill or the quiesce
+			// hop can race the teardown and throw "Execution context was destroyed"/"Request is already
+			// handled". The release is best-effort - the stale snapshot dies with its document regardless -
+			// so swallow the teardown error and still resolve `settled` below so the test can't hang.
+		}
 		resolveSettled();
 	});
 	return { settled };

--- a/e2e/shared-records.test.ts
+++ b/e2e/shared-records.test.ts
@@ -802,8 +802,10 @@ test('shared account and asset reconcile after a realtime reconnect without relo
 		marketValue: 11000
 	});
 
-	// Track the SDK's realtime EventSource so the test can force it to error like a dropped
-	// connection, reproducing a session that misses the share events emitted while disconnected.
+	// Track the SDK's realtime EventSource so the test can dispatch a transport error on it. This
+	// covers the SDK's own reconnect path - onDisconnect, then PB_CONNECT - and only that path: a
+	// real network drop usually leaves the socket OPEN without ever erroring, which is why the
+	// offline test below drives the browser's online/visibility triggers instead.
 	await page.addInitScript(() => {
 		const NativeEventSource = window.EventSource;
 		const sources: EventSource[] = [];
@@ -868,4 +870,98 @@ test('shared account and asset reconcile after a realtime reconnect without relo
 
 	await goToPageViaSidebar(page, 'Assets');
 	await expect(page.getByRole('row', { name: /Reconnect brokerage/ })).toBeVisible();
+});
+
+test('shared account reconciles after the browser goes offline and back online', async ({
+	browserName,
+	page
+}) => {
+	// Only CDP reproduces a real network drop. `context.setOffline()` tears the realtime EventSource
+	// down, so the SDK sees a transport error and reconnects on its own; an actual offline network -
+	// what DevTools' offline mode emulates - leaves the socket OPEN and silent instead.
+	test.skip(browserName !== 'chromium', 'Network emulation is only available through CDP');
+	const cdp = await page.context().newCDPSession(page);
+	await cdp.send('Network.enable');
+	const emulateOffline = (offline: boolean) =>
+		cdp.send('Network.emulateNetworkConditions', {
+			offline,
+			latency: 0,
+			downloadThroughput: -1,
+			uploadThroughput: -1
+		});
+
+	const owner = await seedUser('felix');
+	const recipient = await seedUser('lucia');
+
+	const sharedAccount = await seedAccount({
+		name: 'Offline checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: owner.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: sharedAccount.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 1500
+	});
+	await seedAccountShare({
+		account: sharedAccount.id,
+		recipient: recipient.id,
+		recipientEmail: recipient.email,
+		grantedBy: owner.id,
+		accessRole: 'VIEWER',
+		perspective: 'NORMAL',
+		includeInNetWorth: true
+	});
+	const lateAccount = await seedAccount({
+		name: 'Offline savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: owner.id,
+		balanceType: 'Savings'
+	});
+	await seedAccountBalance({
+		account: lateAccount.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 900
+	});
+
+	await page.goto('/');
+	await signIn(page, recipient.email);
+
+	await goToPageViaSidebar(page, 'Accounts');
+	const checkingRow = page.getByRole('row', { name: /Offline checking/ });
+	await expect(checkingRow).toContainText('$1,500.00');
+
+	// A real network drop leaves the realtime socket OPEN and error-free, so the SDK never notices it
+	// and never reconnects. The socket even keeps delivering events - but the refetch each one
+	// schedules dies on the dead network and its result is discarded, which is what the connection
+	// toast reports. Waiting for that toast is what makes this test meaningful: it proves the missed
+	// mutations have already been consumed and thrown away before the network returns, so nothing but
+	// recovery can converge the session afterwards.
+	await emulateOffline(true);
+	await seedAccountBalance({
+		account: sharedAccount.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 4200
+	});
+	await seedAccountShare({
+		account: lateAccount.id,
+		recipient: recipient.id,
+		recipientEmail: recipient.email,
+		grantedBy: owner.id,
+		accessRole: 'VIEWER',
+		perspective: 'NORMAL',
+		includeInNetWorth: true
+	});
+	await expect(page.getByText("Can't connect to the database server")).toBeVisible();
+	await expect(checkingRow).toContainText('$1,500.00');
+	await expect(page.getByRole('row', { name: /Offline savings/ })).toHaveCount(0);
+
+	// Coming back online must reconcile the session on its own: no reload, no further realtime event.
+	await emulateOffline(false);
+	await expect(checkingRow).toContainText('$4,200.00');
+	await expect(page.getByRole('row', { name: /Offline savings/ })).toContainText('$900.00');
 });

--- a/e2e/shared-records.test.ts
+++ b/e2e/shared-records.test.ts
@@ -769,3 +769,103 @@ test('asset share API rejects self-share and unknown recipient', async () => {
 	);
 	expect(response.status).toBe(200);
 });
+
+test('shared account and asset reconcile after a realtime reconnect without relogin', async ({
+	page
+}) => {
+	const owner = await seedUser('dexter');
+	const recipient = await seedUser('gwen');
+
+	const sharedAccount = await seedAccount({
+		name: 'Reconnect savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: owner.id,
+		balanceType: 'Savings'
+	});
+	await seedAccountBalance({
+		account: sharedAccount.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 4200
+	});
+	const sharedAsset = await seedAsset({
+		name: 'Reconnect brokerage',
+		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
+		owner: owner.id,
+		balanceType: 'Brokerage'
+	});
+	await seedAssetBalance({
+		asset: sharedAsset.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		bookValue: 8000,
+		marketValue: 11000
+	});
+
+	// Track the SDK's realtime EventSource so the test can force it to error like a dropped
+	// connection, reproducing a session that misses the share events emitted while disconnected.
+	await page.addInitScript(() => {
+		const NativeEventSource = window.EventSource;
+		const sources: EventSource[] = [];
+		Object.assign(window, { __realtimeSources: sources });
+		window.EventSource = class extends NativeEventSource {
+			constructor(url: string | URL, init?: EventSourceInit) {
+				super(url, init);
+				sources.push(this);
+			}
+		};
+	});
+
+	await page.goto('/');
+	await signIn(page, recipient.email);
+
+	await goToPageViaSidebar(page, 'Accounts');
+	await expect(page.getByRole('row', { name: /Reconnect savings/ })).toHaveCount(0);
+
+	// Hold the realtime connection down while both records are shared, so the create events are
+	// never delivered to this session. Gating the reconnect (rather than aborting it) keeps the SDK
+	// from backing off, so releasing the gate reconnects promptly.
+	let releaseRealtime = () => {};
+	const realtimeGate = new Promise<void>((resolve) => {
+		releaseRealtime = resolve;
+	});
+	await page.route('**/api/realtime', async (route) => {
+		await realtimeGate;
+		await route.continue();
+	});
+	await page.evaluate(() => {
+		const sources = (window as unknown as { __realtimeSources: EventSource[] }).__realtimeSources;
+		for (const source of sources) source.dispatchEvent(new Event('error'));
+	});
+	await Promise.all([
+		seedAccountShare({
+			account: sharedAccount.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		}),
+		seedAssetShare({
+			asset: sharedAsset.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		})
+	]);
+	releaseRealtime();
+
+	// HACK: reconnect reconciliation refetches shares, accounts, and each account's balance in
+	// sequence, which can outrun the default expect timeout under a loaded CI machine; there is no
+	// reconcile-complete signal to await instead.
+	await expect(page.getByRole('row', { name: /Reconnect savings/ })).toContainText('$4,200.00', {
+		timeout: 15000
+	});
+
+	await goToPageViaSidebar(page, 'Assets');
+	await expect(page.getByRole('row', { name: /Reconnect brokerage/ })).toBeVisible();
+});

--- a/src/lib/account-cashflow.svelte.ts
+++ b/src/lib/account-cashflow.svelte.ts
@@ -7,6 +7,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 
 const DEBOUNCE_MS = 200;
 
@@ -42,23 +43,25 @@ class AccountCashflowContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private _transactions: TransactionsResponse[] = $state([]);
-	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _unsubscribe: (() => void) | null = null;
 	private _disposed = false;
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _recomputeSequence = 0;
 	private _accountId = '';
 	private _currency = $state('USD');
 	private _perspective = $state<AccountSharesPerspectiveOptions>(
 		AccountSharesPerspectiveOptions.NORMAL
 	);
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this.init();
 	}
@@ -139,22 +142,25 @@ class AccountCashflowContext {
 	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
 		if (!e.action) return;
 		if (e.record.account !== this._accountId) return;
+		this.invalidate();
+	}
 
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-		}
-
-		this._debounceTimer = setTimeout(() => {
-			this._debounceTimer = null;
-			void this.recomputeAll().catch((error) => {
-				logError('accountCashflow', 'recompute_on_event', error);
-			});
-		}, DEBOUNCE_MS);
+	// A transaction event or a realtime reconnect is a pure invalidation signal: it schedules the
+	// debounced windowed refetch rather than patching the event payload. A reconnect carries no
+	// record, so it recomputes only when an account is active and someone is signed in.
+	private invalidate() {
+		if (!this._activeUserId || !this._accountId) return;
+		this.debouncer.schedule(
+			() =>
+				void this.recomputeAll().catch((error) =>
+					this._pb.handleConnectionError(error, 'accountCashflow', 'refresh')
+				)
+		);
 	}
 
 	private async recomputeAll() {
 		const accountId = this._accountId;
-		const recomputeSequence = ++this._recomputeSequence;
+		const token = this.sequence.next();
 		const window = computeCashflowWindow();
 
 		try {
@@ -166,31 +172,26 @@ class AccountCashflowContext {
 					requestKey: null
 				});
 
-			if (recomputeSequence !== this._recomputeSequence) return;
+			if (!this.sequence.isCurrent(token)) return;
 
 			this._transactions = transactions;
 		} finally {
-			if (!this._disposed && recomputeSequence === this._recomputeSequence) this.isLoading = false;
+			if (!this._disposed && this.sequence.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
 	private reset() {
-		this._recomputeSequence++;
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-			this._debounceTimer = null;
-		}
+		this.sequence.bump();
+		this.debouncer.cancel();
 		this._transactions = [];
 	}
 
 	dispose() {
 		this._disposed = true;
-		this._recomputeSequence++;
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-			this._debounceTimer = null;
-		}
+		this.sequence.bump();
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -86,6 +86,9 @@ class AccountsContext {
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => {
+		if (this.currentUserId) void this.refreshForCurrentUser();
+	};
 
 	constructor(
 		pb: PocketBaseContext,
@@ -94,6 +97,7 @@ class AccountsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -534,6 +538,7 @@ class AccountsContext {
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -1,4 +1,3 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
@@ -14,16 +13,11 @@ import {
 	type AccountsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 import type { AccountPositionsValue } from './securities.svelte';
 import { sumOrUnknown } from './security-balance-values';
 import { participantExcluded, projectSignedValue } from './sharing';
-import {
-	isUnavailableRecordError,
-	removeById,
-	toPocketBaseDateString,
-	upsertById,
-	type SnapshotMutation
-} from './utils';
+import { toPocketBaseDateString } from './utils';
 
 export type AccountWithBalance = AccountsResponse & {
 	// NOTE: `balance` is the perspective-projected total in the account's own currency (null when
@@ -50,13 +44,12 @@ type PositionsSource = {
 	positionsLoaded: boolean;
 };
 
-type LatestAccountBalance = {
-	id: string;
-	account: string;
+type LatestCash = {
 	value: number;
 	asOf: string;
-	created: string;
 };
+
+const DEBOUNCE_MS = 200;
 
 class AccountsContext {
 	accounts: AccountWithBalance[] = $derived.by(() =>
@@ -80,25 +73,19 @@ class AccountsContext {
 	isLoading: boolean = $state(true);
 
 	private rawAccounts: AccountsResponse[] = $state([]);
-	private latestCashByAccount = new SvelteMap<string, LatestAccountBalance>();
+	private latestCashByAccount = new SvelteMap<string, LatestCash>();
 	private positionsSource: PositionsSource | null = $state(null);
 	private accountsLoaded = false;
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
-	private refreshSequence = 0;
-	private activeSnapshotToken: number | null = null;
-	private accountSnapshotMutations: SnapshotMutation<AccountsResponse>[] = [];
-	private shareSnapshotMutations: SnapshotMutation<AccountSharesResponse>[] = [];
-	private snapshotBalanceOwners = new Set<string>();
-	private snapshotShareAccounts = new Set<string>();
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => {
-		if (this.currentUserId) void this.refreshForCurrentUser();
-	};
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(
 		pb: PocketBaseContext,
@@ -165,25 +152,17 @@ class AccountsContext {
 			recipientEmail,
 			perspective
 		});
-		await this.refreshShares();
-		if (await this.refreshAccount(accountId, this.currentUserId)) this.notifyBalancesChanged();
+		await this.refreshForCurrentUser();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
-		const share = await this._pb.authedClient
-			.collection('accountShares')
-			.update<AccountSharesResponse>(shareId, { includeInNetWorth });
-		await this.refreshShares();
-		if (await this.refreshAccount(share.account, this.currentUserId)) this.notifyBalancesChanged();
+		await this._pb.authedClient.collection('accountShares').update(shareId, { includeInNetWorth });
+		await this.refreshForCurrentUser();
 	}
 
 	async revokeShare(shareId: string) {
-		const accountId = this.shares.find((share) => share.id === shareId)?.account;
 		await this._pb.authedClient.collection('accountShares').delete(shareId);
-		await this.refreshShares();
-		if (accountId && (await this.refreshAccount(accountId, this.currentUserId))) {
-			this.notifyBalancesChanged();
-		}
+		await this.refreshForCurrentUser();
 	}
 
 	private init() {
@@ -191,14 +170,10 @@ class AccountsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.activeSnapshotToken = null;
-			this.accountSnapshotMutations = [];
-			this.shareSnapshotMutations = [];
-			this.snapshotBalanceOwners.clear();
-			this.snapshotShareAccounts.clear();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this.refreshSequence++;
 				this.rawAccounts = [];
 				this.latestCashByAccount.clear();
 				this.shares = [];
@@ -215,20 +190,18 @@ class AccountsContext {
 		});
 	}
 
-	// NOTE: Realtime events landing while these list fetches are in flight are buffered (records and
-	// shares) or noted by owner (balances). Buffered record/share mutations replay onto the fetched
-	// snapshot before it's committed, and touched owners are refetched afterwards, so an event is
-	// never clobbered by the older snapshot and the store never commits emptier than the database.
-	private async refreshForCurrentUser() {
+	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
+	// state, they only schedule a full refetch. Deletes, share membership changes, and cross-account
+	// balance reassignments all resolve for free because the fresh snapshot reflects the database as-is.
+	private invalidate() {
+		this.debouncer.schedule(() => void this.refreshForCurrentUser());
+	}
+
+	async refreshForCurrentUser() {
 		const userId = this.currentUserId;
-		const token = ++this.refreshSequence;
-		this.activeSnapshotToken = token;
-		this.accountSnapshotMutations = [];
-		this.shareSnapshotMutations = [];
-		this.snapshotBalanceOwners.clear();
-		this.snapshotShareAccounts.clear();
+		const token = this.sequence.next();
 		try {
-			const [shares, accounts] = await Promise.all([
+			const [shares, accounts, balances] = await Promise.all([
 				this._pb.authedClient.collection('accountShares').getFullList<AccountSharesResponse>({
 					filter: `grantedBy='${userId}' || recipient='${userId}'`,
 					sort: 'recipientEmail',
@@ -237,88 +210,40 @@ class AccountsContext {
 				this._pb.authedClient.collection('accounts').getFullList<AccountsResponse>({
 					filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
 					requestKey: null
+				}),
+				// One query for every account's latest balance instead of N point-queries: the
+				// 'account,-asOf,-created,-id' sort groups by account and orders each group newest-first,
+				// so the first row seen per account wins - the same tiebreakers getList(1,1) used.
+				this._pb.authedClient.collection('accountBalances').getFullList<AccountBalancesResponse>({
+					sort: 'account,-asOf,-created,-id',
+					fields: 'account,value,asOf',
+					requestKey: null
 				})
 			]);
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
 			for (const account of accounts) {
 				await this.balanceTypesContext.ensureLoaded(account.balanceType);
 			}
-			for (const mutation of this.accountSnapshotMutations) {
-				if (!mutation.deleted)
-					await this.balanceTypesContext.ensureLoaded(mutation.record.balanceType);
-			}
-			const latestBalances = await Promise.all(
-				accounts.map((account) => this.getLatestAccountBalance(account.id))
-			);
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
 
-			let reconciledShares = shares;
-			for (const mutation of this.shareSnapshotMutations) {
-				reconciledShares = mutation.deleted
-					? reconciledShares.filter((share) => share.id !== mutation.record.id)
-					: upsertById(reconciledShares, mutation.record).list;
-			}
-			this.shares = reconciledShares.toSorted((a, b) =>
-				a.recipientEmail.localeCompare(b.recipientEmail)
-			);
-
-			let reconciledAccounts = accounts;
-			for (const mutation of this.accountSnapshotMutations) {
-				reconciledAccounts = mutation.deleted
-					? reconciledAccounts.filter((account) => account.id !== mutation.record.id)
-					: upsertById(reconciledAccounts, mutation.record).list;
-			}
+			this.shares = shares.toSorted((a, b) => a.recipientEmail.localeCompare(b.recipientEmail));
 			this.latestCashByAccount.clear();
-			for (const balance of latestBalances) {
-				if (balance) this.latestCashByAccount.set(balance.account, balance);
+			for (const balance of balances) {
+				if (this.latestCashByAccount.has(balance.account)) continue;
+				this.latestCashByAccount.set(balance.account, {
+					value: balance.value ?? 0,
+					asOf: balance.asOf
+				});
 			}
-			this.rawAccounts = reconciledAccounts;
+			this.rawAccounts = accounts;
 			this.accountsLoaded = true;
 			this.notifyBalancesChanged();
 		} catch (error) {
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-			this._pb.handleConnectionError(error, 'accounts', 'init');
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			this._pb.handleConnectionError(error, 'accounts', 'refresh');
 		} finally {
-			if (this.activeSnapshotToken === token) {
-				this.activeSnapshotToken = null;
-				this.accountSnapshotMutations = [];
-				this.shareSnapshotMutations = [];
-			}
-			if (userId === this.currentUserId && token === this.refreshSequence) this.isLoading = false;
+			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
 		}
-
-		// Refetch owners touched by balance events and accounts touched by share events so a delete or
-		// membership change that landed during the fetch resolves to the database's current state.
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const balanceOwners = [...this.snapshotBalanceOwners];
-		const shareAccounts = [...this.snapshotShareAccounts];
-		this.snapshotBalanceOwners.clear();
-		this.snapshotShareAccounts.clear();
-		let changed = false;
-		try {
-			for (const accountId of shareAccounts) {
-				if (await this.refreshAccount(accountId, userId)) changed = true;
-			}
-			for (const accountId of balanceOwners) {
-				if (shareAccounts.includes(accountId)) continue;
-				if (await this.refreshAccountBalance(accountId, userId)) changed = true;
-			}
-		} catch (error) {
-			if (userId !== this.currentUserId) return;
-			this._pb.handleConnectionError(error, 'accounts', 'snapshot_settle');
-		}
-		if (changed && userId === this.currentUserId) this.notifyBalancesChanged();
-	}
-
-	private async refreshShares(userId = this.currentUserId, token = this.refreshSequence) {
-		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const shares = await this._pb.authedClient.collection('accountShares').getFullList({
-			filter: `grantedBy='${userId}' || recipient='${userId}'`,
-			sort: 'recipientEmail',
-			requestKey: null
-		});
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-		this.shares = shares;
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -326,13 +251,7 @@ class AccountsContext {
 
 		this._pb.authedClient
 			.collection('accounts')
-			.subscribe<AccountsResponse>('*', (event) => {
-				void this.onCollectionEvent(event, userId).catch((error) => {
-					if (userId === this._activeUserId) {
-						this._pb.handleConnectionError(error, 'accounts', 'account_event');
-					}
-				});
-			})
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_accounts');
@@ -342,13 +261,7 @@ class AccountsContext {
 			});
 		this._pb.authedClient
 			.collection('accountBalances')
-			.subscribe<AccountBalancesResponse>('*', (event) => {
-				void this.onCollectionEvent(event, userId).catch((error) => {
-					if (userId === this._activeUserId) {
-						this._pb.handleConnectionError(error, 'accounts', 'balance_event');
-					}
-				});
-			})
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_balances');
@@ -358,7 +271,7 @@ class AccountsContext {
 			});
 		this._pb.authedClient
 			.collection('accountShares')
-			.subscribe<AccountSharesResponse>('*', (event) => this.onAccountShareEvent(event, userId))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'accounts', 'subscribe_shares');
@@ -369,192 +282,17 @@ class AccountsContext {
 		this._isSubscribed = true;
 	}
 
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
+
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('accounts').unsubscribe('*');
 		this._pb.authedClient.collection('accountBalances').unsubscribe('*');
 		this._pb.authedClient.collection('accountShares').unsubscribe('*');
-	}
-
-	private async onCollectionEvent(
-		e: RecordSubscription<AccountsResponse> | RecordSubscription<AccountBalancesResponse>,
-		userId: string
-	) {
-		if (!userId || userId !== this._activeUserId) return;
-		if (!e.action) return;
-		if (this.activeSnapshotToken !== null) {
-			if ('account' in e.record) {
-				this.snapshotBalanceOwners.add(e.record.account);
-			} else {
-				this.accountSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
-				if (e.action === 'create') this.snapshotBalanceOwners.add(e.record.id);
-			}
-			return;
-		}
-		if ('account' in e.record) {
-			await this.onAccountBalanceEvent(e.action, e.record, userId);
-			return;
-		}
-		await this.onAccountEvent(e.action, e.record, userId);
-	}
-
-	private onAccountShareEvent(e: RecordSubscription<AccountSharesResponse>, userId: string) {
-		if (!userId || userId !== this._activeUserId) return;
-		const isRelevantShare = e.record.grantedBy === userId || e.record.recipient === userId;
-		if (this.activeSnapshotToken !== null) {
-			if (e.action === 'delete') {
-				this.shareSnapshotMutations.push({ deleted: true, record: e.record });
-			} else if (isRelevantShare) {
-				this.shareSnapshotMutations.push({ deleted: false, record: e.record });
-			}
-			this.snapshotShareAccounts.add(e.record.account);
-			return;
-		}
-		if (e.action === 'create') {
-			if (isRelevantShare) this.shares = [...this.shares, e.record];
-		} else if (e.action === 'update') {
-			if (isRelevantShare)
-				this.shares = this.shares.map((share) => (share.id === e.record.id ? e.record : share));
-		} else if (e.action === 'delete') {
-			this.shares = this.shares.filter((share) => share.id !== e.record.id);
-		}
-
-		void this.refreshAccount(e.record.account, userId)
-			.then(() => this.notifyBalancesChanged())
-			.catch((error) => {
-				if (userId === this.currentUserId)
-					this._pb.handleConnectionError(error, 'accounts', 'share');
-			});
-	}
-
-	private async onAccountEvent(action: string, account: AccountsResponse, userId: string) {
-		if (action === 'delete') {
-			this.removeAccountRecord(account.id);
-			this.latestCashByAccount.delete(account.id);
-			this.notifyBalancesChanged();
-			return;
-		}
-
-		await this.balanceTypesContext.ensureLoaded(account.balanceType);
-		if (userId !== this.currentUserId) return;
-		this.upsertAccountRecord(account);
-		if (!this.latestCashByAccount.has(account.id)) {
-			await this.refreshAccountBalance(account.id, userId);
-		}
-		this.notifyBalancesChanged();
-	}
-
-	private async onAccountBalanceEvent(
-		action: string,
-		balance: AccountBalancesResponse,
-		userId: string
-	) {
-		const accountId = balance.account;
-		let previousAccountId: string | null = null;
-		for (const [key, currentBalance] of this.latestCashByAccount) {
-			if (currentBalance.id === balance.id) {
-				previousAccountId = key;
-				break;
-			}
-		}
-		if (previousAccountId && previousAccountId !== accountId) {
-			await this.refreshAccountBalance(previousAccountId, userId);
-		}
-
-		if (!this.rawAccounts.some((account) => account.id === accountId)) {
-			await this.refreshAccount(accountId, userId);
-			this.notifyBalancesChanged();
-			return;
-		}
-
-		const current = this.latestCashByAccount.get(accountId);
-		if (action === 'delete' || current?.id === balance.id) {
-			await this.refreshAccountBalance(accountId, userId);
-			this.notifyBalancesChanged();
-			return;
-		}
-
-		if (!current || this.isAtLeastAsRecent(balance, current)) {
-			this.latestCashByAccount.set(accountId, this.toLatestAccountBalance(balance));
-			this.notifyBalancesChanged();
-		}
-	}
-
-	private upsertAccountRecord(account: AccountsResponse) {
-		this.rawAccounts = upsertById(this.rawAccounts, account).list;
-	}
-
-	private removeAccountRecord(accountId: string) {
-		this.rawAccounts = removeById(this.rawAccounts, accountId).list;
-	}
-
-	async refreshAccount(accountId: string, userId: string) {
-		if (!userId || userId !== this.currentUserId) return false;
-		try {
-			const account = await this._pb.authedClient
-				.collection('accounts')
-				.getOne<AccountsResponse>(accountId, { requestKey: null });
-			await this.balanceTypesContext.ensureLoaded(account.balanceType);
-			const balance = await this.getLatestAccountBalance(accountId);
-			if (userId !== this.currentUserId) return false;
-			this.upsertAccountRecord(account);
-			if (balance) this.latestCashByAccount.set(accountId, balance);
-			else this.latestCashByAccount.delete(accountId);
-			return true;
-		} catch (error) {
-			if (isUnavailableRecordError(error)) {
-				this.removeAccountRecord(accountId);
-				this.latestCashByAccount.delete(accountId);
-				return true;
-			}
-			throw error;
-		}
-	}
-
-	private async refreshAccountBalance(accountId: string, userId: string) {
-		const balanceBeforeRefresh = this.latestCashByAccount.get(accountId);
-		const balance = await this.getLatestAccountBalance(accountId);
-		if (userId !== this.currentUserId) return false;
-		if (balance) this.latestCashByAccount.set(accountId, balance);
-		else if (
-			balanceBeforeRefresh &&
-			this.latestCashByAccount.get(accountId)?.id === balanceBeforeRefresh.id
-		) {
-			this.latestCashByAccount.delete(accountId);
-		}
-		return true;
-	}
-
-	private async getLatestAccountBalance(accountId: string) {
-		const res = await this._pb.authedClient
-			.collection('accountBalances')
-			.getList<AccountBalancesResponse>(1, 1, {
-				filter: `account='${accountId}'`,
-				sort: '-asOf,-created,-id',
-				requestKey: null
-			});
-		const balance = res.items[0];
-		return balance ? this.toLatestAccountBalance(balance) : null;
-	}
-
-	private toLatestAccountBalance(balance: AccountBalancesResponse) {
-		return {
-			id: balance.id,
-			account: balance.account,
-			value: balance.value ?? 0,
-			asOf: balance.asOf,
-			created: balance.created
-		};
-	}
-
-	private isAtLeastAsRecent(
-		balance: Pick<AccountBalancesResponse, 'asOf' | 'created' | 'id'>,
-		current: Pick<LatestAccountBalance, 'asOf' | 'created' | 'id'>
-	) {
-		if (balance.asOf !== current.asOf) return balance.asOf > current.asOf;
-		if (balance.created !== current.created) return balance.created > current.created;
-		return balance.id >= current.id;
 	}
 
 	private toAccountWithBalance(
@@ -613,9 +351,11 @@ class AccountsContext {
 	}
 
 	dispose() {
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -17,7 +17,13 @@ import type { PocketBaseContext } from './pocketbase.svelte';
 import type { AccountPositionsValue } from './securities.svelte';
 import { sumOrUnknown } from './security-balance-values';
 import { participantExcluded, projectSignedValue } from './sharing';
-import { isUnavailableRecordError, removeById, toPocketBaseDateString, upsertById } from './utils';
+import {
+	isUnavailableRecordError,
+	removeById,
+	toPocketBaseDateString,
+	upsertById,
+	type SnapshotMutation
+} from './utils';
 
 export type AccountWithBalance = AccountsResponse & {
 	// NOTE: `balance` is the perspective-projected total in the account's own currency (null when
@@ -50,11 +56,6 @@ type LatestAccountBalance = {
 	value: number;
 	asOf: string;
 	created: string;
-};
-
-type SnapshotMutation<T> = {
-	deleted: boolean;
-	record: T;
 };
 
 class AccountsContext {
@@ -290,12 +291,17 @@ class AccountsContext {
 		this.snapshotBalanceOwners.clear();
 		this.snapshotShareAccounts.clear();
 		let changed = false;
-		for (const accountId of shareAccounts) {
-			if (await this.refreshAccount(accountId, userId)) changed = true;
-		}
-		for (const accountId of balanceOwners) {
-			if (shareAccounts.includes(accountId)) continue;
-			if (await this.refreshAccountBalance(accountId, userId)) changed = true;
+		try {
+			for (const accountId of shareAccounts) {
+				if (await this.refreshAccount(accountId, userId)) changed = true;
+			}
+			for (const accountId of balanceOwners) {
+				if (shareAccounts.includes(accountId)) continue;
+				if (await this.refreshAccountBalance(accountId, userId)) changed = true;
+			}
+		} catch (error) {
+			if (userId !== this.currentUserId) return;
+			this._pb.handleConnectionError(error, 'accounts', 'snapshot_settle');
 		}
 		if (changed && userId === this.currentUserId) this.notifyBalancesChanged();
 	}
@@ -376,9 +382,6 @@ class AccountsContext {
 		if (this.activeSnapshotToken !== null) {
 			if ('account' in e.record) {
 				this.snapshotBalanceOwners.add(e.record.account);
-				for (const [ownerAccountId, cash] of this.latestCashByAccount) {
-					if (cash.id === e.record.id) this.snapshotBalanceOwners.add(ownerAccountId);
-				}
 			} else {
 				this.accountSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
 				if (e.action === 'create') this.snapshotBalanceOwners.add(e.record.id);

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -52,6 +52,11 @@ type LatestAccountBalance = {
 	created: string;
 };
 
+type SnapshotMutation<T> = {
+	deleted: boolean;
+	record: T;
+};
+
 class AccountsContext {
 	accounts: AccountWithBalance[] = $derived.by(() =>
 		this.rawAccounts.map((record) => {
@@ -82,7 +87,11 @@ class AccountsContext {
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
 	private refreshSequence = 0;
-	private mutationEpoch = 0;
+	private activeSnapshotToken: number | null = null;
+	private accountSnapshotMutations: SnapshotMutation<AccountsResponse>[] = [];
+	private shareSnapshotMutations: SnapshotMutation<AccountSharesResponse>[] = [];
+	private snapshotBalanceOwners = new Set<string>();
+	private snapshotShareAccounts = new Set<string>();
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
@@ -177,6 +186,11 @@ class AccountsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.activeSnapshotToken = null;
+			this.accountSnapshotMutations = [];
+			this.shareSnapshotMutations = [];
+			this.snapshotBalanceOwners.clear();
+			this.snapshotShareAccounts.clear();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.refreshSequence++;
@@ -196,19 +210,94 @@ class AccountsContext {
 		});
 	}
 
+	// NOTE: Realtime events landing while these list fetches are in flight are buffered (records and
+	// shares) or noted by owner (balances). Buffered record/share mutations replay onto the fetched
+	// snapshot before it's committed, and touched owners are refetched afterwards, so an event is
+	// never clobbered by the older snapshot and the store never commits emptier than the database.
 	private async refreshForCurrentUser() {
 		const userId = this.currentUserId;
 		const token = ++this.refreshSequence;
+		this.activeSnapshotToken = token;
+		this.accountSnapshotMutations = [];
+		this.shareSnapshotMutations = [];
+		this.snapshotBalanceOwners.clear();
+		this.snapshotShareAccounts.clear();
 		try {
-			await this.refreshShares(userId, token);
-			await this.refreshAccounts(userId, token);
+			const [shares, accounts] = await Promise.all([
+				this._pb.authedClient.collection('accountShares').getFullList<AccountSharesResponse>({
+					filter: `grantedBy='${userId}' || recipient='${userId}'`,
+					sort: 'recipientEmail',
+					requestKey: null
+				}),
+				this._pb.authedClient.collection('accounts').getFullList<AccountsResponse>({
+					filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
+					requestKey: null
+				})
+			]);
+			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+			for (const account of accounts) {
+				await this.balanceTypesContext.ensureLoaded(account.balanceType);
+			}
+			for (const mutation of this.accountSnapshotMutations) {
+				if (!mutation.deleted)
+					await this.balanceTypesContext.ensureLoaded(mutation.record.balanceType);
+			}
+			const latestBalances = await Promise.all(
+				accounts.map((account) => this.getLatestAccountBalance(account.id))
+			);
+			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+
+			let reconciledShares = shares;
+			for (const mutation of this.shareSnapshotMutations) {
+				reconciledShares = mutation.deleted
+					? reconciledShares.filter((share) => share.id !== mutation.record.id)
+					: upsertById(reconciledShares, mutation.record).list;
+			}
+			this.shares = reconciledShares.toSorted((a, b) =>
+				a.recipientEmail.localeCompare(b.recipientEmail)
+			);
+
+			let reconciledAccounts = accounts;
+			for (const mutation of this.accountSnapshotMutations) {
+				reconciledAccounts = mutation.deleted
+					? reconciledAccounts.filter((account) => account.id !== mutation.record.id)
+					: upsertById(reconciledAccounts, mutation.record).list;
+			}
+			this.latestCashByAccount.clear();
+			for (const balance of latestBalances) {
+				if (balance) this.latestCashByAccount.set(balance.account, balance);
+			}
+			this.rawAccounts = reconciledAccounts;
+			this.accountsLoaded = true;
 			this.notifyBalancesChanged();
 		} catch (error) {
 			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 			this._pb.handleConnectionError(error, 'accounts', 'init');
 		} finally {
+			if (this.activeSnapshotToken === token) {
+				this.activeSnapshotToken = null;
+				this.accountSnapshotMutations = [];
+				this.shareSnapshotMutations = [];
+			}
 			if (userId === this.currentUserId && token === this.refreshSequence) this.isLoading = false;
 		}
+
+		// Refetch owners touched by balance events and accounts touched by share events so a delete or
+		// membership change that landed during the fetch resolves to the database's current state.
+		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+		const balanceOwners = [...this.snapshotBalanceOwners];
+		const shareAccounts = [...this.snapshotShareAccounts];
+		this.snapshotBalanceOwners.clear();
+		this.snapshotShareAccounts.clear();
+		let changed = false;
+		for (const accountId of shareAccounts) {
+			if (await this.refreshAccount(accountId, userId)) changed = true;
+		}
+		for (const accountId of balanceOwners) {
+			if (shareAccounts.includes(accountId)) continue;
+			if (await this.refreshAccountBalance(accountId, userId)) changed = true;
+		}
+		if (changed && userId === this.currentUserId) this.notifyBalancesChanged();
 	}
 
 	private async refreshShares(userId = this.currentUserId, token = this.refreshSequence) {
@@ -220,36 +309,6 @@ class AccountsContext {
 		});
 		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 		this.shares = shares;
-	}
-
-	private async refreshAccounts(userId = this.currentUserId, token = this.refreshSequence) {
-		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const epoch = this.mutationEpoch;
-		const accounts = await this._pb.authedClient
-			.collection('accounts')
-			.getFullList<AccountsResponse>({
-				filter: `owner='${userId}' || accountShares_via_account.recipient ?= '${userId}'`,
-				requestKey: null
-			});
-		for (const account of accounts) {
-			await this.balanceTypesContext.ensureLoaded(account.balanceType);
-		}
-		const latestBalances = await Promise.all(
-			accounts.map((account) => this.getLatestAccountBalance(account.id))
-		);
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-
-		// NOTE: A targeted membership mutation landed while this list was
-		// in flight, so the fetched snapshot is stale; leave membership and
-		// balances to the mutation but still mark the store loaded.
-		if (epoch === this.mutationEpoch) {
-			this.latestCashByAccount.clear();
-			for (const balance of latestBalances) {
-				if (balance) this.latestCashByAccount.set(balance.account, balance);
-			}
-			this.rawAccounts = accounts;
-		}
-		this.accountsLoaded = true;
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -314,6 +373,18 @@ class AccountsContext {
 	) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!e.action) return;
+		if (this.activeSnapshotToken !== null) {
+			if ('account' in e.record) {
+				this.snapshotBalanceOwners.add(e.record.account);
+				for (const [ownerAccountId, cash] of this.latestCashByAccount) {
+					if (cash.id === e.record.id) this.snapshotBalanceOwners.add(ownerAccountId);
+				}
+			} else {
+				this.accountSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
+				if (e.action === 'create') this.snapshotBalanceOwners.add(e.record.id);
+			}
+			return;
+		}
 		if ('account' in e.record) {
 			await this.onAccountBalanceEvent(e.action, e.record, userId);
 			return;
@@ -324,6 +395,15 @@ class AccountsContext {
 	private onAccountShareEvent(e: RecordSubscription<AccountSharesResponse>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
 		const isRelevantShare = e.record.grantedBy === userId || e.record.recipient === userId;
+		if (this.activeSnapshotToken !== null) {
+			if (e.action === 'delete') {
+				this.shareSnapshotMutations.push({ deleted: true, record: e.record });
+			} else if (isRelevantShare) {
+				this.shareSnapshotMutations.push({ deleted: false, record: e.record });
+			}
+			this.snapshotShareAccounts.add(e.record.account);
+			return;
+		}
 		if (e.action === 'create') {
 			if (isRelevantShare) this.shares = [...this.shares, e.record];
 		} else if (e.action === 'update') {
@@ -394,19 +474,12 @@ class AccountsContext {
 		}
 	}
 
-	// NOTE: Targeted membership changes bump mutationEpoch so an in-flight
-	// refreshAccounts that fetched its list before this mutation aborts its
-	// commit and can't overwrite newer state with a stale snapshot.
 	private upsertAccountRecord(account: AccountsResponse) {
-		const { list, inserted } = upsertById(this.rawAccounts, account);
-		this.rawAccounts = list;
-		if (inserted) this.mutationEpoch++;
+		this.rawAccounts = upsertById(this.rawAccounts, account).list;
 	}
 
 	private removeAccountRecord(accountId: string) {
-		const { list, removed } = removeById(this.rawAccounts, accountId);
-		this.rawAccounts = list;
-		if (removed) this.mutationEpoch++;
+		this.rawAccounts = removeById(this.rawAccounts, accountId).list;
 	}
 
 	async refreshAccount(accountId: string, userId: string) {

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -39,11 +39,17 @@ type AssetDisplayBalanceData = AssetBalanceData & {
 	missingCurrency: string | null;
 };
 
-const DEFAULT_BALANCE_DATA: AssetBalanceData = {
+// The sync-layer cache of each asset's latest balance. Unlike AssetBalanceData it carries no
+// gain/gainPercent - those belong to the display projection (computeBalanceData), not the raw cache.
+type LatestAssetBalance = {
+	marketValue: number;
+	bookValue: number;
+	balanceAsOf: string;
+};
+
+const DEFAULT_BALANCE_DATA: LatestAssetBalance = {
 	marketValue: 0,
 	bookValue: 0,
-	gain: 0,
-	gainPercent: 0,
 	balanceAsOf: ''
 };
 
@@ -74,7 +80,7 @@ class AssetsContext {
 	isLoading = $state(true);
 
 	private rawAssets: AssetsResponse[] = $state([]);
-	private latestBalanceByAsset = new SvelteMap<string, AssetBalanceData>();
+	private latestBalanceByAsset = new SvelteMap<string, LatestAssetBalance>();
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
@@ -213,14 +219,9 @@ class AssetsContext {
 			this.latestBalanceByAsset.clear();
 			for (const balance of balances) {
 				if (this.latestBalanceByAsset.has(balance.asset)) continue;
-				const bookValue = balance.bookValue ?? 0;
-				const marketValue = balance.marketValue ?? 0;
 				this.latestBalanceByAsset.set(balance.asset, {
-					marketValue,
-					bookValue,
-					gain: marketValue - bookValue,
-					gainPercent:
-						bookValue !== 0 ? ((marketValue - bookValue) / Math.abs(bookValue)) * 100 : 0,
+					marketValue: balance.marketValue ?? 0,
+					bookValue: balance.bookValue ?? 0,
 					balanceAsOf: balance.asOf
 				});
 			}
@@ -316,7 +317,7 @@ class AssetsContext {
 		};
 	}
 
-	private toAssetWithBalance(asset: AssetsResponse, rawBalanceData: AssetBalanceData) {
+	private toAssetWithBalance(asset: AssetsResponse, rawBalanceData: LatestAssetBalance) {
 		const incomingShare = this.getIncomingShare(asset.id);
 		const isOwner = asset.owner === this.currentUserId;
 		const perspective = isOwner

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -15,7 +15,13 @@ import {
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
 import { participantExcluded, projectAssetFinancials } from './sharing';
-import { isUnavailableRecordError, removeById, toPocketBaseDateString, upsertById } from './utils';
+import {
+	isUnavailableRecordError,
+	removeById,
+	toPocketBaseDateString,
+	upsertById,
+	type SnapshotMutation
+} from './utils';
 
 type AssetBalanceData = {
 	marketValue: number;
@@ -42,11 +48,6 @@ type AssetDisplayBalanceData = AssetBalanceData & {
 type LatestAssetBalance = AssetBalanceData & {
 	id: string;
 	created: string;
-};
-
-type SnapshotMutation<T> = {
-	deleted: boolean;
-	record: T;
 };
 
 const DEFAULT_BALANCE_DATA: AssetBalanceData = {
@@ -276,13 +277,18 @@ class AssetsContext {
 		this.snapshotBalanceOwners.clear();
 		this.snapshotShareAssets.clear();
 		let changed = false;
-		for (const assetId of shareAssets) {
-			if (await this.refreshAsset(assetId, userId)) changed = true;
-		}
-		for (const assetId of balanceOwners) {
-			if (shareAssets.includes(assetId)) continue;
-			await this.refetchAssetBalance(assetId, userId);
-			changed = true;
+		try {
+			for (const assetId of shareAssets) {
+				if (await this.refreshAsset(assetId, userId)) changed = true;
+			}
+			for (const assetId of balanceOwners) {
+				if (shareAssets.includes(assetId)) continue;
+				await this.refetchAssetBalance(assetId, userId);
+				changed = true;
+			}
+		} catch (error) {
+			if (userId !== this.currentUserId) return;
+			this._pb.handleConnectionError(error, 'assets', 'snapshot_settle');
 		}
 		if (changed && userId === this.currentUserId) this.lastBalanceEvent = Date.now();
 	}
@@ -383,9 +389,6 @@ class AssetsContext {
 		if (!e.action) return;
 		if (this.activeSnapshotToken !== null) {
 			this.snapshotBalanceOwners.add(e.record.asset);
-			for (const [ownerAssetId, current] of this.latestBalanceByAsset) {
-				if (current.id === e.record.id) this.snapshotBalanceOwners.add(ownerAssetId);
-			}
 			return;
 		}
 		const assetId = e.record.asset;

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -87,6 +87,9 @@ class AssetsContext {
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => {
+		if (this.currentUserId) void this.refreshForCurrentUser();
+	};
 
 	constructor(
 		pb: PocketBaseContext,
@@ -95,6 +98,7 @@ class AssetsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -556,6 +560,7 @@ class AssetsContext {
 	dispose() {
 		this.refreshSequence++;
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -44,6 +44,11 @@ type LatestAssetBalance = AssetBalanceData & {
 	created: string;
 };
 
+type SnapshotMutation<T> = {
+	deleted: boolean;
+	record: T;
+};
+
 const DEFAULT_BALANCE_DATA: AssetBalanceData = {
 	marketValue: 0,
 	bookValue: 0,
@@ -83,7 +88,11 @@ class AssetsContext {
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
 	private refreshSequence = 0;
-	private mutationEpoch = 0;
+	private activeSnapshotToken: number | null = null;
+	private assetSnapshotMutations: SnapshotMutation<AssetsResponse>[] = [];
+	private shareSnapshotMutations: SnapshotMutation<AssetSharesResponse>[] = [];
+	private snapshotBalanceOwners = new Set<string>();
+	private snapshotShareAssets = new Set<string>();
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
@@ -167,6 +176,11 @@ class AssetsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.activeSnapshotToken = null;
+			this.assetSnapshotMutations = [];
+			this.shareSnapshotMutations = [];
+			this.snapshotBalanceOwners.clear();
+			this.snapshotShareAssets.clear();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.refreshSequence++;
@@ -184,19 +198,93 @@ class AssetsContext {
 		});
 	}
 
+	// NOTE: Realtime events landing while these list fetches are in flight are buffered (records and
+	// shares) or noted by owner (balances). Buffered record/share mutations replay onto the fetched
+	// snapshot before it's committed, and touched owners are refetched afterwards, so an event is
+	// never clobbered by the older snapshot and the store never commits emptier than the database.
 	private async refreshForCurrentUser() {
 		const userId = this.currentUserId;
 		const token = ++this.refreshSequence;
+		this.activeSnapshotToken = token;
+		this.assetSnapshotMutations = [];
+		this.shareSnapshotMutations = [];
+		this.snapshotBalanceOwners.clear();
+		this.snapshotShareAssets.clear();
 		try {
-			await this.refreshShares(userId, token);
-			await this.refreshAssets(userId, token);
+			const [shares, list] = await Promise.all([
+				this._pb.authedClient.collection('assetShares').getFullList<AssetSharesResponse>({
+					sort: 'recipientEmail',
+					requestKey: null
+				}),
+				this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
+					requestKey: null
+				})
+			]);
+			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+			for (const asset of list) {
+				await this.balanceTypesContext.ensureLoaded(asset.balanceType);
+			}
+			for (const mutation of this.assetSnapshotMutations) {
+				if (!mutation.deleted)
+					await this.balanceTypesContext.ensureLoaded(mutation.record.balanceType);
+			}
+			const latestBalances = await Promise.all(
+				list.map((asset) => this.getLatestAssetBalance(asset.id))
+			);
+			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+
+			let reconciledShares = shares;
+			for (const mutation of this.shareSnapshotMutations) {
+				reconciledShares = mutation.deleted
+					? reconciledShares.filter((share) => share.id !== mutation.record.id)
+					: upsertById(reconciledShares, mutation.record).list;
+			}
+			this.shares = reconciledShares.toSorted((a, b) =>
+				a.recipientEmail.localeCompare(b.recipientEmail)
+			);
+
+			let reconciledAssets = list;
+			for (const mutation of this.assetSnapshotMutations) {
+				reconciledAssets = mutation.deleted
+					? reconciledAssets.filter((asset) => asset.id !== mutation.record.id)
+					: upsertById(reconciledAssets, mutation.record).list;
+			}
+			this.latestBalanceByAsset.clear();
+			list.forEach((asset, index) => {
+				const balance = latestBalances[index];
+				if (balance) this.latestBalanceByAsset.set(asset.id, balance);
+			});
+			this.rawAssets = reconciledAssets;
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
 			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 			this._pb.handleConnectionError(error, 'assets', 'init');
 		} finally {
+			if (this.activeSnapshotToken === token) {
+				this.activeSnapshotToken = null;
+				this.assetSnapshotMutations = [];
+				this.shareSnapshotMutations = [];
+			}
 			if (userId === this.currentUserId && token === this.refreshSequence) this.isLoading = false;
 		}
+
+		// Refetch owners touched by balance events and assets touched by share events so a delete or
+		// membership change that landed during the fetch resolves to the database's current state.
+		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+		const balanceOwners = [...this.snapshotBalanceOwners];
+		const shareAssets = [...this.snapshotShareAssets];
+		this.snapshotBalanceOwners.clear();
+		this.snapshotShareAssets.clear();
+		let changed = false;
+		for (const assetId of shareAssets) {
+			if (await this.refreshAsset(assetId, userId)) changed = true;
+		}
+		for (const assetId of balanceOwners) {
+			if (shareAssets.includes(assetId)) continue;
+			await this.refetchAssetBalance(assetId, userId);
+			changed = true;
+		}
+		if (changed && userId === this.currentUserId) this.lastBalanceEvent = Date.now();
 	}
 
 	private async refreshShares(userId = this.currentUserId, token = this.refreshSequence) {
@@ -207,33 +295,6 @@ class AssetsContext {
 		});
 		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
 		this.shares = shares;
-	}
-
-	private async refreshAssets(userId = this.currentUserId, token = this.refreshSequence) {
-		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const epoch = this.mutationEpoch;
-		const list = await this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
-			requestKey: null
-		});
-		for (const asset of list) {
-			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
-		}
-		const latestBalances = await Promise.all(
-			list.map((asset) => this.getLatestAssetBalance(asset.id))
-		);
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-
-		// NOTE: A targeted membership mutation landed while this list was in
-		// flight, so the fetched snapshot is stale; leave membership and
-		// balances to the mutation rather than overwriting with stale state.
-		if (epoch === this.mutationEpoch) {
-			this.latestBalanceByAsset.clear();
-			list.forEach((asset, index) => {
-				const balance = latestBalances[index];
-				if (balance) this.latestBalanceByAsset.set(asset.id, balance);
-			});
-			this.rawAssets = list;
-		}
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -290,6 +351,11 @@ class AssetsContext {
 
 	private async onAssetEvent(e: RecordSubscription<AssetsResponse>, userId: string) {
 		if (userId !== this.currentUserId) return;
+		if (this.activeSnapshotToken !== null) {
+			this.assetSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
+			if (e.action === 'create') this.snapshotBalanceOwners.add(e.record.id);
+			return;
+		}
 
 		if (e.action === 'create') {
 			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
@@ -315,6 +381,13 @@ class AssetsContext {
 	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>, userId: string) {
 		if (userId !== this.currentUserId) return;
 		if (!e.action) return;
+		if (this.activeSnapshotToken !== null) {
+			this.snapshotBalanceOwners.add(e.record.asset);
+			for (const [ownerAssetId, current] of this.latestBalanceByAsset) {
+				if (current.id === e.record.id) this.snapshotBalanceOwners.add(ownerAssetId);
+			}
+			return;
+		}
 		const assetId = e.record.asset;
 		let displayedAssetId: string | null = null;
 		for (const [key, currentBalance] of this.latestBalanceByAsset) {
@@ -362,6 +435,11 @@ class AssetsContext {
 
 	private onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>, userId: string) {
 		if (userId !== this.currentUserId) return;
+		if (this.activeSnapshotToken !== null) {
+			this.shareSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
+			this.snapshotShareAssets.add(e.record.asset);
+			return;
+		}
 
 		if (e.action === 'create') {
 			this.shares = [...this.shares, e.record];
@@ -473,19 +551,12 @@ class AssetsContext {
 		}
 	}
 
-	// NOTE: Targeted membership changes bump mutationEpoch so an in-flight
-	// refreshAssets that fetched its list before this mutation aborts its
-	// commit and can't overwrite newer state with a stale snapshot.
 	private upsertAssetRecord(asset: AssetsResponse) {
-		const { list, inserted } = upsertById(this.rawAssets, asset);
-		this.rawAssets = list;
-		if (inserted) this.mutationEpoch++;
+		this.rawAssets = upsertById(this.rawAssets, asset).list;
 	}
 
 	private removeAssetRecord(assetId: string) {
-		const { list, removed } = removeById(this.rawAssets, assetId);
-		this.rawAssets = list;
-		if (removed) this.mutationEpoch++;
+		this.rawAssets = removeById(this.rawAssets, assetId).list;
 	}
 
 	private async refreshAsset(assetId: string, userId: string) {

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -1,4 +1,3 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
@@ -14,14 +13,9 @@ import {
 	type AssetsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 import { participantExcluded, projectAssetFinancials } from './sharing';
-import {
-	isUnavailableRecordError,
-	removeById,
-	toPocketBaseDateString,
-	upsertById,
-	type SnapshotMutation
-} from './utils';
+import { toPocketBaseDateString } from './utils';
 
 type AssetBalanceData = {
 	marketValue: number;
@@ -45,11 +39,6 @@ type AssetDisplayBalanceData = AssetBalanceData & {
 	missingCurrency: string | null;
 };
 
-type LatestAssetBalance = AssetBalanceData & {
-	id: string;
-	created: string;
-};
-
 const DEFAULT_BALANCE_DATA: AssetBalanceData = {
 	marketValue: 0,
 	bookValue: 0,
@@ -57,6 +46,8 @@ const DEFAULT_BALANCE_DATA: AssetBalanceData = {
 	gainPercent: 0,
 	balanceAsOf: ''
 };
+
+const DEBOUNCE_MS = 200;
 
 export type AssetWithBalance = AssetsResponse &
 	AssetDisplayBalanceData & {
@@ -79,27 +70,21 @@ class AssetsContext {
 		)
 	);
 	shares: AssetSharesResponse[] = $state([]);
-	lastBalanceEvent: number = $state(0);
-	isLoading: boolean = $state(true);
+	lastBalanceEvent = $state(0);
+	isLoading = $state(true);
 
 	private rawAssets: AssetsResponse[] = $state([]);
-	private latestBalanceByAsset = new SvelteMap<string, LatestAssetBalance>();
+	private latestBalanceByAsset = new SvelteMap<string, AssetBalanceData>();
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private balanceTypesContext: ReturnType<typeof setBalanceTypesContext>;
-	private refreshSequence = 0;
-	private activeSnapshotToken: number | null = null;
-	private assetSnapshotMutations: SnapshotMutation<AssetsResponse>[] = [];
-	private shareSnapshotMutations: SnapshotMutation<AssetSharesResponse>[] = [];
-	private snapshotBalanceOwners = new Set<string>();
-	private snapshotShareAssets = new Set<string>();
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
-	private _reconnectCallback = () => {
-		if (this.currentUserId) void this.refreshForCurrentUser();
-	};
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(
 		pb: PocketBaseContext,
@@ -147,33 +132,22 @@ class AssetsContext {
 		recipientEmail: string,
 		perspective: AssetSharesPerspectiveOptions
 	) {
-		const userId = this.currentUserId;
 		await this._pb.postJson('/api/shares/assets', {
 			assetId,
 			recipientEmail,
 			perspective
 		});
-		await this.refreshShares(userId);
-		if (await this.refreshAsset(assetId, userId)) this.lastBalanceEvent = Date.now();
+		await this.refreshForCurrentUser();
 	}
 
 	async updateShareIncludeInNetWorth(shareId: string, includeInNetWorth: boolean) {
-		const userId = this.currentUserId;
-		const share = await this._pb.authedClient
-			.collection('assetShares')
-			.update<AssetSharesResponse>(shareId, { includeInNetWorth });
-		await this.refreshShares(userId);
-		if (await this.refreshAsset(share.asset, userId)) this.lastBalanceEvent = Date.now();
+		await this._pb.authedClient.collection('assetShares').update(shareId, { includeInNetWorth });
+		await this.refreshForCurrentUser();
 	}
 
 	async revokeShare(shareId: string) {
-		const userId = this.currentUserId;
-		const assetId = this.shares.find((share) => share.id === shareId)?.asset;
 		await this._pb.authedClient.collection('assetShares').delete(shareId);
-		await this.refreshShares(userId);
-		if (assetId && (await this.refreshAsset(assetId, userId))) {
-			this.lastBalanceEvent = Date.now();
-		}
+		await this.refreshForCurrentUser();
 	}
 
 	private init() {
@@ -181,14 +155,10 @@ class AssetsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.activeSnapshotToken = null;
-			this.assetSnapshotMutations = [];
-			this.shareSnapshotMutations = [];
-			this.snapshotBalanceOwners.clear();
-			this.snapshotShareAssets.clear();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this.refreshSequence++;
 				this.rawAssets = [];
 				this.latestBalanceByAsset.clear();
 				this.shares = [];
@@ -203,108 +173,65 @@ class AssetsContext {
 		});
 	}
 
-	// NOTE: Realtime events landing while these list fetches are in flight are buffered (records and
-	// shares) or noted by owner (balances). Buffered record/share mutations replay onto the fetched
-	// snapshot before it's committed, and touched owners are refetched afterwards, so an event is
-	// never clobbered by the older snapshot and the store never commits emptier than the database.
-	private async refreshForCurrentUser() {
+	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
+	// state, they only schedule a full refetch. Deletes, share membership changes, and cross-asset
+	// balance reassignments all resolve for free because the fresh snapshot reflects the database as-is.
+	private invalidate() {
+		this.debouncer.schedule(() => void this.refreshForCurrentUser());
+	}
+
+	async refreshForCurrentUser() {
 		const userId = this.currentUserId;
-		const token = ++this.refreshSequence;
-		this.activeSnapshotToken = token;
-		this.assetSnapshotMutations = [];
-		this.shareSnapshotMutations = [];
-		this.snapshotBalanceOwners.clear();
-		this.snapshotShareAssets.clear();
+		const token = this.sequence.next();
 		try {
-			const [shares, list] = await Promise.all([
+			const [shares, assets, balances] = await Promise.all([
 				this._pb.authedClient.collection('assetShares').getFullList<AssetSharesResponse>({
+					filter: `grantedBy='${userId}' || recipient='${userId}'`,
 					sort: 'recipientEmail',
 					requestKey: null
 				}),
 				this._pb.authedClient.collection('assets').getFullList<AssetsResponse>({
+					filter: `owner='${userId}' || assetShares_via_asset.recipient ?= '${userId}'`,
+					requestKey: null
+				}),
+				// One query for every asset's latest balance instead of N point-queries: the
+				// 'asset,-asOf,-created,-id' sort groups by asset and orders each group newest-first,
+				// so the first row seen per asset wins - the same tiebreakers getList(1,1) used.
+				this._pb.authedClient.collection('assetBalances').getFullList<AssetBalancesResponse>({
+					sort: 'asset,-asOf,-created,-id',
+					fields: 'asset,bookValue,marketValue,asOf',
 					requestKey: null
 				})
 			]);
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-			for (const asset of list) {
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			for (const asset of assets) {
 				await this.balanceTypesContext.ensureLoaded(asset.balanceType);
 			}
-			for (const mutation of this.assetSnapshotMutations) {
-				if (!mutation.deleted)
-					await this.balanceTypesContext.ensureLoaded(mutation.record.balanceType);
-			}
-			const latestBalances = await Promise.all(
-				list.map((asset) => this.getLatestAssetBalance(asset.id))
-			);
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
 
-			let reconciledShares = shares;
-			for (const mutation of this.shareSnapshotMutations) {
-				reconciledShares = mutation.deleted
-					? reconciledShares.filter((share) => share.id !== mutation.record.id)
-					: upsertById(reconciledShares, mutation.record).list;
-			}
-			this.shares = reconciledShares.toSorted((a, b) =>
-				a.recipientEmail.localeCompare(b.recipientEmail)
-			);
-
-			let reconciledAssets = list;
-			for (const mutation of this.assetSnapshotMutations) {
-				reconciledAssets = mutation.deleted
-					? reconciledAssets.filter((asset) => asset.id !== mutation.record.id)
-					: upsertById(reconciledAssets, mutation.record).list;
-			}
+			this.shares = shares.toSorted((a, b) => a.recipientEmail.localeCompare(b.recipientEmail));
 			this.latestBalanceByAsset.clear();
-			list.forEach((asset, index) => {
-				const balance = latestBalances[index];
-				if (balance) this.latestBalanceByAsset.set(asset.id, balance);
-			});
-			this.rawAssets = reconciledAssets;
+			for (const balance of balances) {
+				if (this.latestBalanceByAsset.has(balance.asset)) continue;
+				const bookValue = balance.bookValue ?? 0;
+				const marketValue = balance.marketValue ?? 0;
+				this.latestBalanceByAsset.set(balance.asset, {
+					marketValue,
+					bookValue,
+					gain: marketValue - bookValue,
+					gainPercent:
+						bookValue !== 0 ? ((marketValue - bookValue) / Math.abs(bookValue)) * 100 : 0,
+					balanceAsOf: balance.asOf
+				});
+			}
+			this.rawAssets = assets;
 			this.lastBalanceEvent = Date.now();
 		} catch (error) {
-			if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-			this._pb.handleConnectionError(error, 'assets', 'init');
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			this._pb.handleConnectionError(error, 'assets', 'refresh');
 		} finally {
-			if (this.activeSnapshotToken === token) {
-				this.activeSnapshotToken = null;
-				this.assetSnapshotMutations = [];
-				this.shareSnapshotMutations = [];
-			}
-			if (userId === this.currentUserId && token === this.refreshSequence) this.isLoading = false;
+			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
 		}
-
-		// Refetch owners touched by balance events and assets touched by share events so a delete or
-		// membership change that landed during the fetch resolves to the database's current state.
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const balanceOwners = [...this.snapshotBalanceOwners];
-		const shareAssets = [...this.snapshotShareAssets];
-		this.snapshotBalanceOwners.clear();
-		this.snapshotShareAssets.clear();
-		let changed = false;
-		try {
-			for (const assetId of shareAssets) {
-				if (await this.refreshAsset(assetId, userId)) changed = true;
-			}
-			for (const assetId of balanceOwners) {
-				if (shareAssets.includes(assetId)) continue;
-				await this.refetchAssetBalance(assetId, userId);
-				changed = true;
-			}
-		} catch (error) {
-			if (userId !== this.currentUserId) return;
-			this._pb.handleConnectionError(error, 'assets', 'snapshot_settle');
-		}
-		if (changed && userId === this.currentUserId) this.lastBalanceEvent = Date.now();
-	}
-
-	private async refreshShares(userId = this.currentUserId, token = this.refreshSequence) {
-		if (!userId || userId !== this.currentUserId || token !== this.refreshSequence) return;
-		const shares = await this._pb.authedClient.collection('assetShares').getFullList({
-			sort: 'recipientEmail',
-			requestKey: null
-		});
-		if (userId !== this.currentUserId || token !== this.refreshSequence) return;
-		this.shares = shares;
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -312,15 +239,7 @@ class AssetsContext {
 
 		this._pb.authedClient
 			.collection('assets')
-			.subscribe<AssetsResponse>('*', (event) => {
-				void this.onAssetEvent(event, userId).catch((error) => {
-					if (userId === this.currentUserId) {
-						this._pb.handleConnectionError(error, 'assets', 'asset_event');
-					} else {
-						logError('assetsStore', 'stale_event', error);
-					}
-				});
-			})
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_assets');
@@ -330,7 +249,7 @@ class AssetsContext {
 			});
 		this._pb.authedClient
 			.collection('assetBalances')
-			.subscribe<AssetBalancesResponse>('*', (event) => this.onAssetBalanceEvent(event, userId))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_balances');
@@ -340,7 +259,7 @@ class AssetsContext {
 			});
 		this._pb.authedClient
 			.collection('assetShares')
-			.subscribe<AssetSharesResponse>('*', (event) => this.onAssetShareEvent(event, userId))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'assets', 'subscribe_shares');
@@ -351,123 +270,17 @@ class AssetsContext {
 		this._isSubscribed = true;
 	}
 
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
+
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('assets').unsubscribe('*');
 		this._pb.authedClient.collection('assetBalances').unsubscribe('*');
 		this._pb.authedClient.collection('assetShares').unsubscribe('*');
-	}
-
-	private async onAssetEvent(e: RecordSubscription<AssetsResponse>, userId: string) {
-		if (userId !== this.currentUserId) return;
-		if (this.activeSnapshotToken !== null) {
-			this.assetSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
-			if (e.action === 'create') this.snapshotBalanceOwners.add(e.record.id);
-			return;
-		}
-
-		if (e.action === 'create') {
-			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
-			const balanceData = await this.getLatestAssetBalance(e.record.id);
-			if (userId !== this.currentUserId) return;
-			this.upsertAssetRecord(e.record);
-			if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
-		} else if (e.action === 'update') {
-			await this.balanceTypesContext.ensureLoaded(e.record.balanceType);
-			if (userId !== this.currentUserId) return;
-			this.upsertAssetRecord(e.record);
-			if (!this.latestBalanceByAsset.has(e.record.id)) {
-				const balanceData = await this.getLatestAssetBalance(e.record.id);
-				if (userId !== this.currentUserId) return;
-				if (balanceData) this.latestBalanceByAsset.set(e.record.id, balanceData);
-			}
-		} else if (e.action === 'delete') {
-			this.removeAssetRecord(e.record.id);
-			this.latestBalanceByAsset.delete(e.record.id);
-		}
-	}
-
-	private onAssetBalanceEvent(e: RecordSubscription<AssetBalancesResponse>, userId: string) {
-		if (userId !== this.currentUserId) return;
-		if (!e.action) return;
-		if (this.activeSnapshotToken !== null) {
-			this.snapshotBalanceOwners.add(e.record.asset);
-			return;
-		}
-		const assetId = e.record.asset;
-		let displayedAssetId: string | null = null;
-		for (const [key, currentBalance] of this.latestBalanceByAsset) {
-			if (currentBalance.id === e.record.id) {
-				displayedAssetId = key;
-				break;
-			}
-		}
-		if (displayedAssetId && displayedAssetId !== assetId) {
-			void this.refetchAssetBalance(displayedAssetId, userId);
-		}
-
-		if (e.action === 'create' || e.action === 'update') {
-			const asset = this.rawAssets.find((x) => x.id === assetId);
-			if (!asset) {
-				void this.refreshAsset(assetId, userId)
-					.then((refreshed) => {
-						if (userId !== this.currentUserId) return;
-						if (refreshed) this.lastBalanceEvent = Date.now();
-					})
-					.catch((error) => {
-						if (userId === this.currentUserId) {
-							this._pb.handleConnectionError(error, 'assets', 'balance');
-						} else {
-							logError('assetsStore', 'stale_event', error);
-						}
-					});
-				return;
-			}
-
-			const current = this.latestBalanceByAsset.get(assetId);
-			if (current?.id === e.record.id) {
-				void this.refetchAssetBalance(assetId, userId);
-				return;
-			}
-
-			if (!current || this.isAtLeastAsRecent(e.record, current)) {
-				this.latestBalanceByAsset.set(assetId, this.toLatestAssetBalance(e.record));
-				this.lastBalanceEvent = Date.now();
-			}
-		} else if (e.action === 'delete' && displayedAssetId === assetId) {
-			void this.refetchAssetBalance(assetId, userId);
-		}
-	}
-
-	private onAssetShareEvent(e: RecordSubscription<AssetSharesResponse>, userId: string) {
-		if (userId !== this.currentUserId) return;
-		if (this.activeSnapshotToken !== null) {
-			this.shareSnapshotMutations.push({ deleted: e.action === 'delete', record: e.record });
-			this.snapshotShareAssets.add(e.record.asset);
-			return;
-		}
-
-		if (e.action === 'create') {
-			this.shares = [...this.shares, e.record];
-		} else if (e.action === 'update') {
-			this.shares = this.shares.map((share) => (share.id === e.record.id ? e.record : share));
-		} else if (e.action === 'delete') {
-			this.shares = this.shares.filter((share) => share.id !== e.record.id);
-		}
-
-		void this.refreshAsset(e.record.asset, userId)
-			.then((refreshed) => {
-				if (userId !== this.currentUserId) return;
-				if (refreshed) this.lastBalanceEvent = Date.now();
-			})
-			.catch((error) => {
-				if (userId === this.currentUserId) {
-					this._pb.handleConnectionError(error, 'assets', 'share');
-				} else {
-					logError('assetsStore', 'stale_event', error);
-				}
-			});
 	}
 
 	private computeBalanceData(
@@ -540,102 +353,12 @@ class AssetsContext {
 		};
 	}
 
-	private async refetchAssetBalance(assetId: string, userId: string) {
-		if (userId !== this.currentUserId) return;
-
-		try {
-			const balanceData = await this.getLatestAssetBalance(assetId);
-			if (userId !== this.currentUserId) return;
-			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
-			else this.latestBalanceByAsset.delete(assetId);
-			this.lastBalanceEvent = Date.now();
-		} catch (error) {
-			if (userId === this.currentUserId) {
-				logError('assets', 'refetch_balance', error);
-			} else {
-				logError('assetsStore', 'stale_event', error);
-			}
-		}
-	}
-
-	private upsertAssetRecord(asset: AssetsResponse) {
-		this.rawAssets = upsertById(this.rawAssets, asset).list;
-	}
-
-	private removeAssetRecord(assetId: string) {
-		this.rawAssets = removeById(this.rawAssets, assetId).list;
-	}
-
-	private async refreshAsset(assetId: string, userId: string) {
-		if (userId !== this.currentUserId) return false;
-
-		try {
-			const asset = await this._pb.authedClient
-				.collection('assets')
-				.getOne<AssetsResponse>(assetId, { requestKey: null });
-			if (userId !== this.currentUserId) return false;
-			await this.balanceTypesContext.ensureLoaded(asset.balanceType);
-			if (userId !== this.currentUserId) return false;
-			const balanceData = await this.getLatestAssetBalance(assetId);
-			if (userId !== this.currentUserId) return false;
-			this.upsertAssetRecord(asset);
-			if (balanceData) this.latestBalanceByAsset.set(assetId, balanceData);
-			else this.latestBalanceByAsset.delete(assetId);
-			return true;
-		} catch (error) {
-			if (userId !== this.currentUserId) return false;
-			if (isUnavailableRecordError(error)) {
-				this.removeAssetRecord(assetId);
-				this.latestBalanceByAsset.delete(assetId);
-				return true;
-			}
-			throw error;
-		}
-	}
-
-	private async getLatestAssetBalance(assetId: string) {
-		const res = await this._pb.authedClient
-			.collection('assetBalances')
-			.getList<AssetBalancesResponse>(1, 1, {
-				filter: `asset='${assetId}'`,
-				sort: '-asOf,-created,-id',
-				requestKey: null
-			});
-		const balance = res.items[0];
-		return balance ? this.toLatestAssetBalance(balance) : null;
-	}
-
-	private toLatestAssetBalance(balance: AssetBalancesResponse) {
-		return {
-			id: balance.id,
-			marketValue: balance.marketValue ?? 0,
-			bookValue: balance.bookValue ?? 0,
-			gain: (balance.marketValue ?? 0) - (balance.bookValue ?? 0),
-			gainPercent:
-				(balance.bookValue ?? 0) !== 0
-					? (((balance.marketValue ?? 0) - (balance.bookValue ?? 0)) /
-							Math.abs(balance.bookValue ?? 0)) *
-						100
-					: 0,
-			balanceAsOf: balance.asOf,
-			created: balance.created
-		};
-	}
-
-	private isAtLeastAsRecent(
-		balance: Pick<AssetBalancesResponse, 'asOf' | 'created' | 'id'>,
-		current: Pick<LatestAssetBalance, 'balanceAsOf' | 'created' | 'id'>
-	) {
-		if (balance.asOf !== current.balanceAsOf) return balance.asOf > current.balanceAsOf;
-		if (balance.created !== current.created) return balance.created > current.created;
-		return balance.id >= current.id;
-	}
-
 	dispose() {
-		this.refreshSequence++;
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
 		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/balance-types.svelte.ts
+++ b/src/lib/balance-types.svelte.ts
@@ -1,54 +1,74 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
 import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { BalanceTypesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
+
+const DEBOUNCE_MS = 200;
 
 class BalanceTypesContext {
 	byId: Record<string, BalanceTypesResponse> = $state({});
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this.init();
+	}
+
+	private get currentUserId() {
+		return this._auth.currentUserId;
 	}
 
 	private init() {
 		$effect(() => {
-			const userId = this._auth.currentUserId;
+			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.byId = {};
 				return;
 			}
 			this.realtimeSubscribe(userId);
-			void this.refreshForCurrentUser(userId);
+			void this.refreshForCurrentUser();
 		});
 	}
 
-	private async refreshForCurrentUser(userId: string) {
+	// Realtime events and reconnects are pure invalidation signals: they schedule a debounced full
+	// refetch of the dictionary rather than patching a single record from the event payload.
+	private invalidate() {
+		this.debouncer.schedule(() => void this.refreshForCurrentUser());
+	}
+
+	private async refreshForCurrentUser() {
+		const userId = this.currentUserId;
+		const token = this.sequence.next();
 		try {
 			const list = await this._pb.authedClient
 				.collection('balanceTypes')
-				.getFullList<BalanceTypesResponse>();
-			if (userId !== this._activeUserId) return;
+				.getFullList<BalanceTypesResponse>({ requestKey: null });
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
 			const map: Record<string, BalanceTypesResponse> = {};
 			for (const bt of list) map[bt.id] = bt;
 			this.byId = map;
 		} catch (error) {
-			if (userId !== this._activeUserId) return;
-			this._pb.handleConnectionError(error, 'balance_types', 'init');
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			this._pb.handleConnectionError(error, 'balance_types', 'refresh');
 		}
 	}
 
@@ -57,7 +77,7 @@ class BalanceTypesContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('balanceTypes')
-			.subscribe('*', this.onEvent.bind(this))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'balance_types', 'subscribe');
@@ -67,20 +87,15 @@ class BalanceTypesContext {
 			});
 	}
 
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
+
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('balanceTypes').unsubscribe('*');
-	}
-
-	private onEvent(e: RecordSubscription<BalanceTypesResponse>) {
-		if (e.action === 'create' || e.action === 'update') {
-			this.byId = { ...this.byId, [e.record.id]: e.record };
-		} else if (e.action === 'delete') {
-			const next = { ...this.byId };
-			delete next[e.record.id];
-			this.byId = next;
-		}
 	}
 
 	getName(id: string | undefined | null) {
@@ -116,8 +131,11 @@ class BalanceTypesContext {
 	}
 
 	dispose() {
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/cashflow.svelte.ts
+++ b/src/lib/cashflow.svelte.ts
@@ -1,4 +1,3 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
@@ -15,6 +14,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import { AccountSharesPerspectiveOptions, type TransactionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 
 const DEBOUNCE_MS = 200;
 
@@ -51,23 +51,25 @@ class CashflowContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private _accountsContext: ReturnType<typeof getAccountsContext>;
-	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _unsubscribe: (() => void) | null = null;
 	private _disposed = false;
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _recomputeSequence = 0;
+	private sequence = new RequestSequence();
 	private _recomputeAllInFlight = 0;
 	private _transactionsById = new SvelteMap<string, TransactionsResponse>();
 	private _activeWindow: CashflowWindow | null = null;
 	private _hasTransactionSnapshot = false;
 	private _watchedAccountsKey: string | null = null;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this._accountsContext = getAccountsContext();
 		this.init();
@@ -78,13 +80,10 @@ class CashflowContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this._recomputeSequence++;
-				if (this._debounceTimer) {
-					clearTimeout(this._debounceTimer);
-					this._debounceTimer = null;
-				}
 				this._transactionsById = new SvelteMap();
 				this._activeWindow = null;
 				this._hasTransactionSnapshot = false;
@@ -174,7 +173,7 @@ class CashflowContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('transactions')
-			.subscribe('*', this.onTransactionEvent.bind(this))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.then((unsubscribe) => {
 				if (this._disposed || userId !== this._activeUserId) {
 					unsubscribe();
@@ -200,72 +199,26 @@ class CashflowContext {
 		this._unsubscribe = null;
 	}
 
-	private onTransactionEvent(e: RecordSubscription<TransactionsResponse>) {
-		if (!e.action) return;
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
 
-		const cashflowWindow = this.getCashflowWindow();
-		const activeWindow = this._activeWindow;
-		let shouldRecomputeAll = false;
-		let shouldRecomputeFromMap = false;
-
-		if (
-			!this._hasTransactionSnapshot ||
-			!activeWindow ||
-			activeWindow.earliestKey !== cashflowWindow.earliestKey ||
-			activeWindow.startNextMonthKey !== cashflowWindow.startNextMonthKey
-		) {
-			shouldRecomputeAll = true;
-		} else {
-			if (e.action === 'delete') {
-				if (this._transactionsById.delete(e.record.id)) {
-					shouldRecomputeFromMap = true;
-				} else {
-					const membership = this.transactionWindowMembership(e.record, activeWindow);
-					shouldRecomputeAll = membership !== false;
-				}
-			} else if (e.action === 'create' || e.action === 'update') {
-				const membership = this.transactionWindowMembership(e.record, activeWindow);
-
-				if (membership === null) {
-					shouldRecomputeAll = true;
-				} else if (membership) {
-					if (!this._accountsContext.accounts.some((account) => account.id === e.record.account)) {
-						shouldRecomputeAll = true;
-					} else {
-						this._transactionsById.set(e.record.id, e.record);
-						shouldRecomputeFromMap = true;
-					}
-				} else if (this._transactionsById.delete(e.record.id)) {
-					shouldRecomputeFromMap = true;
-				}
-			} else {
-				shouldRecomputeAll = true;
-			}
-
-			if (shouldRecomputeFromMap) {
-				shouldRecomputeAll = this._recomputeAllInFlight > 0;
-				this._recomputeSequence++;
-				this.recomputeFromTransactionMap(this._accountsContext.accounts, activeWindow);
-				if (!shouldRecomputeAll) return;
-			}
-		}
-
-		if (!shouldRecomputeAll) return;
-
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-		}
-
-		this._debounceTimer = setTimeout(() => {
-			this._debounceTimer = null;
-			void this.recomputeAll(this._accountsContext.accounts).catch((error) => {
-				logError('cashflow', 'recompute_on_event', error);
-			});
-		}, DEBOUNCE_MS);
+	// A transaction event (or a reconnect) is a pure invalidation signal: instead of patching the
+	// in-memory transaction map from the event payload, it schedules a debounced full refetch of the
+	// windowed transactions via recomputeAll. Projection (recomputeFromTransactionMap driven by the
+	// accounts effect) stays incremental and network-free; only this sync path was ever a refetch.
+	private invalidate() {
+		this.debouncer.schedule(
+			() =>
+				void this.recomputeAll(this._accountsContext.accounts).catch((error) =>
+					this._pb.handleConnectionError(error, 'cashflow', 'refresh')
+				)
+		);
 	}
 
 	private async recomputeAll(accounts: AccountWithBalance[]) {
-		const recomputeSequence = ++this._recomputeSequence;
+		const token = this.sequence.next();
 		const cashflowWindow = this.getCashflowWindow();
 
 		this._recomputeAllInFlight++;
@@ -278,7 +231,7 @@ class CashflowContext {
 					requestKey: null
 				});
 
-			if (recomputeSequence !== this._recomputeSequence) return;
+			if (!this.sequence.isCurrent(token)) return;
 
 			this._transactionsById = new SvelteMap(
 				txns.map((transaction) => [transaction.id, transaction])
@@ -289,28 +242,12 @@ class CashflowContext {
 			this.recomputeFromTransactionMap(accounts, cashflowWindow);
 		} finally {
 			this._recomputeAllInFlight--;
-			if (!this._disposed && recomputeSequence === this._recomputeSequence) this.isLoading = false;
+			if (!this._disposed && this.sequence.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
 	private getCashflowWindow() {
 		return computeCashflowWindow();
-	}
-
-	private transactionWindowMembership(
-		transaction: TransactionsResponse,
-		cashflowWindow: CashflowWindow
-	) {
-		if (!transaction.date || !('excluded' in transaction)) return null;
-
-		const date = new Date(transaction.date);
-		if (Number.isNaN(date.valueOf())) return null;
-
-		return (
-			date >= cashflowWindow.earliest &&
-			date < cashflowWindow.startNextMonth &&
-			!transaction.excluded
-		);
 	}
 
 	private recomputeFromTransactionMap(
@@ -344,12 +281,10 @@ class CashflowContext {
 
 	dispose() {
 		this._disposed = true;
-		this._recomputeSequence++;
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-			this._debounceTimer = null;
-		}
+		this.sequence.bump();
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/currencies.svelte.ts
+++ b/src/lib/currencies.svelte.ts
@@ -5,6 +5,7 @@ import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { CurrenciesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 
 const DEBOUNCE_MS = 200;
 
@@ -34,17 +35,19 @@ class CurrenciesContext {
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _refreshSequence = 0;
-	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _disposed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this.init();
 	}
 
@@ -53,13 +56,10 @@ class CurrenciesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			if (this._debounceTimer) {
-				clearTimeout(this._debounceTimer);
-				this._debounceTimer = null;
-			}
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this._refreshSequence++;
 				this._records = [];
 				this._isLoaded = false;
 				return;
@@ -72,7 +72,7 @@ class CurrenciesContext {
 
 	private async refresh(userId: string) {
 		if (!userId) return;
-		const sequence = ++this._refreshSequence;
+		const token = this.sequence.next();
 		try {
 			const list = await this._pb.authedClient
 				.collection('currencies')
@@ -80,14 +80,14 @@ class CurrenciesContext {
 					sort: 'code',
 					requestKey: null
 				});
-			if (this._disposed || userId !== this._activeUserId || sequence !== this._refreshSequence)
+			if (this._disposed || userId !== this._activeUserId || !this.sequence.isCurrent(token))
 				return;
 
 			this._records = list;
 			this._isLoaded = true;
 		} catch (error) {
 			if (userId !== this._activeUserId) return;
-			this._pb.handleConnectionError(error, 'currencies', 'init');
+			this._pb.handleConnectionError(error, 'currencies', 'refresh');
 		}
 	}
 
@@ -96,7 +96,7 @@ class CurrenciesContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('currencies')
-			.subscribe('*', this.onEvent.bind(this))
+			.subscribe('*', () => this.invalidate())
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'currencies', 'subscribe');
@@ -112,12 +112,11 @@ class CurrenciesContext {
 		this._pb.authedClient.collection('currencies').unsubscribe('*');
 	}
 
-	private onEvent() {
-		if (this._debounceTimer) clearTimeout(this._debounceTimer);
-		this._debounceTimer = setTimeout(() => {
-			this._debounceTimer = null;
-			void this.refresh(this._activeUserId);
-		}, DEBOUNCE_MS);
+	// Realtime events and reconnects are pure invalidation signals: both schedule a debounced full
+	// refetch, so a reconnect converges on any events missed while the socket was disconnected.
+	private invalidate() {
+		if (!this._activeUserId) return;
+		this.debouncer.schedule(() => void this.refresh(this._activeUserId));
 	}
 
 	get currencies() {
@@ -146,12 +145,11 @@ class CurrenciesContext {
 
 	dispose() {
 		this._disposed = true;
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-			this._debounceTimer = null;
-		}
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/exchange-rates.svelte.ts
+++ b/src/lib/exchange-rates.svelte.ts
@@ -7,6 +7,7 @@ import { interfacePreferences } from './interface-preferences.svelte';
 import { logError } from './logger';
 import type { ExchangeRatesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
 
 const DEBOUNCE_MS = 200;
 
@@ -57,18 +58,20 @@ class ExchangeRatesContext {
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _currencies: ReturnType<typeof setCurrenciesContext>;
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
-	private _refreshSequence = 0;
-	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _disposed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext, currencies: ReturnType<typeof setCurrenciesContext>) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._currencies = currencies;
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this.init();
 	}
 
@@ -77,13 +80,10 @@ class ExchangeRatesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			if (this._debounceTimer) {
-				clearTimeout(this._debounceTimer);
-				this._debounceTimer = null;
-			}
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this._refreshSequence++;
 				this._records = [];
 				this._isLoaded = false;
 				return;
@@ -96,19 +96,19 @@ class ExchangeRatesContext {
 
 	private async refresh(userId: string) {
 		if (!userId) return;
-		const sequence = ++this._refreshSequence;
+		const token = this.sequence.next();
 		try {
 			const list = await this._pb.authedClient
 				.collection('exchangeRates')
 				.getFullList<ExchangeRatesResponse>({ requestKey: null });
-			if (this._disposed || userId !== this._activeUserId || sequence !== this._refreshSequence)
+			if (this._disposed || userId !== this._activeUserId || !this.sequence.isCurrent(token))
 				return;
 
 			this._records = list;
 			this._isLoaded = true;
 		} catch (error) {
 			if (userId !== this._activeUserId) return;
-			this._pb.handleConnectionError(error, 'exchange_rates', 'init');
+			this._pb.handleConnectionError(error, 'exchange_rates', 'refresh');
 		}
 	}
 
@@ -117,7 +117,7 @@ class ExchangeRatesContext {
 		this._isSubscribed = true;
 		this._pb.authedClient
 			.collection('exchangeRates')
-			.subscribe('*', this.onEvent.bind(this))
+			.subscribe('*', () => this.invalidate())
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'exchange_rates', 'subscribe');
@@ -134,13 +134,11 @@ class ExchangeRatesContext {
 	}
 
 	// NOTE: the ensure-rates worker writes many rows per entity, so coalesce the burst into a
-	// single refetch rather than maintaining the sorted index incrementally on each event.
-	private onEvent() {
-		if (this._debounceTimer) clearTimeout(this._debounceTimer);
-		this._debounceTimer = setTimeout(() => {
-			this._debounceTimer = null;
-			void this.refresh(this._activeUserId);
-		}, DEBOUNCE_MS);
+	// single refetch rather than maintaining the sorted index incrementally on each event. Reconnects
+	// route here too, converging on any events missed while the socket was disconnected.
+	private invalidate() {
+		if (!this._activeUserId) return;
+		this.debouncer.schedule(() => void this.refresh(this._activeUserId));
 	}
 
 	get records() {
@@ -206,12 +204,11 @@ class ExchangeRatesContext {
 
 	dispose() {
 		this._disposed = true;
-		if (this._debounceTimer) {
-			clearTimeout(this._debounceTimer);
-			this._debounceTimer = null;
-		}
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/import-sessions.svelte.ts
+++ b/src/lib/import-sessions.svelte.ts
@@ -1,10 +1,12 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 
 import { getAuthContext } from './auth.svelte';
 import { logError } from './logger';
 import type { ImportSessionsResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer, RequestSequence } from './realtime-sync';
+
+const DEBOUNCE_MS = 200;
 
 class ImportSessionsContext {
 	sessions: ImportSessionsResponse[] = $state([]);
@@ -12,14 +14,18 @@ class ImportSessionsContext {
 
 	private _pb: PocketBaseContext;
 	private _auth: ReturnType<typeof getAuthContext>;
+	private sequence = new RequestSequence();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this.init();
 	}
 
@@ -32,6 +38,8 @@ class ImportSessionsContext {
 			const userId = this.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
 				this.sessions = [];
@@ -44,19 +52,26 @@ class ImportSessionsContext {
 		});
 	}
 
+	// Realtime events and reconnects are pure invalidation signals: they schedule a debounced full
+	// refetch sorted '-created', which reproduces the newest-first order without patching the payload.
+	private invalidate() {
+		this.debouncer.schedule(() => void this.refreshForCurrentUser());
+	}
+
 	private async refreshForCurrentUser() {
 		const userId = this.currentUserId;
+		const token = this.sequence.next();
 		try {
 			const sessions = await this._pb.authedClient
 				.collection('importSessions')
-				.getFullList<ImportSessionsResponse>({ sort: '-created' });
-			if (userId !== this.currentUserId) return;
+				.getFullList<ImportSessionsResponse>({ sort: '-created', requestKey: null });
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
 			this.sessions = sessions;
 		} catch (error) {
-			if (userId !== this.currentUserId) return;
-			this._pb.handleConnectionError(error, 'importSessions', 'init');
+			if (userId !== this.currentUserId || !this.sequence.isCurrent(token)) return;
+			this._pb.handleConnectionError(error, 'importSessions', 'refresh');
 		} finally {
-			if (userId === this.currentUserId) this.isLoading = false;
+			if (userId === this.currentUserId && this.sequence.isCurrent(token)) this.isLoading = false;
 		}
 	}
 
@@ -65,7 +80,7 @@ class ImportSessionsContext {
 
 		this._pb.authedClient
 			.collection('importSessions')
-			.subscribe('*', this.onSessionEvent.bind(this))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'importSessions', 'subscribe');
@@ -76,25 +91,23 @@ class ImportSessionsContext {
 		this._isSubscribed = true;
 	}
 
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
+
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('importSessions').unsubscribe('*');
 	}
 
-	private onSessionEvent(e: RecordSubscription<ImportSessionsResponse>) {
-		if (e.action === 'create') {
-			this.sessions = [e.record, ...this.sessions];
-		} else if (e.action === 'update') {
-			this.sessions = this.sessions.map((s) => (s.id === e.record.id ? e.record : s));
-		} else if (e.action === 'delete') {
-			this.sessions = this.sessions.filter((s) => s.id !== e.record.id);
-		}
-	}
-
 	dispose() {
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -20,8 +20,43 @@ export class PocketBaseContext {
 	setupStatus: SetupStatus = $state('checking');
 	onAuthInvalidated?: () => void;
 
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- never read in a reactive context
+	private _reconnectCallbacks = new Set<() => void>();
+	private _reconnectListening = false;
+	private _pendingReconnect = false;
+
 	constructor() {
 		this.authedClient = new PocketBase(getBackendUrl());
+	}
+
+	// NOTE: the SDK resubmits subscriptions on realtime reconnect but never replays events emitted
+	// while disconnected, so records shared to the user during that gap (e.g. a laptop wake or
+	// network blip) stay invisible until a full re-init. Registered stores refetch on reconnect so a
+	// session converges with what the backend allows without a logout/login.
+	registerRealtimeReconnect(callback: () => void) {
+		this._reconnectCallbacks.add(callback);
+		if (this._reconnectListening) return;
+		this._reconnectListening = true;
+		this.authedClient.realtime.onDisconnect = (activeSubscriptions) => {
+			this._pendingReconnect = activeSubscriptions.length > 0;
+		};
+		void this.authedClient.realtime
+			.subscribe('PB_CONNECT', () => {
+				if (!this._pendingReconnect) return;
+				this._pendingReconnect = false;
+				for (const reconnect of this._reconnectCallbacks) {
+					try {
+						reconnect();
+					} catch (error) {
+						logError('pocketbase', 'reconnect_callback', error);
+					}
+				}
+			})
+			.catch((error) => logError('pocketbase', 'reconnect_subscribe', error));
+	}
+
+	unregisterRealtimeReconnect(callback: () => void) {
+		this._reconnectCallbacks.delete(callback);
 	}
 
 	get backendUrl(): string {

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -2,12 +2,19 @@ import PocketBase, { ClientResponseError } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
 import { toast } from 'svelte-sonner';
 
+import { browser } from '$app/environment';
+
 import { logError } from './logger';
 import { m } from './paraglide/messages';
 import type { TypedPocketBase } from './pocketbase.schema';
 import { getBackendUrl } from './utils';
 
 export type SetupStatus = 'checking' | 'ready' | 'needs-setup' | 'unreachable';
+
+// Waits between backend health probes during a recovery attempt. The list doubles as the attempt
+// budget: after the last delay the attempt gives up and waits for the next trigger, so a user who
+// stays offline for an hour is probed a handful of times, not continuously.
+const RECOVERY_PROBE_DELAYS_MS = [1000, 2000, 4000, 8000, 16000, 30000];
 
 enum ToastId {
 	CONNECTION_ERROR = 'connection-error',
@@ -24,6 +31,14 @@ export class PocketBaseContext {
 	private _reconnectCallbacks = new Set<() => void>();
 	private _reconnectListening = false;
 	private _pendingReconnect = false;
+	private _recovering = false;
+	// Fires on the two browser signals that a dead connection may be usable again: the network
+	// coming back, and the tab becoming visible after a sleep/wake or a backgrounded stretch. While
+	// hidden the tab is left alone - the visibility signal picks it up when the user returns.
+	private _recoveryTrigger = () => {
+		if (document.visibilityState !== 'visible') return;
+		void this.recoverRealtime();
+	};
 
 	constructor() {
 		this.authedClient = new PocketBase(getBackendUrl());
@@ -33,6 +48,12 @@ export class PocketBaseContext {
 	// while disconnected, so records shared to the user during that gap (e.g. a laptop wake or
 	// network blip) stay invisible until a full re-init. Registered stores refetch on reconnect so a
 	// session converges with what the backend allows without a logout/login.
+	//
+	// The SDK only reconnects when the EventSource reports a transport error, and EventSource has no
+	// liveness detection: an offline network or a slept laptop routinely leaves the socket in an OPEN
+	// state that never errors, so `onDisconnect` never fires and nothing would ever refetch. The
+	// browser's `online` and `visibilitychange` signals are therefore part of the recovery contract,
+	// not a nicety - they are the only trigger in the failing case.
 	registerRealtimeReconnect(callback: () => void) {
 		this._reconnectCallbacks.add(callback);
 		if (this._reconnectListening) return;
@@ -44,19 +65,49 @@ export class PocketBaseContext {
 			.subscribe('PB_CONNECT', () => {
 				if (!this._pendingReconnect) return;
 				this._pendingReconnect = false;
-				for (const reconnect of this._reconnectCallbacks) {
-					try {
-						reconnect();
-					} catch (error) {
-						logError('pocketbase', 'reconnect_callback', error);
-					}
-				}
+				void this.recoverRealtime();
 			})
 			.catch((error) => logError('pocketbase', 'reconnect_subscribe', error));
+		if (!browser) return;
+		window.addEventListener('online', this._recoveryTrigger);
+		document.addEventListener('visibilitychange', this._recoveryTrigger);
 	}
 
 	unregisterRealtimeReconnect(callback: () => void) {
 		this._reconnectCallbacks.delete(callback);
+	}
+
+	// A refetch issued the instant a trigger fires can still hit a network that is not usable yet (an
+	// `online` event precedes real connectivity, and a store refetch that fails is discarded), so
+	// recovery is latched: it probes the backend on a bounded backoff and only invalidates the stores
+	// once the backend actually answers. `_recovering` coalesces a burst of triggers - an SDK
+	// reconnect, `online`, and `visibilitychange` typically arrive together - into a single refetch.
+	private async recoverRealtime() {
+		if (this._recovering || !this.authedClient.authStore.isValid) return;
+		this._recovering = true;
+		try {
+			for (let attempt = 0; ; attempt++) {
+				try {
+					await this.authedClient.health.check({ requestKey: null });
+					break;
+				} catch (error) {
+					if (attempt === RECOVERY_PROBE_DELAYS_MS.length) {
+						logError('pocketbase', 'recovery_unreachable', error);
+						return;
+					}
+					await new Promise((resolve) => setTimeout(resolve, RECOVERY_PROBE_DELAYS_MS[attempt]));
+				}
+			}
+			for (const reconnect of this._reconnectCallbacks) {
+				try {
+					reconnect();
+				} catch (error) {
+					logError('pocketbase', 'reconnect_callback', error);
+				}
+			}
+		} finally {
+			this._recovering = false;
+		}
 	}
 
 	get backendUrl(): string {

--- a/src/lib/realtime-sync.ts
+++ b/src/lib/realtime-sync.ts
@@ -1,5 +1,3 @@
-import { upsertById, type SnapshotMutation } from './utils';
-
 // Monotonic latest-request guard. An async refresh takes a token from next() and bails as soon as
 // isCurrent(token) turns false because a newer refresh - or a supersede via bump() - advanced it.
 export class RequestSequence {
@@ -23,78 +21,23 @@ export class RequestSequence {
 	}
 }
 
-// Buffers realtime events that arrive while a snapshot fetch is in flight, then replays them onto
-// the fetched list before it is committed so the older snapshot can't clobber a newer event.
-export class SnapshotReconciler<T extends { id: string }> {
-	#token: number | null = null;
-	#buffer: SnapshotMutation<T>[] = [];
+// Trailing-edge debounce. schedule() coalesces a burst of realtime events into a single deferred
+// call; cancel() drops any pending call on dispose or logout.
+export class Debouncer {
+	private timer: ReturnType<typeof setTimeout> | null = null;
 
-	begin(token: number) {
-		this.#token = token;
-		this.#buffer = [];
+	constructor(private delayMs: number) {}
+
+	schedule(callback: () => void) {
+		if (this.timer) clearTimeout(this.timer);
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			callback();
+		}, this.delayMs);
 	}
 
-	// No-ops unless a snapshot is in flight, so callers buffer unconditionally on every event.
-	buffer(record: T, deleted: boolean) {
-		if (this.#token === null) return;
-		this.#buffer.push({ deleted, record });
-	}
-
-	get deletedIds() {
-		return new Set(this.#buffer.filter((mutation) => mutation.deleted).map((m) => m.record.id));
-	}
-
-	replay(list: T[]) {
-		let result = list;
-		for (const mutation of this.#buffer) {
-			result = mutation.deleted
-				? result.filter((record) => record.id !== mutation.record.id)
-				: upsertById(result, mutation.record).list;
-		}
-		return result;
-	}
-
-	// Reset only when this snapshot is still the active one - a newer begin() must not be discarded
-	// by a superseded fetch's finally block.
-	end(token: number) {
-		if (this.#token === token) this.reset();
-	}
-
-	reset() {
-		this.#token = null;
-		this.#buffer = [];
-	}
-}
-
-// Per-key mutation counter. A targeted refetch reads its key's epoch before fetching and bails on
-// commit when the epoch moved, so a delete/update landing mid-fetch is never overwritten by a stale
-// result.
-export class MutationEpochMap {
-	#epochs = new Map<string, number>();
-
-	// Reading a key registers it (defaulting to 0) so bumpMatching can invalidate an in-flight
-	// targeted fetch that has not yet recorded any mutation of its own.
-	read(key: string) {
-		const epoch = this.#epochs.get(key) ?? 0;
-		this.#epochs.set(key, epoch);
-		return epoch;
-	}
-
-	isCurrent(key: string, epoch: number) {
-		return (this.#epochs.get(key) ?? 0) === epoch;
-	}
-
-	bump(key: string) {
-		this.#epochs.set(key, (this.#epochs.get(key) ?? 0) + 1);
-	}
-
-	bumpMatching(predicate: (key: string) => boolean) {
-		for (const key of this.#epochs.keys()) {
-			if (predicate(key)) this.bump(key);
-		}
-	}
-
-	clear() {
-		this.#epochs.clear();
+	cancel() {
+		if (this.timer) clearTimeout(this.timer);
+		this.timer = null;
 	}
 }

--- a/src/lib/realtime-sync.ts
+++ b/src/lib/realtime-sync.ts
@@ -1,23 +1,23 @@
 // Monotonic latest-request guard. An async refresh takes a token from next() and bails as soon as
 // isCurrent(token) turns false because a newer refresh - or a supersede via bump() - advanced it.
 export class RequestSequence {
-	#value = 0;
+	private value = 0;
 
 	next() {
-		return ++this.#value;
+		return ++this.value;
 	}
 
 	get current() {
-		return this.#value;
+		return this.value;
 	}
 
 	isCurrent(token: number) {
-		return token === this.#value;
+		return token === this.value;
 	}
 
 	// Advance without starting a request, superseding any in-flight refresh (e.g. on logout).
 	bump() {
-		this.#value++;
+		this.value++;
 	}
 }
 

--- a/src/lib/realtime-sync.ts
+++ b/src/lib/realtime-sync.ts
@@ -1,0 +1,100 @@
+import { upsertById, type SnapshotMutation } from './utils';
+
+// Monotonic latest-request guard. An async refresh takes a token from next() and bails as soon as
+// isCurrent(token) turns false because a newer refresh - or a supersede via bump() - advanced it.
+export class RequestSequence {
+	#value = 0;
+
+	next() {
+		return ++this.#value;
+	}
+
+	get current() {
+		return this.#value;
+	}
+
+	isCurrent(token: number) {
+		return token === this.#value;
+	}
+
+	// Advance without starting a request, superseding any in-flight refresh (e.g. on logout).
+	bump() {
+		this.#value++;
+	}
+}
+
+// Buffers realtime events that arrive while a snapshot fetch is in flight, then replays them onto
+// the fetched list before it is committed so the older snapshot can't clobber a newer event.
+export class SnapshotReconciler<T extends { id: string }> {
+	#token: number | null = null;
+	#buffer: SnapshotMutation<T>[] = [];
+
+	begin(token: number) {
+		this.#token = token;
+		this.#buffer = [];
+	}
+
+	// No-ops unless a snapshot is in flight, so callers buffer unconditionally on every event.
+	buffer(record: T, deleted: boolean) {
+		if (this.#token === null) return;
+		this.#buffer.push({ deleted, record });
+	}
+
+	get deletedIds() {
+		return new Set(this.#buffer.filter((mutation) => mutation.deleted).map((m) => m.record.id));
+	}
+
+	replay(list: T[]) {
+		let result = list;
+		for (const mutation of this.#buffer) {
+			result = mutation.deleted
+				? result.filter((record) => record.id !== mutation.record.id)
+				: upsertById(result, mutation.record).list;
+		}
+		return result;
+	}
+
+	// Reset only when this snapshot is still the active one - a newer begin() must not be discarded
+	// by a superseded fetch's finally block.
+	end(token: number) {
+		if (this.#token === token) this.reset();
+	}
+
+	reset() {
+		this.#token = null;
+		this.#buffer = [];
+	}
+}
+
+// Per-key mutation counter. A targeted refetch reads its key's epoch before fetching and bails on
+// commit when the epoch moved, so a delete/update landing mid-fetch is never overwritten by a stale
+// result.
+export class MutationEpochMap {
+	#epochs = new Map<string, number>();
+
+	// Reading a key registers it (defaulting to 0) so bumpMatching can invalidate an in-flight
+	// targeted fetch that has not yet recorded any mutation of its own.
+	read(key: string) {
+		const epoch = this.#epochs.get(key) ?? 0;
+		this.#epochs.set(key, epoch);
+		return epoch;
+	}
+
+	isCurrent(key: string, epoch: number) {
+		return (this.#epochs.get(key) ?? 0) === epoch;
+	}
+
+	bump(key: string) {
+		this.#epochs.set(key, (this.#epochs.get(key) ?? 0) + 1);
+	}
+
+	bumpMatching(predicate: (key: string) => boolean) {
+		for (const key of this.#epochs.keys()) {
+			if (predicate(key)) this.bump(key);
+		}
+	}
+
+	clear() {
+		this.#epochs.clear();
+	}
+}

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -1,6 +1,5 @@
-import { type RecordSubscription } from 'pocketbase';
 import { getContext, setContext } from 'svelte';
-import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { SvelteMap } from 'svelte/reactivity';
 
 import { getAccountsContext } from './accounts.svelte';
 import { getAuthContext } from './auth.svelte';
@@ -8,7 +7,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import type { SecuritiesResponse, SecurityBalancesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
-import { MutationEpochMap, RequestSequence, SnapshotReconciler } from './realtime-sync';
+import { Debouncer, RequestSequence } from './realtime-sync';
 import {
 	compareByValueDescThenName,
 	resolveSecurityBalanceValues,
@@ -16,7 +15,7 @@ import {
 	type SecurityBalanceResolvedValue
 } from './security-balance-values';
 import { projectSignedValue } from './sharing';
-import { toNumber, upsertById } from './utils';
+import { toNumber } from './utils';
 
 type SecurityBalance = SecurityBalancesResponse<number, number, number, number>;
 
@@ -87,7 +86,7 @@ const DEBOUNCE_MS = 200;
 
 class SecuritiesContext {
 	securities: SecuritiesResponse[] = $state([]);
-	isLoading: boolean = $state(true);
+	isLoading = $state(true);
 	positionsLoaded = false;
 
 	positionsValueByAccount = $derived.by(() => {
@@ -139,19 +138,18 @@ class SecuritiesContext {
 	private _auth: ReturnType<typeof getAuthContext>;
 	private _accounts: ReturnType<typeof getAccountsContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
-	private positionRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	private positionEpochs = new MutationEpochMap();
 	private sequence = new RequestSequence();
-	private securitiesSnapshot = new SnapshotReconciler<SecuritiesResponse>();
-	private balancesSnapshot = new SnapshotReconciler<SecurityBalance>();
+	private debouncer = new Debouncer(DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 
 	constructor(pb: PocketBaseContext) {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._accounts = getAccountsContext();
 		this._fx = getExchangeRatesContext();
 		this.init();
@@ -185,16 +183,9 @@ class SecuritiesContext {
 			...balanceData,
 			security: securityId
 		});
-		if (
-			await this.refreshPosition(
-				balanceData.account,
-				securityId,
-				this._auth.currentUserId,
-				this.sequence.current
-			)
-		) {
-			this._accounts.notifyBalancesChanged();
-		}
+		// Refresh directly rather than via the debounce so the user's own write shows immediately;
+		// refreshAll notifies accounts of the new balances on commit.
+		await this.refreshForCurrentUser();
 	}
 
 	private init() {
@@ -202,13 +193,10 @@ class SecuritiesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.securitiesSnapshot.reset();
-			this.balancesSnapshot.reset();
-			this.positionEpochs.clear();
+			this.debouncer.cancel();
+			this.sequence.bump();
 			this._activeUserId = userId;
 			if (!userId) {
-				this.sequence.bump();
-				this.clearPositionRefreshTimers();
 				this.securities = [];
 				this.currentPositions.clear();
 				this.positionsLoaded = false;
@@ -220,6 +208,14 @@ class SecuritiesContext {
 			this.realtimeSubscribe(userId);
 			void this.refreshForCurrentUser();
 		});
+	}
+
+	// Realtime events and reconnects are pure invalidation signals: they never patch a payload into
+	// state, they only schedule a full refetch. A security delete cascades to its securityBalances
+	// server-side, so the deleted rows are simply absent from the next snapshot - no epoch guard or
+	// buffered replay is needed to keep them gone.
+	private invalidate() {
+		this.debouncer.schedule(() => void this.refreshForCurrentUser());
 	}
 
 	private async refreshForCurrentUser() {
@@ -243,38 +239,26 @@ class SecuritiesContext {
 	}
 
 	private async refreshAll(userId: string, token: number) {
-		this.securitiesSnapshot.begin(token);
-		this.balancesSnapshot.begin(token);
-		try {
-			const [securities, securityBalances] = await Promise.all([
-				this._pb.authedClient.collection('securities').getFullList<SecuritiesResponse>({
-					sort: 'name',
-					requestKey: null
-				}),
-				this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
-					sort: 'security,account,-asOf,-created,-id',
-					requestKey: null
-				})
-			]);
-			if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
+		const [securities, securityBalances] = await Promise.all([
+			this._pb.authedClient.collection('securities').getFullList<SecuritiesResponse>({
+				sort: 'name',
+				requestKey: null
+			}),
+			this._pb.authedClient.collection('securityBalances').getFullList<SecurityBalance>({
+				sort: 'security,account,-asOf,-created,-id',
+				requestKey: null
+			})
+		]);
+		if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
 
-			this.securities = this.securitiesSnapshot
-				.replay(securities)
-				.toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
-			const deletedSecurityIds = this.securitiesSnapshot.deletedIds;
-
-			const reconciledBalances = this.balancesSnapshot.replay(
-				securityBalances.filter((balance) => !deletedSecurityIds.has(balance.security))
-			);
-			this.currentPositions.clear();
-			for (const [key, position] of resolveSecurityBalanceValues(reconciledBalances)) {
-				this.currentPositions.set(key, position);
-			}
-			this.resolvePositionsLoaded();
-		} finally {
-			this.securitiesSnapshot.end(token);
-			this.balancesSnapshot.end(token);
+		this.securities = securities.toSorted((a, b) =>
+			a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+		);
+		this.currentPositions.clear();
+		for (const [key, position] of resolveSecurityBalanceValues(securityBalances)) {
+			this.currentPositions.set(key, position);
 		}
+		this.resolvePositionsLoaded();
 	}
 
 	private realtimeSubscribe(userId = this._activeUserId) {
@@ -282,7 +266,7 @@ class SecuritiesContext {
 
 		this._pb.authedClient
 			.collection('securities')
-			.subscribe<SecuritiesResponse>('*', (event) => this.onSecurityEvent(event, userId))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe');
@@ -292,7 +276,7 @@ class SecuritiesContext {
 			});
 		this._pb.authedClient
 			.collection('securityBalances')
-			.subscribe<SecurityBalance>('*', (event) => this.onSecurityBalanceEvent(event, userId))
+			.subscribe('*', () => this.onRealtimeEvent(userId))
 			.catch((error) => {
 				if (userId === this._activeUserId) {
 					this._pb.handleSubscriptionError(error, 'securities', 'subscribe_balances');
@@ -303,120 +287,16 @@ class SecuritiesContext {
 		this._isSubscribed = true;
 	}
 
+	private onRealtimeEvent(userId: string) {
+		if (!userId || userId !== this._activeUserId) return;
+		this.invalidate();
+	}
+
 	private unsubscribeRealtime() {
 		if (!this._isSubscribed) return;
 		this._isSubscribed = false;
 		this._pb.authedClient.collection('securities').unsubscribe('*');
 		this._pb.authedClient.collection('securityBalances').unsubscribe('*');
-	}
-
-	private onSecurityEvent(event: RecordSubscription<SecuritiesResponse>, userId: string) {
-		if (!userId || userId !== this._activeUserId) return;
-		if (!event.action) return;
-		this.securitiesSnapshot.buffer(event.record, event.action === 'delete');
-		if (event.action === 'delete') {
-			this.securities = this.securities.filter((security) => security.id !== event.record.id);
-			this.positionEpochs.bumpMatching((key) => key.endsWith(`:${event.record.id}`));
-			for (const [key, position] of this.currentPositions) {
-				if (position.balance.security === event.record.id) this.currentPositions.delete(key);
-			}
-			if (this.positionsLoaded) this._accounts.notifyBalancesChanged();
-			return;
-		}
-
-		this.upsertSecurity(event.record);
-	}
-
-	private onSecurityBalanceEvent(event: RecordSubscription<SecurityBalance>, userId: string) {
-		if (!userId || userId !== this._activeUserId) return;
-		if (!event.action) return;
-		this.balancesSnapshot.buffer(event.record, event.action === 'delete');
-
-		const key = this.positionKey(event.record.account, event.record.security);
-		const affectedKeys = new SvelteSet([key]);
-		if (event.action === 'update') {
-			for (const [currentKey, position] of this.currentPositions) {
-				if (position.balance.id === event.record.id && currentKey !== key) {
-					const [accountId, securityId] = currentKey.split(':');
-					if (accountId && securityId) affectedKeys.add(currentKey);
-				}
-			}
-		}
-
-		for (const affectedKey of affectedKeys) {
-			this.positionEpochs.bump(affectedKey);
-			const [accountId, securityId] = affectedKey.split(':');
-			if (accountId && securityId) this.schedulePositionRefresh(accountId, securityId, userId);
-		}
-	}
-
-	private schedulePositionRefresh(accountId: string, securityId: string, userId: string) {
-		const key = this.positionKey(accountId, securityId);
-		const existing = this.positionRefreshTimers.get(key);
-		if (existing) clearTimeout(existing);
-
-		this.positionRefreshTimers.set(
-			key,
-			setTimeout(() => {
-				this.positionRefreshTimers.delete(key);
-				const token = this.sequence.current;
-				void this.refreshPosition(accountId, securityId, userId, token)
-					.then((refreshed) => {
-						if (refreshed && this.positionsLoaded) this._accounts.notifyBalancesChanged();
-					})
-					.catch((error) => {
-						if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
-						this._pb.handleConnectionError(error, 'securities', 'position_refresh');
-					});
-			}, DEBOUNCE_MS)
-		);
-	}
-
-	private async refreshPosition(
-		accountId: string,
-		securityId: string,
-		userId: string,
-		token: number
-	) {
-		if (!userId || userId !== this._auth.currentUserId || !this.sequence.isCurrent(token))
-			return false;
-		const key = this.positionKey(accountId, securityId);
-		const mutationEpoch = this.positionEpochs.read(key);
-		const balances = await this._pb.authedClient
-			.collection('securityBalances')
-			.getFullList<SecurityBalance>({
-				filter: `account='${accountId}' && security='${securityId}'`,
-				sort: '-asOf,-created,-id',
-				requestKey: null
-			});
-		if (
-			userId !== this._auth.currentUserId ||
-			!this.sequence.isCurrent(token) ||
-			!this.positionEpochs.isCurrent(key, mutationEpoch)
-		)
-			return false;
-
-		const position = resolveSecurityBalanceValues(balances).get(key);
-		if (position) this.currentPositions.set(key, position);
-		else this.currentPositions.delete(key);
-		return true;
-	}
-
-	private positionKey(accountId: string, securityId: string) {
-		return `${accountId}:${securityId}`;
-	}
-
-	private upsertSecurity(security: SecuritiesResponse) {
-		this.securities = upsertById(this.securities, security).list.toSorted((a, b) =>
-			a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-		);
-	}
-
-	private clearPositionRefreshTimers() {
-		for (const timer of this.positionRefreshTimers.values()) {
-			clearTimeout(timer);
-		}
-		this.positionRefreshTimers.clear();
 	}
 
 	private getLatestAccountBalanceRows() {
@@ -529,9 +409,11 @@ class SecuritiesContext {
 	}
 
 	dispose() {
+		this.debouncer.cancel();
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
-		this.clearPositionRefreshTimers();
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
+		this.sequence.bump();
 	}
 }
 

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -15,7 +15,7 @@ import {
 	type SecurityBalanceResolvedValue
 } from './security-balance-values';
 import { projectSignedValue } from './sharing';
-import { toNumber, upsertById } from './utils';
+import { toNumber, upsertById, type SnapshotMutation } from './utils';
 
 type SecurityBalance = SecurityBalancesResponse<number, number, number, number>;
 
@@ -80,11 +80,6 @@ type PositionsAccumulator = {
 	isConverted: boolean;
 	isUnconverted: boolean;
 	missingCurrency: string | null;
-};
-
-type SnapshotMutation<T> = {
-	deleted: boolean;
-	record: T;
 };
 
 const DEBOUNCE_MS = 200;

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -8,6 +8,7 @@ import { getExchangeRatesContext } from './exchange-rates.svelte';
 import { logError } from './logger';
 import type { SecuritiesResponse, SecurityBalancesResponse } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { MutationEpochMap, RequestSequence, SnapshotReconciler } from './realtime-sync';
 import {
 	compareByValueDescThenName,
 	resolveSecurityBalanceValues,
@@ -15,7 +16,7 @@ import {
 	type SecurityBalanceResolvedValue
 } from './security-balance-values';
 import { projectSignedValue } from './sharing';
-import { toNumber, upsertById, type SnapshotMutation } from './utils';
+import { toNumber, upsertById } from './utils';
 
 type SecurityBalance = SecurityBalancesResponse<number, number, number, number>;
 
@@ -139,11 +140,10 @@ class SecuritiesContext {
 	private _accounts: ReturnType<typeof getAccountsContext>;
 	private _fx: ReturnType<typeof getExchangeRatesContext>;
 	private positionRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	private positionMutationEpochs = new Map<string, number>();
-	private refreshSequence = 0;
-	private activeSnapshotToken: number | null = null;
-	private securitySnapshotMutations: SnapshotMutation<SecuritiesResponse>[] = [];
-	private balanceSnapshotMutations: SnapshotMutation<SecurityBalance>[] = [];
+	private positionEpochs = new MutationEpochMap();
+	private sequence = new RequestSequence();
+	private securitiesSnapshot = new SnapshotReconciler<SecuritiesResponse>();
+	private balancesSnapshot = new SnapshotReconciler<SecurityBalance>();
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
@@ -190,7 +190,7 @@ class SecuritiesContext {
 				balanceData.account,
 				securityId,
 				this._auth.currentUserId,
-				this.refreshSequence
+				this.sequence.current
 			)
 		) {
 			this._accounts.notifyBalancesChanged();
@@ -202,13 +202,12 @@ class SecuritiesContext {
 			const userId = this._auth.currentUserId;
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
-			this.activeSnapshotToken = null;
-			this.securitySnapshotMutations = [];
-			this.balanceSnapshotMutations = [];
-			this.positionMutationEpochs.clear();
+			this.securitiesSnapshot.reset();
+			this.balancesSnapshot.reset();
+			this.positionEpochs.clear();
 			this._activeUserId = userId;
 			if (!userId) {
-				this.refreshSequence++;
+				this.sequence.bump();
 				this.clearPositionRefreshTimers();
 				this.securities = [];
 				this.currentPositions.clear();
@@ -225,15 +224,15 @@ class SecuritiesContext {
 
 	private async refreshForCurrentUser() {
 		const userId = this._auth.currentUserId;
-		const token = ++this.refreshSequence;
+		const token = this.sequence.next();
 		try {
 			await this.refreshAll(userId, token);
 		} catch (error) {
-			if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
+			if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
 			this._pb.handleConnectionError(error, 'securities', 'init');
 			this.resolvePositionsLoaded();
 		} finally {
-			if (userId === this._auth.currentUserId && token === this.refreshSequence)
+			if (userId === this._auth.currentUserId && this.sequence.isCurrent(token))
 				this.isLoading = false;
 		}
 	}
@@ -243,10 +242,9 @@ class SecuritiesContext {
 		this._accounts.notifyBalancesChanged();
 	}
 
-	private async refreshAll(userId = this._auth.currentUserId, token = ++this.refreshSequence) {
-		this.activeSnapshotToken = token;
-		this.securitySnapshotMutations = [];
-		this.balanceSnapshotMutations = [];
+	private async refreshAll(userId: string, token: number) {
+		this.securitiesSnapshot.begin(token);
+		this.balancesSnapshot.begin(token);
 		try {
 			const [securities, securityBalances] = await Promise.all([
 				this._pb.authedClient.collection('securities').getFullList<SecuritiesResponse>({
@@ -258,39 +256,24 @@ class SecuritiesContext {
 					requestKey: null
 				})
 			]);
-			if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
+			if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
 
-			let reconciledSecurities = securities;
-			const deletedSecurityIds = new SvelteSet<string>();
-			for (const mutation of this.securitySnapshotMutations) {
-				if (mutation.deleted) deletedSecurityIds.add(mutation.record.id);
-				reconciledSecurities = mutation.deleted
-					? reconciledSecurities.filter((security) => security.id !== mutation.record.id)
-					: upsertById(reconciledSecurities, mutation.record).list;
-			}
-			this.securities = reconciledSecurities.toSorted((a, b) =>
-				a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-			);
+			this.securities = this.securitiesSnapshot
+				.replay(securities)
+				.toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+			const deletedSecurityIds = this.securitiesSnapshot.deletedIds;
 
-			let reconciledBalances = securityBalances.filter(
-				(balance) => !deletedSecurityIds.has(balance.security)
+			const reconciledBalances = this.balancesSnapshot.replay(
+				securityBalances.filter((balance) => !deletedSecurityIds.has(balance.security))
 			);
-			for (const mutation of this.balanceSnapshotMutations) {
-				reconciledBalances = mutation.deleted
-					? reconciledBalances.filter((balance) => balance.id !== mutation.record.id)
-					: upsertById(reconciledBalances, mutation.record).list;
-			}
 			this.currentPositions.clear();
 			for (const [key, position] of resolveSecurityBalanceValues(reconciledBalances)) {
 				this.currentPositions.set(key, position);
 			}
 			this.resolvePositionsLoaded();
 		} finally {
-			if (this.activeSnapshotToken === token) {
-				this.activeSnapshotToken = null;
-				this.securitySnapshotMutations = [];
-				this.balanceSnapshotMutations = [];
-			}
+			this.securitiesSnapshot.end(token);
+			this.balancesSnapshot.end(token);
 		}
 	}
 
@@ -330,18 +313,10 @@ class SecuritiesContext {
 	private onSecurityEvent(event: RecordSubscription<SecuritiesResponse>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!event.action) return;
-		if (this.activeSnapshotToken !== null) {
-			this.securitySnapshotMutations.push({
-				deleted: event.action === 'delete',
-				record: event.record
-			});
-		}
+		this.securitiesSnapshot.buffer(event.record, event.action === 'delete');
 		if (event.action === 'delete') {
 			this.securities = this.securities.filter((security) => security.id !== event.record.id);
-			for (const key of this.positionMutationEpochs.keys()) {
-				if (!key.endsWith(`:${event.record.id}`)) continue;
-				this.positionMutationEpochs.set(key, (this.positionMutationEpochs.get(key) ?? 0) + 1);
-			}
+			this.positionEpochs.bumpMatching((key) => key.endsWith(`:${event.record.id}`));
 			for (const [key, position] of this.currentPositions) {
 				if (position.balance.security === event.record.id) this.currentPositions.delete(key);
 			}
@@ -355,12 +330,7 @@ class SecuritiesContext {
 	private onSecurityBalanceEvent(event: RecordSubscription<SecurityBalance>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
 		if (!event.action) return;
-		if (this.activeSnapshotToken !== null) {
-			this.balanceSnapshotMutations.push({
-				deleted: event.action === 'delete',
-				record: event.record
-			});
-		}
+		this.balancesSnapshot.buffer(event.record, event.action === 'delete');
 
 		const key = this.positionKey(event.record.account, event.record.security);
 		const affectedKeys = new SvelteSet([key]);
@@ -374,10 +344,7 @@ class SecuritiesContext {
 		}
 
 		for (const affectedKey of affectedKeys) {
-			this.positionMutationEpochs.set(
-				affectedKey,
-				(this.positionMutationEpochs.get(affectedKey) ?? 0) + 1
-			);
+			this.positionEpochs.bump(affectedKey);
 			const [accountId, securityId] = affectedKey.split(':');
 			if (accountId && securityId) this.schedulePositionRefresh(accountId, securityId, userId);
 		}
@@ -392,13 +359,13 @@ class SecuritiesContext {
 			key,
 			setTimeout(() => {
 				this.positionRefreshTimers.delete(key);
-				const token = this.refreshSequence;
+				const token = this.sequence.current;
 				void this.refreshPosition(accountId, securityId, userId, token)
 					.then((refreshed) => {
 						if (refreshed && this.positionsLoaded) this._accounts.notifyBalancesChanged();
 					})
 					.catch((error) => {
-						if (userId !== this._auth.currentUserId || token !== this.refreshSequence) return;
+						if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
 						this._pb.handleConnectionError(error, 'securities', 'position_refresh');
 					});
 			}, DEBOUNCE_MS)
@@ -411,13 +378,10 @@ class SecuritiesContext {
 		userId: string,
 		token: number
 	) {
-		if (!userId || userId !== this._auth.currentUserId || token !== this.refreshSequence)
+		if (!userId || userId !== this._auth.currentUserId || !this.sequence.isCurrent(token))
 			return false;
 		const key = this.positionKey(accountId, securityId);
-		const mutationEpoch = this.positionMutationEpochs.get(key) ?? 0;
-		// NOTE: Register the key so security-delete invalidation can see this in-flight
-		// targeted fetch when it scans positionMutationEpochs.keys().
-		this.positionMutationEpochs.set(key, mutationEpoch);
+		const mutationEpoch = this.positionEpochs.read(key);
 		const balances = await this._pb.authedClient
 			.collection('securityBalances')
 			.getFullList<SecurityBalance>({
@@ -427,8 +391,8 @@ class SecuritiesContext {
 			});
 		if (
 			userId !== this._auth.currentUserId ||
-			token !== this.refreshSequence ||
-			mutationEpoch !== (this.positionMutationEpochs.get(key) ?? 0)
+			!this.sequence.isCurrent(token) ||
+			!this.positionEpochs.isCurrent(key, mutationEpoch)
 		)
 			return false;
 

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -225,7 +225,7 @@ class SecuritiesContext {
 			await this.refreshAll(userId, token);
 		} catch (error) {
 			if (userId !== this._auth.currentUserId || !this.sequence.isCurrent(token)) return;
-			this._pb.handleConnectionError(error, 'securities', 'init');
+			this._pb.handleConnectionError(error, 'securities', 'refresh');
 			this.resolvePositionsLoaded();
 		} finally {
 			if (userId === this._auth.currentUserId && this.sequence.isCurrent(token))

--- a/src/lib/trades.svelte.ts
+++ b/src/lib/trades.svelte.ts
@@ -17,9 +17,12 @@ import {
 	type SecurityTransactionsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer } from './realtime-sync';
 import { getSecuritiesContext } from './securities.svelte';
 import type { PeriodOption } from './transactions.svelte';
 import { toNumber, toPocketBaseDateString } from './utils';
+
+const REFRESH_DEBOUNCE_MS = 200;
 
 type TradeExpand = {
 	account?: AccountsResponse;
@@ -51,17 +54,17 @@ class TradesContext {
 	private _customLabel: string | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
-	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
+	private _refreshDebouncer = new Debouncer(REFRESH_DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate();
 	private _refreshSequence = 0;
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
 
 	private static readonly LOADING_DELAY_MS = 150;
 	private static readonly SEARCH_DEBOUNCE_MS = 300;
-	private static readonly REFRESH_DEBOUNCE_MS = 200;
 
 	readonly periodOptions: PeriodOption[] = [
 		'this-month',
@@ -80,6 +83,7 @@ class TradesContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._accountsContext = getAccountsContext();
 		this._securitiesContext = getSecuritiesContext();
 		this.syncFromUrl(false);
@@ -367,10 +371,7 @@ class TradesContext {
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
 			this._refreshSequence++;
-			if (this._refreshTimer) {
-				clearTimeout(this._refreshTimer);
-				this._refreshTimer = null;
-			}
+			this._refreshDebouncer.cancel();
 			if (this._loadingDelayTimer) {
 				clearTimeout(this._loadingDelayTimer);
 				this._loadingDelayTimer = null;
@@ -419,16 +420,21 @@ class TradesContext {
 
 	private onTradeEvent(event: RecordSubscription<Trade>, userId: string) {
 		if (!userId || userId !== this._activeUserId) return;
-
 		if (!event.action) return;
-		if (this._refreshTimer) clearTimeout(this._refreshTimer);
-		this._refreshTimer = setTimeout(() => {
-			this._refreshTimer = null;
+		this.invalidate();
+	}
+
+	// A trade event or a realtime reconnect is a pure invalidation signal: it schedules the debounced
+	// page/summary refetch rather than patching the event payload into the cached rows.
+	private invalidate() {
+		const userId = this._activeUserId;
+		if (!userId) return;
+		this._refreshDebouncer.schedule(() => {
 			if (userId !== this._activeUserId) return;
 			this.refreshTransactions(userId).catch((error) =>
 				this._pb.handleConnectionError(error, 'securityTransactions', 'realtime_refresh')
 			);
-		}, TradesContext.REFRESH_DEBOUNCE_MS);
+		});
 	}
 
 	private get currentUrl() {
@@ -629,9 +635,10 @@ class TradesContext {
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
 		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
-		if (this._refreshTimer) clearTimeout(this._refreshTimer);
+		this._refreshDebouncer.cancel();
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -17,12 +17,15 @@ import type {
 	TransactionsResponse
 } from './pocketbase.schema';
 import type { PocketBaseContext } from './pocketbase.svelte';
+import { Debouncer } from './realtime-sync';
 import {
 	createSortComparator,
 	toPocketBaseDateString,
 	type SortDirection,
 	type SortState
 } from './utils';
+
+const REFRESH_DEBOUNCE_MS = 200;
 
 type TransactionSortColumn = 'date' | 'description' | 'account' | 'amount';
 
@@ -94,10 +97,11 @@ class TransactionsContext {
 	private _customLabel: string | null = $state(null);
 	private _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _loadingDelayTimer: ReturnType<typeof setTimeout> | null = null;
-	private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
+	private _refreshDebouncer = new Debouncer(REFRESH_DEBOUNCE_MS);
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => this.invalidate(true);
 	private _unsubscribe: (() => void) | null = null;
 	private _unsubscribeLabels: (() => void) | null = null;
 	private _refreshSequence = 0;
@@ -107,7 +111,6 @@ class TransactionsContext {
 
 	private static readonly LOADING_DELAY_MS = 150;
 	private static readonly SEARCH_DEBOUNCE_MS = 300;
-	private static readonly REFRESH_DEBOUNCE_MS = 200;
 
 	readonly periodOptions: PeriodOption[] = [
 		'this-month',
@@ -130,6 +133,7 @@ class TransactionsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._accountsContext = getAccountsContext();
 		this._fx = getExchangeRatesContext();
 		this.syncFromUrl(false);
@@ -268,10 +272,7 @@ class TransactionsContext {
 			if (userId === this._activeUserId) return;
 			this.unsubscribeRealtime();
 			this._refreshSequence++;
-			if (this._refreshTimer) {
-				clearTimeout(this._refreshTimer);
-				this._refreshTimer = null;
-			}
+			this._refreshDebouncer.cancel();
 			if (this._loadingDelayTimer) {
 				clearTimeout(this._loadingDelayTimer);
 				this._loadingDelayTimer = null;
@@ -602,16 +603,24 @@ class TransactionsContext {
 		userId: string
 	) {
 		if (!userId || userId !== this._activeUserId) return;
-
 		if (!e.action) return;
-		if (this._refreshTimer) clearTimeout(this._refreshTimer);
-		this._refreshTimer = setTimeout(() => {
-			this._refreshTimer = null;
+		this.invalidate(false);
+	}
+
+	// A transaction event or a realtime reconnect is a pure invalidation signal: it schedules the
+	// debounced page/summary refetch rather than patching the event payload. A reconnect may also
+	// have missed transactionLabels events, so it refreshes labels too; a plain transaction event
+	// cannot change labels and skips them.
+	private invalidate(includeLabels: boolean) {
+		const userId = this._activeUserId;
+		if (!userId) return;
+		this._refreshDebouncer.schedule(() => {
 			if (userId !== this._activeUserId) return;
+			if (includeLabels) void this.refreshLabels(userId);
 			this.refreshTransactions(userId).catch((error) =>
 				this._pb.handleConnectionError(error, 'transactions', 'realtime_refresh')
 			);
-		}, TransactionsContext.REFRESH_DEBOUNCE_MS);
+		});
 	}
 
 	private getPeriodRange(option: PeriodOption) {
@@ -1033,9 +1042,10 @@ class TransactionsContext {
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		if (this._searchDebounceTimer) clearTimeout(this._searchDebounceTimer);
 		if (this._loadingDelayTimer) clearTimeout(this._loadingDelayTimer);
-		if (this._refreshTimer) clearTimeout(this._refreshTimer);
+		this._refreshDebouncer.cancel();
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/transactions.svelte.ts
+++ b/src/lib/transactions.svelte.ts
@@ -103,6 +103,7 @@ class TransactionsContext {
 	private _refreshSequence = 0;
 	private _pageRefreshSequence = 0;
 	private _summaryRefreshSequence = 0;
+	private _labelRefreshSequence = 0;
 
 	private static readonly LOADING_DELAY_MS = 150;
 	private static readonly SEARCH_DEBOUNCE_MS = 300;
@@ -305,6 +306,7 @@ class TransactionsContext {
 	private async refreshLabels(userId = this._activeUserId) {
 		if (!userId || userId !== this._activeUserId) return;
 
+		const labelRefreshId = ++this._labelRefreshSequence;
 		try {
 			const labels = await this._pb.authedClient
 				.collection('transactionLabels')
@@ -312,10 +314,10 @@ class TransactionsContext {
 					sort: 'name',
 					requestKey: null
 				});
-			if (userId !== this._activeUserId) return;
+			if (userId !== this._activeUserId || labelRefreshId !== this._labelRefreshSequence) return;
 			this.transactionLabels = labels;
 		} catch (error) {
-			if (userId !== this._activeUserId) return;
+			if (userId !== this._activeUserId || labelRefreshId !== this._labelRefreshSequence) return;
 			this._pb.handleConnectionError(error, 'transactionLabels', 'refresh');
 		}
 	}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -155,6 +155,13 @@ export function isDuplicateSecurityNameError(error: unknown) {
 	);
 }
 
+// A realtime event buffered while a store's snapshot fetch is in flight, replayed onto the fetched
+// list before it's committed so the older snapshot can't clobber the event.
+export type SnapshotMutation<T> = {
+	deleted: boolean;
+	record: T;
+};
+
 export function upsertById<T extends { id: string }>(list: T[], record: T) {
 	const exists = list.some((r) => r.id === record.id);
 	return {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -154,23 +154,3 @@ export function isDuplicateSecurityNameError(error: unknown) {
 		responseFieldCode(error, 'name') === 'security_name_exists'
 	);
 }
-
-// A realtime event buffered while a store's snapshot fetch is in flight, replayed onto the fetched
-// list before it's committed so the older snapshot can't clobber the event.
-export type SnapshotMutation<T> = {
-	deleted: boolean;
-	record: T;
-};
-
-export function upsertById<T extends { id: string }>(list: T[], record: T) {
-	const exists = list.some((r) => r.id === record.id);
-	return {
-		list: exists ? list.map((r) => (r.id === record.id ? record : r)) : [...list, record],
-		inserted: !exists
-	};
-}
-
-export function removeById<T extends { id: string }>(list: T[], id: string) {
-	if (!list.some((r) => r.id === id)) return { list, removed: false };
-	return { list: list.filter((r) => r.id !== id), removed: true };
-}

--- a/src/routes/(app)/accounts/add/+page.svelte
+++ b/src/routes/(app)/accounts/add/+page.svelte
@@ -86,9 +86,7 @@
 			};
 
 			await pb.authedClient.collection('accountBalances').create(balanceData);
-			if (await accountsContext.refreshAccount(account.id, currentOwnerId)) {
-				accountsContext.notifyBalancesChanged();
-			}
+			await accountsContext.refreshForCurrentUser();
 
 			toast.success(m.accounts_add_success());
 			await goto(resolve('/accounts'));


### PR DESCRIPTION
## What this does

Rewrites every realtime context store onto a single sync model — **realtime events and reconnects are pure invalidation signals** that schedule a debounced (200ms), latest-request-wins full refetch replacing the whole cache — and makes connection recovery actually work under real-world disconnects. Event payloads are never patched into local state.

Closes two data-loss bug classes by making them structurally impossible rather than guarded:

- **#390** — a realtime event landing while a snapshot fetch was in flight was overwritten by the older snapshot (balances stale until reload, renames visually reverting). Now the event schedules a corrective refetch and the stale fetch is discarded by a `RequestSequence` token.
- **#388** — changes missed while the realtime connection was down (laptop sleep, network blip, server restart) were never replayed, so shared accounts/assets could vanish until relogin. Now every data store refetches on recovery, and recovery has real triggers (below).

## The store rewrite

- The three patch-local stores (**accounts, assets, securities**) are rewritten to the contract, deleting the snapshot-reconciler / mutation-epoch / settle-set / targeted-refetch machinery that made event patching "safe". `src/lib/realtime-sync.ts` now holds only `RequestSequence` and a small shared `Debouncer`.
- **accounts/assets** also collapse an N+1 latest-balance lookup (one query per account) into a single sorted fetch reduced client-side; selection tiebreakers are identical and the sort is index-backed.
- **cashflow** drops its incremental event patching but keeps its network-free projection recompute (the #359 performance gate) untouched.
- **balance-types / import-sessions** convert for uniformity, closing their latent copy of the mid-fetch clobber.
- `auth` is exempt (single own-user record, self-correcting).

## Connection recovery

Manual QA against a real DevTools offline cycle found that the SDK-reconnect-based recovery **never fires under a genuine disconnect**: EventSource has no liveness detection, so an offline network or a slept laptop leaves the socket OPEN with no error — no reconnect, no refetch, stale forever (pre-existing in the original #388 fix, not a rewrite regression). Recovery now has three triggers funneled through one registry in `pocketbase.svelte.ts`:

1. the SDK's own reconnect (`PB_CONNECT` after a transport error),
2. the browser's `online` event,
3. the tab becoming visible again (covers sleep/wake).

Recovery is latched behind a bounded health-probe backoff (1s→30s, then give up until the next trigger), so a refetch fired before the network is actually usable is retried instead of silently discarded, and a burst of triggers coalesces into one refetch round. Zero changes to the stores themselves.

## Tests

- New regression test drives a **real CDP offline cycle** (`Network.emulateNetworkConditions`) and fails without the recovery fix. Playwright's `context.setOffline()` and the pre-existing hand-dispatched-error test tear the socket down and therefore only cover the SDK path — their comments now say so honestly.
- A two-token race test on a live store instance covers the latest-wins guard directly: verified to fail deterministically with the guard broken, 5/5 clean repeats. The six hold-the-initial-fetch race tests assert convergence and are documented as such.
- New securities delete-during-initial-fetch test locks in the structural delete-resurrection guarantee.
- Every chunk was verified locally against its affected suites; CI runs the full suite on both projects.

Behavior note: balances during a bulk import now update in one debounced step after the burst instead of ticking per event — consistent with how transactions already behave.

The realtime skill documents the store sync contract and recovery triggers (isolated `docs:` commits, droppable).

Closes #390
Closes #388
