### PR TITLE
fix: reconcile shared accounts and assets on realtime reconnect

### DIFF
--- a/e2e/shared-records.test.ts
+++ b/e2e/shared-records.test.ts
@@ -769,3 +769,103 @@ test('asset share API rejects self-share and unknown recipient', async () => {
 	);
 	expect(response.status).toBe(200);
 });
+
+test('shared account and asset reconcile after a realtime reconnect without relogin', async ({
+	page
+}) => {
+	const owner = await seedUser('dexter');
+	const recipient = await seedUser('gwen');
+
+	const sharedAccount = await seedAccount({
+		name: 'Reconnect savings',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: owner.id,
+		balanceType: 'Savings'
+	});
+	await seedAccountBalance({
+		account: sharedAccount.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		value: 4200
+	});
+	const sharedAsset = await seedAsset({
+		name: 'Reconnect brokerage',
+		balanceGroup: AssetsBalanceGroupOptions.INVESTMENT,
+		owner: owner.id,
+		balanceType: 'Brokerage'
+	});
+	await seedAssetBalance({
+		asset: sharedAsset.id,
+		owner: owner.id,
+		asOf: new Date().toISOString(),
+		bookValue: 8000,
+		marketValue: 11000
+	});
+
+	// Track the SDK's realtime EventSource so the test can force it to error like a dropped
+	// connection, reproducing a session that misses the share events emitted while disconnected.
+	await page.addInitScript(() => {
+		const NativeEventSource = window.EventSource;
+		const sources: EventSource[] = [];
+		Object.assign(window, { __realtimeSources: sources });
+		window.EventSource = class extends NativeEventSource {
+			constructor(url: string | URL, init?: EventSourceInit) {
+				super(url, init);
+				sources.push(this);
+			}
+		};
+	});
+
+	await page.goto('/');
+	await signIn(page, recipient.email);
+
+	await goToPageViaSidebar(page, 'Accounts');
+	await expect(page.getByRole('row', { name: /Reconnect savings/ })).toHaveCount(0);
+
+	// Hold the realtime connection down while both records are shared, so the create events are
+	// never delivered to this session. Gating the reconnect (rather than aborting it) keeps the SDK
+	// from backing off, so releasing the gate reconnects promptly.
+	let releaseRealtime = () => {};
+	const realtimeGate = new Promise<void>((resolve) => {
+		releaseRealtime = resolve;
+	});
+	await page.route('**/api/realtime', async (route) => {
+		await realtimeGate;
+		await route.continue();
+	});
+	await page.evaluate(() => {
+		const sources = (window as unknown as { __realtimeSources: EventSource[] }).__realtimeSources;
+		for (const source of sources) source.dispatchEvent(new Event('error'));
+	});
+	await Promise.all([
+		seedAccountShare({
+			account: sharedAccount.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		}),
+		seedAssetShare({
+			asset: sharedAsset.id,
+			recipient: recipient.id,
+			recipientEmail: recipient.email,
+			grantedBy: owner.id,
+			accessRole: 'VIEWER',
+			perspective: 'NORMAL',
+			includeInNetWorth: true
+		})
+	]);
+	releaseRealtime();
+
+	// HACK: reconnect reconciliation refetches shares, accounts, and each account's balance in
+	// sequence, which can outrun the default expect timeout under a loaded CI machine; there is no
+	// reconcile-complete signal to await instead.
+	await expect(page.getByRole('row', { name: /Reconnect savings/ })).toContainText('$4,200.00', {
+		timeout: 15000
+	});
+
+	await goToPageViaSidebar(page, 'Assets');
+	await expect(page.getByRole('row', { name: /Reconnect brokerage/ })).toBeVisible();
+});

