### PR TITLE
fix: sort tables in place without resetting scroll position

### DIFF
--- a/e2e/accounts.sorting.test.ts
+++ b/e2e/accounts.sorting.test.ts
@@ -175,3 +175,52 @@ test('sorts accounts by every column and preserves sorting across reloads and fi
 		await getRowIndex(rows, 'Many Transactions')
 	);
 });
+
+test('reorders rows in place without resetting scroll when sorting a scrolled page', async ({
+	page
+}) => {
+	const user = await seedUser('zelda');
+	const now = new Date().toISOString();
+
+	// Seed enough accounts that the list overflows the viewport and the window can scroll.
+	// Zero-padded names keep row-text matching unambiguous; balances are unique so the
+	// default descending sort has a stable order that the ascending toggle fully reverses.
+	for (let index = 1; index <= 30; index++) {
+		const name = `Account ${String(index).padStart(2, '0')}`;
+		const account = await seedAccount({
+			name,
+			balanceGroup: AccountsBalanceGroupOptions.CASH,
+			owner: user.id,
+			balanceType: 'Checking'
+		});
+		await seedAccountBalance({
+			account: account.id,
+			owner: user.id,
+			asOf: now,
+			value: index * 100
+		});
+	}
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Accounts');
+	await expect(page.getByRole('tab', { name: 'Open' })).toHaveAttribute('aria-selected', 'true');
+	await expect(page.getByRole('row', { name: 'Account 30' })).toBeVisible();
+
+	// Scroll the balance header to the top of the viewport: the page is now scrolled past the
+	// top (scrollY > 0) while the header stays fully visible, so clicking it needs no auto-scroll.
+	const balanceButton = page.getByRole('button', { name: 'Balance' });
+	await balanceButton.evaluate((element) => element.scrollIntoView({ block: 'start' }));
+	const scrolledY = await page.evaluate(() => window.scrollY);
+	expect(scrolledY).toBeGreaterThan(0);
+
+	// Balance defaults to descending, so the highest balance leads before the toggle.
+	const firstRow = page.locator('tbody tr').first();
+	await expect(firstRow).toContainText('Account 30');
+
+	// Toggling to ascending must reorder the rows in place: the row order flips, but the shallow
+	// route update means the scroll position stays exactly where it was.
+	await balanceButton.click();
+	await expect(firstRow).toContainText('Account 01');
+	expect(await page.evaluate(() => window.scrollY)).toBe(scrolledY);
+});

--- a/src/lib/sorting.svelte.ts
+++ b/src/lib/sorting.svelte.ts
@@ -1,0 +1,49 @@
+import { replaceState } from '$app/navigation';
+import { page } from '$app/state';
+
+import { setSortInUrl, type SortDirection, type SortState } from './utils';
+
+export class TableSort<T extends string> {
+	column: T | null = $state(null);
+	direction: SortDirection | null = $state(null);
+
+	private _validColumns: readonly T[];
+
+	constructor(validColumns: readonly T[], defaultSort: SortState<T>) {
+		this._validColumns = validColumns;
+		const sortParam = page.url.searchParams.get('sort');
+		const dirParam = page.url.searchParams.get('dir');
+		if (
+			sortParam &&
+			(dirParam === 'asc' || dirParam === 'desc') &&
+			validColumns.includes(sortParam as T)
+		) {
+			this.column = sortParam as T;
+			this.direction = dirParam;
+		} else {
+			this.column = defaultSort.column;
+			this.direction = defaultSort.direction;
+		}
+	}
+
+	get state() {
+		return { column: this.column, direction: this.direction };
+	}
+
+	toggle = (column: string) => {
+		if (!this._validColumns.includes(column as T)) return;
+		if (this.column !== column) {
+			this.column = column as T;
+			this.direction = 'desc';
+		} else if (this.direction === 'desc') {
+			this.direction = 'asc';
+		} else {
+			this.direction = 'desc';
+		}
+		// Shallow routing does not update `page.url`, so read the live URL to keep any other params.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- throwaway URL, not reactive state
+		const path = setSortInUrl(new URL(window.location.href), this.state);
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
+		replaceState(path, {});
+	};
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -67,16 +67,6 @@ export type SortState<T extends string = string> = {
 	direction: SortDirection | null;
 };
 
-export function toggleSort<T extends string>(currentState: SortState<T>, column: T): SortState<T> {
-	if (currentState.column !== column) {
-		return { column, direction: 'desc' };
-	}
-	if (currentState.direction === 'desc') {
-		return { column, direction: 'asc' };
-	}
-	return { column, direction: 'desc' };
-}
-
 export function createSortComparator<T, K extends string>(
 	sortState: SortState<K>,
 	getters: Record<K, (item: T) => string | number | null | undefined>
@@ -102,15 +92,6 @@ export function createSortComparator<T, K extends string>(
 		}
 
 		return sortState.direction === 'asc' ? comparison : -comparison;
-	};
-}
-
-export function getSortFromUrl(url: URL): SortState {
-	const column = url.searchParams.get('sort');
-	const dir = url.searchParams.get('dir');
-	return {
-		column: column || null,
-		direction: dir === 'asc' || dir === 'desc' ? dir : null
 	};
 }
 

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import { SvelteMap } from 'svelte/reactivity';
 
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import Currency, { getCurrencyFxLabel } from '$lib/components/currency.svelte';
 	import Empty from '$lib/components/empty.svelte';
@@ -22,13 +20,8 @@
 	import type { TransactionsResponse } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
 	import { sumOrUnknown } from '$lib/security-balance-values';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, type SortState } from '$lib/utils';
 
 	type BalanceGroup = 'CASH' | 'DEBT' | 'INVESTMENT' | 'OTHER';
 
@@ -98,24 +91,7 @@
 	const validSortColumns: AccountSortColumn[] = ['name', 'institution', 'balance', 'transactions'];
 
 	const defaultSort: SortState<AccountSortColumn> = { column: 'balance', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as AccountSortColumn)