--- a/src/lib/accounts.svelte.ts
+++ b/src/lib/accounts.svelte.ts
@@ -86,6 +86,9 @@ class AccountsContext {
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => {
+		if (this.currentUserId) void this.refreshForCurrentUser();
+	};
 
 	constructor(
 		pb: PocketBaseContext,
@@ -94,6 +97,7 @@ class AccountsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -534,6 +538,7 @@ class AccountsContext {
 
 	dispose() {
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/assets.svelte.ts
+++ b/src/lib/assets.svelte.ts
@@ -87,6 +87,9 @@ class AssetsContext {
 	private _activeUserId = '';
 	private _isSubscribed = false;
 	private _teardownCallback = () => this.unsubscribeRealtime();
+	private _reconnectCallback = () => {
+		if (this.currentUserId) void this.refreshForCurrentUser();
+	};
 
 	constructor(
 		pb: PocketBaseContext,
@@ -95,6 +98,7 @@ class AssetsContext {
 		this._pb = pb;
 		this._auth = getAuthContext();
 		this._auth.registerRealtimeTeardown(this._teardownCallback);
+		this._pb.registerRealtimeReconnect(this._reconnectCallback);
 		this._fx = getExchangeRatesContext();
 		this.balanceTypesContext = balanceTypesContext;
 		this.init();
@@ -556,6 +560,7 @@ class AssetsContext {
 	dispose() {
 		this.refreshSequence++;
 		this._auth.unregisterRealtimeTeardown(this._teardownCallback);
+		this._pb.unregisterRealtimeReconnect(this._reconnectCallback);
 		this.unsubscribeRealtime();
 	}
 }

--- a/src/lib/pocketbase.svelte.ts
+++ b/src/lib/pocketbase.svelte.ts
@@ -20,8 +20,43 @@ export class PocketBaseContext {
 	setupStatus: SetupStatus = $state('checking');
 	onAuthInvalidated?: () => void;
 
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- never read in a reactive context
+	private _reconnectCallbacks = new Set<() => void>();
+	private _reconnectListening = false;
+	private _pendingReconnect = false;
+
 	constructor() {
 		this.authedClient = new PocketBase(getBackendUrl());
+	}
+
+	// NOTE: the SDK resubmits subscriptions on realtime reconnect but never replays events emitted
+	// while disconnected, so records shared to the user during that gap (e.g. a laptop wake or
+	// network blip) stay invisible until a full re-init. Registered stores refetch on reconnect so a
+	// session converges with what the backend allows without a logout/login.
+	registerRealtimeReconnect(callback: () => void) {
+		this._reconnectCallbacks.add(callback);
+		if (this._reconnectListening) return;
+		this._reconnectListening = true;
+		this.authedClient.realtime.onDisconnect = (activeSubscriptions) => {
+			this._pendingReconnect = activeSubscriptions.length > 0;
+		};
+		void this.authedClient.realtime
+			.subscribe('PB_CONNECT', () => {
+				if (!this._pendingReconnect) return;
+				this._pendingReconnect = false;
+				for (const reconnect of this._reconnectCallbacks) {
+					try {
+						reconnect();
+					} catch (error) {
+						logError('pocketbase', 'reconnect_callback', error);
+					}
+				}
+			})
+			.catch((error) => logError('pocketbase', 'reconnect_subscribe', error));
+	}
+
+	unregisterRealtimeReconnect(callback: () => void) {
+		this._reconnectCallbacks.delete(callback);
 	}
 
 	get backendUrl(): string {


### PR DESCRIPTION
- Shared accounts and assets could vanish from a logged-in session until logout/login: the PocketBase SDK resubmits realtime subscriptions on reconnect but never replays events emitted while disconnected, so share events landing in a disconnect window (laptop sleep, network blip) were lost for that session.
- Adds a reconnect registry to the PocketBase context store: it watches the SDK's `onDisconnect`/`PB_CONNECT` pair and fires registered callbacks only on a genuine reconnect, never on the initial connect.
- The accounts and assets stores register a callback that re-runs their existing full snapshot refresh, so a stale session converges with whatever the backend permits without relogin.
- Per-callback errors are isolated so one failing store refresh cannot poison the SDK's reconnect cycle.
- Regression test drops the recipient's realtime connection while an account and an asset are shared to them, then releases it and asserts both records appear without relogin.
- Merge-order note vs #400: both PRs touch the accounts/assets stores; #400 reworks `refreshForCurrentUser` but it remains a full server snapshot fetch (buffered events only supplement it), so this reconnect refetch composes correctly — expect at most a trivial context conflict in `dispose()`.

Closes #388