-		) {
-			return urlSort as SortState<AccountSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as AccountSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<AccountSortColumn>(validSortColumns, defaultSort);
 
 	const sortedRows = $derived.by(() => {
 		const rows = accountsContext.accounts.map((account) => ({
@@ -136,7 +112,7 @@
 			isShared: account.isShared
 		}));
 
-		const comparator = createSortComparator<AccountRow, AccountSortColumn>(sortState, {
+		const comparator = createSortComparator<AccountRow, AccountSortColumn>(sort.state, {
 			name: (r) => r.name,
 			institution: (r) => r.institution,
 			balance: (r) => r.balance,
@@ -286,18 +262,18 @@
 											<Table.SortableHead
 												class="text-left whitespace-nowrap"
 												column="name"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.accounts_table_header_account()}
 											</Table.SortableHead>
 											<Table.SortableHead
 												class="text-left whitespace-nowrap"
 												column="institution"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.accounts_table_header_institution()}
 											</Table.SortableHead>
@@ -313,18 +289,18 @@
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="transactions"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.accounts_table_header_transactions()}
 											</Table.SortableHead>
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="balance"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.accounts_table_header_balance()}
 											</Table.SortableHead>

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { getAccountCashflowContext } from '$lib/account-cashflow.svelte';
@@ -40,14 +39,8 @@
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { gainLossPercentOrNull, sentiment, sumOrUnknown } from '$lib/security-balance-values';
 	import { projectSignedValue } from '$lib/sharing';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		toNumber,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, toNumber, type SortState } from '$lib/utils';
 
 	const accountsContext = getAccountsContext();
 	const securitiesContext = getSecuritiesContext();
@@ -368,24 +361,7 @@
 	];
 
 	const defaultSort: SortState<PositionSortColumn> = { column: 'value', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as PositionSortColumn)
-		) {
-			return urlSort as SortState<PositionSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as PositionSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<PositionSortColumn>(validSortColumns, defaultSort);
 
 	const positionsRows = $derived.by(() => {
 		const rows = positionsBalances.map((balance) => ({
@@ -395,7 +371,7 @@
 			nativeCurrency: securitiesContext.getSecurity(balance.securityId)?.currency ?? 'USD'
 		}));
 
-		const comparator = createSortComparator<(typeof rows)[number], PositionSortColumn>(sortState, {
+		const comparator = createSortComparator<(typeof rows)[number], PositionSortColumn>(sort.state, {
 			asOf: (row) => new Date(row.asOf).getTime(),
 			securityName: (row) => row.entityName,
 			quantity: (row) => row.quantity,
@@ -474,7 +450,12 @@
 					isUnconverted={positionsMarketValue.isUnconverted}
 				/>
 			</div>
-			<PositionsTable rows={positionsRows} entity="security" {sortState} onSort={handleSort} />
+			<PositionsTable
+				rows={positionsRows}
+				entity="security"
+				sortState={sort.state}
+				onSort={sort.toggle}
+			/>
 		{:else}
 			<Empty>{m.accounts_overview_positions_empty()}</Empty>
 		{/if}

--- a/src/routes/(app)/assets/+page.svelte
+++ b/src/routes/(app)/assets/+page.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import { SvelteMap } from 'svelte/reactivity';
 
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import { getAssetsContext } from '$lib/assets.svelte';
 	import Currency, { getCurrencyFxLabel } from '$lib/components/currency.svelte';
 	import Empty from '$lib/components/empty.svelte';
@@ -20,14 +18,8 @@
 	import * as Tabs from '$lib/components/ui/tabs/index';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { m } from '$lib/paraglide/messages';
-	import {
-		createSortComparator,
-		formatPercent,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, formatPercent, type SortState } from '$lib/utils';
 
 	type BalanceGroup = 'CASH' | 'DEBT' | 'INVESTMENT' | 'OTHER';
 
@@ -104,24 +96,7 @@
 	];
 
 	const defaultSort: SortState<AssetSortColumn> = { column: 'marketValue', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as AssetSortColumn)
-		) {
-			return urlSort as SortState<AssetSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as AssetSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<AssetSortColumn>(validSortColumns, defaultSort);
 
 	const sortedRows = $derived.by(() => {
 		const rows = assetsContext.assets.map((asset) => ({
@@ -145,7 +120,7 @@
 			nativeCurrency: asset.currency
 		}));
 
-		const comparator = createSortComparator<AssetRow, AssetSortColumn>(sortState, {
+		const comparator = createSortComparator<AssetRow, AssetSortColumn>(sort.state, {
 			name: (r) => r.name,
 			bookValue: (r) => r.bookValue,
 			gain: (r) => r.gain,
@@ -267,9 +242,9 @@
 											<Table.SortableHead
 												class="text-left whitespace-nowrap"
 												column="name"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.assets_table_header_asset()}
 											</Table.SortableHead>
@@ -285,36 +260,36 @@
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="bookValue"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.assets_table_header_book_value()}
 											</Table.SortableHead>
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="gain"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.assets_table_header_gain_loss()}
 											</Table.SortableHead>
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="gainPercent"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.assets_table_header_gain_percent()}
 											</Table.SortableHead>
 											<Table.SortableHead
 												class="text-right whitespace-nowrap"
 												column="marketValue"
-												sortColumn={sortState.column}
-												sortDirection={sortState.direction}
-												onSort={handleSort}
+												sortColumn={sort.column}
+												sortDirection={sort.direction}
+												onSort={sort.toggle}
 											>
 												{m.assets_table_header_market_value()}
 											</Table.SortableHead>

--- a/src/routes/(app)/currencies/+page.svelte
+++ b/src/routes/(app)/currencies/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { formatNativeCurrency } from '$lib/components/currency';
@@ -17,13 +16,8 @@
 	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import type { ExchangeRatesResponse } from '$lib/pocketbase.schema';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, setSortInUrl, type SortState } from '$lib/utils';
 
 	const currenciesContext = getCurrenciesContext();
 	const exchangeRatesContext = getExchangeRatesContext();
@@ -48,24 +42,13 @@
 	];
 
 	const defaultSort: SortState<CurrencySortColumn> = { column: 'code', direction: 'asc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as CurrencySortColumn)
-		) {
-			return urlSort as SortState<CurrencySortColumn>;
-		}
-		return defaultSort;
-	});
+	const sort = new TableSort<CurrencySortColumn>(validSortColumns, defaultSort);
+	// Shallow sort routing leaves `page.url` stale, so rebuild the back-link target from the live sort.
+	const listUrl = $derived(setSortInUrl(page.url, sort.state));
 
 	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as CurrencySortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
+		sort.toggle(column);
 		currentPage = 1;
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
 	}
 
 	function latestQuoteFor(code: string) {
@@ -100,7 +83,7 @@
 			};
 		});
 
-		const comparator = createSortComparator<CurrencyRow, CurrencySortColumn>(sortState, {
+		const comparator = createSortComparator<CurrencyRow, CurrencySortColumn>(sort.state, {
 			code: (r) => r.code,
 			name: (r) => r.name || null,
 			autoUpdate: (r) => (r.isUsd ? null : autoUpdateLabel(r)),
@@ -155,8 +138,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="code"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_code()}
@@ -164,8 +147,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="name"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_name()}
@@ -173,8 +156,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="autoUpdate"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_auto_update()}
@@ -182,8 +165,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="lastUpdated"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_last_updated()}
@@ -191,8 +174,8 @@
 								<Table.SortableHead
 									class="text-right whitespace-nowrap"
 									column="latestQuote"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_latest_quote()}
@@ -204,9 +187,7 @@
 								<Table.Row>
 									<Table.Cell>
 										<Link
-											href={`${resolve(`/currencies/${row.id}`)}?from=${encodeURIComponent(
-												page.url.pathname + page.url.search
-											)}`}
+											href={`${resolve(`/currencies/${row.id}`)}?from=${encodeURIComponent(listUrl)}`}
 											class="text-foreground/90 text-sm font-medium">{row.code}</Link
 										>
 									</Table.Cell>

--- a/src/routes/(app)/currencies/[id]/+page.svelte
+++ b/src/routes/(app)/currencies/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import BalanceHistoryChart from '$lib/components/balance-history-chart.svelte';
 	import { formatNativeCurrency } from '$lib/components/currency';
@@ -16,13 +15,8 @@
 	import { getFormattingLocale } from '$lib/interface-preferences.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import { ExchangeRatesSourceOptions, type ExchangeRatesResponse } from '$lib/pocketbase.schema';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, type SortState } from '$lib/utils';
 
 	const currenciesContext = getCurrenciesContext();
 	const exchangeRatesContext = getExchangeRatesContext();
@@ -47,26 +41,13 @@
 	const validSortColumns: QuoteSortColumn[] = ['date', 'rate', 'source'];
 
 	const defaultSort: SortState<QuoteSortColumn> = { column: 'date', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as QuoteSortColumn)
-		) {
-			return urlSort as SortState<QuoteSortColumn>;
-		}
-		return defaultSort;
-	});
+	const sort = new TableSort<QuoteSortColumn>(validSortColumns, defaultSort);
 
 	let currentPage = $state(1);
 
 	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as QuoteSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
+		sort.toggle(column);
 		currentPage = 1;
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
 	}
 
 	function sourceLabel(source: ExchangeRatesSourceOptions) {
@@ -106,7 +87,7 @@
 			owner: record.owner
 		}));
 
-		const comparator = createSortComparator<QuoteRow, QuoteSortColumn>(sortState, {
+		const comparator = createSortComparator<QuoteRow, QuoteSortColumn>(sort.state, {
 			date: (r) => new Date(r.date).getTime(),
 			rate: (r) => r.rate,
 			source: (r) => sourceLabel(r.source)
@@ -186,8 +167,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="date"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_date()}
@@ -195,8 +176,8 @@
 								<Table.SortableHead
 									class="text-left whitespace-nowrap"
 									column="source"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_source()}
@@ -204,8 +185,8 @@
 								<Table.SortableHead
 									class="text-right whitespace-nowrap"
 									column="rate"
-									sortColumn={sortState.column}
-									sortDirection={sortState.direction}
+									sortColumn={sort.column}
+									sortDirection={sort.direction}
 									onSort={handleSort}
 								>
 									{m.currencies_table_header_rate()}

--- a/src/routes/(app)/portfolio/+page.svelte
+++ b/src/routes/(app)/portfolio/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import Currency from '$lib/components/currency.svelte';
 	import Empty from '$lib/components/empty.svelte';
 	import KeyValue from '$lib/components/key-value.svelte';
@@ -19,14 +17,8 @@
 		gainLossPercentOrNull,
 		sentiment
 	} from '$lib/security-balance-values';
-	import {
-		createSortComparator,
-		formatPercent,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, formatPercent, type SortState } from '$lib/utils';
 
 	const securitiesContext = getSecuritiesContext();
 
@@ -53,27 +45,10 @@
 	];
 
 	const defaultSort: SortState<PortfolioSortColumn> = { column: 'value', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as PortfolioSortColumn)
-		) {
-			return urlSort as SortState<PortfolioSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as PortfolioSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<PortfolioSortColumn>(validSortColumns, defaultSort);
 
 	const sortedRows = $derived.by(() => {
-		const comparator = createSortComparator<SecurityAggregate, PortfolioSortColumn>(sortState, {
+		const comparator = createSortComparator<SecurityAggregate, PortfolioSortColumn>(sort.state, {
 			name: (r) => r.name,
 			symbol: (r) => r.symbol,
 			quantity: (r) => r.quantity,
@@ -147,18 +122,18 @@
 							<Table.SortableHead
 								class="text-left whitespace-nowrap"
 								column="name"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_security()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-left whitespace-nowrap"
 								column="symbol"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_symbol()}
 							</Table.SortableHead>
@@ -168,45 +143,45 @@
 							<Table.SortableHead
 								class="text-right whitespace-nowrap"
 								column="quantity"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_quantity()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-right whitespace-nowrap"
 								column="costBasis"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_cost_basis()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-right whitespace-nowrap"
 								column="gainLoss"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_gain_loss()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-right whitespace-nowrap"
 								column="gainLossPercent"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_gain_loss_percent()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-right whitespace-nowrap"
 								column="value"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_value()}
 							</Table.SortableHead>

--- a/src/routes/(app)/securities/+page.svelte
+++ b/src/routes/(app)/securities/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import Empty from '$lib/components/empty.svelte';
 	import Link from '$lib/components/link.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -12,13 +10,8 @@
 	import { m } from '$lib/paraglide/messages';
 	import type { SecuritiesResponse } from '$lib/pocketbase.schema';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, type SortState } from '$lib/utils';
 
 	const securitiesContext = getSecuritiesContext();
 
@@ -26,27 +19,10 @@
 	const validSortColumns: SecuritiesSortColumn[] = ['name', 'symbol'];
 
 	const defaultSort: SortState<SecuritiesSortColumn> = { column: 'name', direction: 'asc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as SecuritiesSortColumn)
-		) {
-			return urlSort as SortState<SecuritiesSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as SecuritiesSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<SecuritiesSortColumn>(validSortColumns, defaultSort);
 
 	const sortedRows = $derived.by(() => {
-		const comparator = createSortComparator<SecuritiesResponse, SecuritiesSortColumn>(sortState, {
+		const comparator = createSortComparator<SecuritiesResponse, SecuritiesSortColumn>(sort.state, {
 			name: (r) => r.name,
 			symbol: (r) => r.symbol ?? null
 		});
@@ -73,18 +49,18 @@
 							<Table.SortableHead
 								class="text-left whitespace-nowrap"
 								column="name"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_security()}
 							</Table.SortableHead>
 							<Table.SortableHead
 								class="text-left whitespace-nowrap"
 								column="symbol"
-								sortColumn={sortState.column}
-								sortDirection={sortState.direction}
-								onSort={handleSort}
+								sortColumn={sort.column}
+								sortDirection={sort.direction}
+								onSort={sort.toggle}
 							>
 								{m.securities_table_header_symbol()}
 							</Table.SortableHead>

--- a/src/routes/(app)/securities/[id]/+page.svelte
+++ b/src/routes/(app)/securities/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import BalanceHistoryChart from '$lib/components/balance-history-chart.svelte';
 	import { formatNativeCurrency } from '$lib/components/currency';
@@ -15,13 +14,8 @@
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
 	import { getSecuritiesContext, type SecurityAccountBalance } from '$lib/securities.svelte';
 	import { gainLossPercentOrNull, sumOrUnknown } from '$lib/security-balance-values';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, type SortState } from '$lib/utils';
 
 	const securitiesContext = getSecuritiesContext();
 	const fx = getExchangeRatesContext();
@@ -99,27 +93,10 @@
 	];
 
 	const defaultSort: SortState<BalanceSortColumn> = { column: 'value', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as BalanceSortColumn)
-		) {
-			return urlSort as SortState<BalanceSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as BalanceSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<BalanceSortColumn>(validSortColumns, defaultSort);
 
 	const sortedBalances = $derived.by(() => {
-		const comparator = createSortComparator<SecurityAccountBalance, BalanceSortColumn>(sortState, {
+		const comparator = createSortComparator<SecurityAccountBalance, BalanceSortColumn>(sort.state, {
 			asOf: (r) => new Date(r.asOf).getTime(),
 			accountName: (r) => r.accountName,
 			quantity: (r) => r.quantity,
@@ -182,7 +159,12 @@
 				isUnconverted={balancesMarketValue.isUnconverted}
 			/>
 		</div>
-		<PositionsTable rows={sortedBalances} entity="account" {sortState} onSort={handleSort} />
+		<PositionsTable
+			rows={sortedBalances}
+			entity="account"
+			sortState={sort.state}
+			onSort={sort.toggle}
+		/>
 	{:else}
 		<Empty>{m.securities_balances_empty()}</Empty>
 	{/if}

--- a/src/routes/(app)/settings/imports/+page.svelte
+++ b/src/routes/(app)/settings/imports/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import Empty from '$lib/components/empty.svelte';
 	import Fieldset from '$lib/components/fieldset.svelte';
 	import FormFieldRow from '$lib/components/form-field-row.svelte';
@@ -21,13 +19,8 @@
 	import { m } from '$lib/paraglide/messages';
 	import type { ImportSessionsResponse } from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
-	import {
-		createSortComparator,
-		getSortFromUrl,
-		setSortInUrl,
-		toggleSort,
-		type SortState
-	} from '$lib/utils';
+	import { TableSort } from '$lib/sorting.svelte';
+	import { createSortComparator, type SortState } from '$lib/utils';
 
 	const importSessionsContext = getImportSessionsContext();
 	const pb = getPocketBaseContext();
@@ -53,24 +46,7 @@
 	];
 
 	const defaultSort: SortState<SessionSortColumn> = { column: 'created', direction: 'desc' };
-	const sortState = $derived.by(() => {
-		const urlSort = getSortFromUrl(page.url);
-		if (
-			urlSort.column &&
-			urlSort.direction &&
-			validSortColumns.includes(urlSort.column as SessionSortColumn)
-		) {
-			return urlSort as SortState<SessionSortColumn>;
-		}
-		return defaultSort;
-	});
-
-	function handleSort(column: string) {
-		const newState = toggleSort(sortState, column as SessionSortColumn);
-		const newUrl = setSortInUrl(page.url, newState);
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- dynamic URL computed at runtime
-		goto(newUrl, { replaceState: true, keepFocus: true });
-	}
+	const sort = new TableSort<SessionSortColumn>(validSortColumns, defaultSort);
 
 	const sortedRows = $derived.by(() => {
 		const rows: SessionRow[] = importSessionsContext.sessions.map((session) => ({
@@ -83,7 +59,7 @@
 			created: session.created
 		}));
 
-		const comparator = createSortComparator<SessionRow, SessionSortColumn>(sortState, {
+		const comparator = createSortComparator<SessionRow, SessionSortColumn>(sort.state, {
 			label: (r) => r.label,
 			recordsCreated: (r) => r.recordsCreated,
 			recordsSkipped: (r) => r.recordsSkipped,
@@ -139,9 +115,9 @@
 						<Table.SortableHead
 							class="text-left whitespace-nowrap"
 							column="label"
-							sortColumn={sortState.column}
-							sortDirection={sortState.direction}
-							onSort={handleSort}
+							sortColumn={sort.column}
+							sortDirection={sort.direction}
+							onSort={sort.toggle}
 						>
 							{m.settings_imports_table_header_label()}
 						</Table.SortableHead>
@@ -151,36 +127,36 @@
 						<Table.SortableHead
 							class="text-right whitespace-nowrap"
 							column="recordsCreated"
-							sortColumn={sortState.column}
-							sortDirection={sortState.direction}
-							onSort={handleSort}
+							sortColumn={sort.column}
+							sortDirection={sort.direction}
+							onSort={sort.toggle}
 						>
 							{m.settings_imports_table_header_records()}
 						</Table.SortableHead>
 						<Table.SortableHead
 							class="text-right whitespace-nowrap"
 							column="recordsSkipped"
-							sortColumn={sortState.column}
-							sortDirection={sortState.direction}
-							onSort={handleSort}
+							sortColumn={sort.column}
+							sortDirection={sort.direction}
+							onSort={sort.toggle}
 						>
 							{m.settings_imports_table_header_skipped()}
 						</Table.SortableHead>
 						<Table.SortableHead
 							class="text-right whitespace-nowrap"
 							column="recordsFailed"
-							sortColumn={sortState.column}
-							sortDirection={sortState.direction}
-							onSort={handleSort}
+							sortColumn={sort.column}
+							sortDirection={sort.direction}
+							onSort={sort.toggle}
 						>
 							{m.settings_imports_table_header_failed()}
 						</Table.SortableHead>
 						<Table.SortableHead
 							class="text-right whitespace-nowrap"
 							column="created"
-							sortColumn={sortState.column}
-							sortDirection={sortState.direction}
-							onSort={handleSort}
+							sortColumn={sort.column}
+							sortDirection={sort.direction}
+							onSort={sort.toggle}
 						>
 							{m.settings_imports_table_header_created()}
 						</Table.SortableHead>


### PR DESCRIPTION
- Clicking a sort header on the list pages triggered a `goto()` navigation, which reset the scroll position and shifted the layout just to reorder rows already on screen.
- Sorting now updates the URL with SvelteKit shallow routing (`replaceState`), the same approach the transactions table already used, so rows reorder instantly in place.
- Sort state moved from a per-page `$derived` on `page.url` into a shared `TableSort` class (`src/lib/sorting.svelte.ts`), since shallow routing does not update `page.url`; the nine pages that duplicated the old boilerplate now share it.
- Deep links and reload persistence are unchanged: `?sort=`/`?dir=` params are still written on every change and read on load.
- Adds a regression test that scrolls the accounts list, sorts, and asserts the scroll position is preserved; all existing sorting specs pass unchanged.

Closes #397