### PR TITLE
fix: stop carrying stale cost basis across quantity changes

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -46,4 +46,4 @@ bun run build     # Production build
 bun run pb        # PocketBase backend
 ```
 
-Dev servers are owned by the user. Do not run `bun run dev`.
+Assume every existing Vite or PocketBase listener belongs to the user: reuse healthy listeners and never stop or replace them. By default, do not start local servers. Agents may run `bun run dev` or `bun run pb` from the active worktree when explicitly requested; track the process and stop it only if the current agent started it.

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ Canutin is a SvelteKit + PocketBase personal finance application using Bun.
 
 ## Backend: PocketBase
 
-- Dev server: `http://127.0.0.1:42070` by default, run with `bun run pb`, override with `PB_PORT`.
+- Dev server URL, ports, and start commands: see [local-servers](../local-servers/SKILL.md).
 - Types are generated in `src/lib/pocketbase.schema.ts`.
 - Custom Go hooks for balance calculations live in `pocketbase/main.go`.
 - Core collections: accounts, transactions, assets, assetBalances, accountBalances, balanceTypes, transactionLabels, accountShares, assetShares, users.
@@ -46,4 +46,4 @@ bun run build     # Production build
 bun run pb        # PocketBase backend
 ```
 
-Assume every existing Vite or PocketBase listener belongs to the user: reuse healthy listeners and never stop or replace them. By default, do not start local servers. Agents may run `bun run dev` or `bun run pb` from the active worktree when explicitly requested; track the process and stop it only if the current agent started it.
+Server ownership, ports, and start/stop rules live in the [local-servers skill](../local-servers/SKILL.md).

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -25,7 +25,7 @@ Do not rewrite the diff unless the orchestrator explicitly assigns implementatio
 - Edge cases are handled where the changed behavior requires them.
 - Failures are surfaced through the project failures-and-logs pattern.
 - No silent failures, swallowed promises, or user-visible raw error messages.
-- A change that alters behavior documented in a skill (`.agents/skills/`) or the served skill reference (`pocketbase/skill.go`) updates those docs in the same change set - flag it if the docs went stale.
+- A change that alters behavior documented in a skill (`.agents/skills/`) or the served skill reference updates those docs in the same change set - flag it if the docs went stale (see the `pocketbase/skill.go` rule in [pocketbase](../pocketbase/SKILL.md)).
 
 ## Conventions
 

--- a/.agents/skills/failure-discipline/SKILL.md
+++ b/.agents/skills/failure-discipline/SKILL.md
@@ -30,7 +30,7 @@ If CI is failing on infrastructure issues (PocketBase dev server not starting, G
 - **DO** read CI logs and PocketBase logs before diagnosing failures
 - **DO** verify each push succeeded before moving on
 - **DO** stop and report after two consecutive failures
-- **DO** run `bun run quality` and the relevant Playwright project locally before pushing
+- **DO** verify locally before pushing - see [verify](../verify/SKILL.md)
 - **DON'T** push speculative fixes — diagnose from logs first
 - **DON'T** re-trigger CI when it fails on infrastructure issues
 - **DON'T** change test files or timeouts when debugging CI flakiness

--- a/.agents/skills/issue-writing/SKILL.md
+++ b/.agents/skills/issue-writing/SKILL.md
@@ -71,4 +71,4 @@ Before creating the issue, fetch the current repository labels and apply the one
 ## See Also
 
 - [code-quality.md](../code-quality/SKILL.md) - Shared writing and repo conventions
-- [deliver.md](../deliver/SKILL.md) - PR guidance once the issue work is complete
+- [commits-and-prs](../commits-and-prs/SKILL.md) - PR guidance once the issue work is complete

--- a/.agents/skills/local-servers/SKILL.md
+++ b/.agents/skills/local-servers/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: local-servers
+description: Local server ownership, ports, and start/stop rules for Vite and PocketBase
+---
+
+# Local Servers
+
+## Ownership
+
+Assume every existing local listener - Vite dev, Vite preview, PocketBase - belongs to the user: reuse a healthy listener, never stop or replace one you didn't start. Agents may start servers from the active worktree when explicitly requested; track any process you start, and stop only processes the current agent started and tracked. Exception: a Playwright preview server lingering from a crashed test run may be killed only if the current agent started that run - otherwise report the port conflict.
+
+Managed-worktree removal has its own listener-ownership safeguards - see the [setup skill](../setup/SKILL.md).
+
+## Ports
+
+- Vite dev — default `:5173`, overridable via `VITE_PORT`
+- Vite preview — default `:42069`, overridable via `VITE_PREVIEW_PORT` (falls back to `VITE_PORT`)
+- PocketBase — default `:42070`, overridable via `PB_PORT` (`PUBLIC_PB_URL` points the client at the same host)
+
+In a managed worktree, read the actual ports from the worktree's `.env` (or `.worktree.json` if the worktree scripts created it) before curling or opening a browser.
+
+## Commands
+
+```bash
+bun run dev       # Vite dev server
+bun run pb        # PocketBase (compiles the Go binary on first run)
+bun run pb:reset  # Wipe the PocketBase dev database
+```

--- a/.agents/skills/orchestrator/SKILL.md
+++ b/.agents/skills/orchestrator/SKILL.md
@@ -107,7 +107,7 @@ The `Conventions` list on a write template and the `Review lens` list on a revie
 
 A missing convention skill is the most common cause of executor work the user has to send back. When in doubt, include more.
 
-When a write concern's in-bounds files touch PocketBase custom routes, hooks, or import behavior, its `Done when` must include updating `pocketbase/skill.go`'s hand-maintained sections and any affected `.agents/skills/` doc. Those doc updates are part of the concern, not a follow-up.
+When a write concern's in-bounds files touch PocketBase custom routes, hooks, or import behavior, its `Done when` must include the doc updates required by the `pocketbase/skill.go` rule in [pocketbase](../pocketbase/SKILL.md) - part of the concern, not a follow-up.
 
 ## Acceptance gate
 

--- a/.agents/skills/pb-import/SKILL.md
+++ b/.agents/skills/pb-import/SKILL.md
@@ -71,13 +71,13 @@ Consequences you must design for:
 
 ### Nullable numbers on securities (carry-forward)
 
-`securityBalances` and `securityTransactions` number fields (`quantity`, `price`, `value`, `costBasis`, `amount`, `fees`) are **nullable**, and the distinction is load-bearing:
+`securityBalances` and `securityTransactions` number fields (`quantity`, `price`, `value`, `costBasis`, `amount`, `fees`) are **nullable**. `null` (or omitted) means unknown; `0` means a known zero. For `securityBalances` holding snapshots, carry-forward depends on the field:
 
-- **`null` (or omitted) = unknown.** The frontend carries the value forward from the most recent prior snapshot that had a known value.
-- **`0` = a known zero**, not carried forward.
-- **`quantity: 0` closes a position.** Value and cost basis resolve to 0 and carry-forward **stops** at that row (a later re-buy with no fresh value stays unknown, not the old lot's value).
+- **Market value (`value`)** carries forward from the most recent prior snapshot with a known value. **`price` does not carry forward.**
+- **`costBasis`** carries forward only while the current and prior quantities are both known and unchanged. After any quantity-changing event, importers must explicitly provide the resulting `costBasis` when it is known, including after a split; otherwise leave it `null`.
+- **`quantity: 0` closes a position.** Value and cost basis resolve to 0 and carry-forward **stops** at that lot boundary (a later re-buy with no fresh value or cost basis stays unknown, rather than reusing the old lot's data).
 
-Rule of thumb: send `value`/`price`/`costBasis` explicitly on every snapshot you actually know; leave them `null` only when genuinely unknown. **Never emit `0` for an unknown value** — it will be read as a real zero. Post a `quantity: 0` snapshot to close out a holding.
+Rule of thumb: send `value`/`price`/`costBasis` explicitly on every snapshot you actually know; leave them `null` only when genuinely unknown. **Never emit `0` for an unknown value** — it will be read as a real zero. Always send the resulting basis when known after quantity changes, including splits, and post a `quantity: 0` snapshot to close out a holding.
 
 ### currencies[]
 

--- a/.agents/skills/pocketbase/SKILL.md
+++ b/.agents/skills/pocketbase/SKILL.md
@@ -12,10 +12,7 @@ Backend runtime and database for canutin. Custom Go hooks extend PocketBase with
 ## Dev Environment
 
 - Base URL: `http://127.0.0.1:42070` (default; override with `PB_PORT` env var)
-- Assume an existing server belongs to the user; reuse it when healthy and never stop or replace it
-- Agents may start one when explicitly requested; track the process and stop it only if the current agent started it
-- Start/rebuild: `bun run pb` (compiles the Go binary on first run)
-- Reset DB: `bun run pb:reset`
+- Server ownership, ports, and start/reset commands: see [local-servers](../local-servers/SKILL.md)
 - Types auto-generated in `src/lib/pocketbase.schema.ts` on schema changes
 
 ## Authentication
@@ -69,6 +66,10 @@ Pattern for new hooks:
 - Handle account reassignment in update hooks (old and new account)
 - Split into multiple files when `main.go` becomes unwieldy
 
+## Served Skill Reference
+
+`pocketbase/skill.go` hand-maintains the behavioral semantics — custom endpoints, behavioral constraints, auth — of the `/api/canutin/skill` reference; the import payload shape is generated from the Go structs. Update the hand-maintained sections whenever custom routes or backend hooks change. CI enforces this: a change under `pocketbase/**/*.go` without a matching `pocketbase/skill.go` or `.agents/skills/` update fails the PR unless labeled `skip-skill-check`.
+
 ## Schema Changes
 
 - **Never** write migration files by hand
@@ -79,7 +80,7 @@ Pattern for new hooks:
 
 - **Dev credentials in production** — these are for local development only
 - **Hand-written migrations** — always go through the admin API
-- **Starting PocketBase by default** — reuse a healthy existing listener; start one only when explicitly requested
+- **Starting PocketBase by default** — follow the ownership rules in [local-servers](../local-servers/SKILL.md)
 - **Raw `app.Save()` Go calls for schema** — use the collection API endpoints so automigrate hooks fire
 
 ## See Also

--- a/.agents/skills/pocketbase/SKILL.md
+++ b/.agents/skills/pocketbase/SKILL.md
@@ -12,7 +12,8 @@ Backend runtime and database for canutin. Custom Go hooks extend PocketBase with
 ## Dev Environment
 
 - Base URL: `http://127.0.0.1:42070` (default; override with `PB_PORT` env var)
-- Server is always running in background — don't start it
+- Assume an existing server belongs to the user; reuse it when healthy and never stop or replace it
+- Agents may start one when explicitly requested; track the process and stop it only if the current agent started it
 - Start/rebuild: `bun run pb` (compiles the Go binary on first run)
 - Reset DB: `bun run pb:reset`
 - Types auto-generated in `src/lib/pocketbase.schema.ts` on schema changes
@@ -78,7 +79,7 @@ Pattern for new hooks:
 
 - **Dev credentials in production** — these are for local development only
 - **Hand-written migrations** — always go through the admin API
-- **Starting the PB server** — it's already running; don't start it
+- **Starting PocketBase by default** — reuse a healthy existing listener; start one only when explicitly requested
 - **Raw `app.Save()` Go calls for schema** — use the collection API endpoints so automigrate hooks fire
 
 ## See Also

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -103,11 +103,11 @@ bun run test -- e2e/file.test.ts --repeat-each=10
 
 Wait for each test run to finish before starting the next. Two test commands running at the same time fight over the same backend and preview server and produce false flake. To run several files together, pass them to a single Playwright invocation instead of launching multiple processes.
 
-If a previous run ended early (Ctrl-C, killed terminal, crashed reporter), the preview server may linger and the next run will fail to bind. Assume any existing preview, dev, or backend listener belongs to the user. Stop only a server process the current agent started and tracked; otherwise report the port conflict instead of killing the listener.
+If a previous run ended early (Ctrl-C, killed terminal, crashed reporter), the preview server may linger and the next run will fail to bind. Ownership rules for existing listeners: see [local-servers](../local-servers/SKILL.md).
 
 ### Local verification before push
 
-Run one or two targeted smoke tests related to the change before pushing - never the full file when a focused `-g` pattern covers the behavior you actually touched. CI will run the whole suite; your job locally is to catch the obvious regression cheaply.
+The full pre-push workflow (quality checks plus Playwright) lives in [verify](../verify/SKILL.md). Locally, run one or two targeted smoke tests related to the change - never the full file when a focused `-g` pattern covers the behavior you actually touched. CI will run the whole suite; your job locally is to catch the obvious regression cheaply.
 
 ```bash
 bun run test -- -g 'name of the test you care about'
@@ -134,6 +134,6 @@ Test code follows the same rules as production code (see [code-quality](../code-
 
 ## Troubleshooting
 
-- **Preview server port already in use** - check the port in `.env` or `.worktree.json`. Stop and rerun only if the current agent started and tracked that preview process; otherwise report the conflict because the listener is user-owned.
-- **PocketBase port already in use** - check `.env` or `.worktree.json` for the actual `PB_PORT` and reuse a healthy listener. Do not stop it because existing backend listeners are user-owned.
+- **Preview server port already in use** - check the port in `.env` or `.worktree.json`; follow the ownership rules in [local-servers](../local-servers/SKILL.md) before stopping anything.
+- **PocketBase port already in use** - check `.env` or `.worktree.json` for the actual `PB_PORT` and reuse a healthy listener per [local-servers](../local-servers/SKILL.md).
 - **Generated messages missing** - run the relevant quality/build command so Paraglide regenerates output; do not hand-edit generated files.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -103,7 +103,7 @@ bun run test -- e2e/file.test.ts --repeat-each=10
 
 Wait for each test run to finish before starting the next. Two test commands running at the same time fight over the same backend and preview server and produce false flake. To run several files together, pass them to a single Playwright invocation instead of launching multiple processes.
 
-If a previous run ended early (Ctrl-C, killed terminal, crashed reporter) the preview server may linger and the next run will fail to bind. Killing a preview server is always safe - preview only exists to serve tests. Never kill a dev server or backend server; the user owns those.
+If a previous run ended early (Ctrl-C, killed terminal, crashed reporter), the preview server may linger and the next run will fail to bind. Assume any existing preview, dev, or backend listener belongs to the user. Stop only a server process the current agent started and tracked; otherwise report the port conflict instead of killing the listener.
 
 ### Local verification before push
 
@@ -134,6 +134,6 @@ Test code follows the same rules as production code (see [code-quality](../code-
 
 ## Troubleshooting
 
-- **Preview server port already in use** - Playwright's preview server lingered from a previous run that ended early. Kill it and rerun after checking the port in `.env` or `.worktree.json`. Preview servers are always safe to kill. Never apply this to a dev or backend server - those belong to the user.
-- **PocketBase port already in use** - check `.env` or `.worktree.json` for the actual `PB_PORT`. Do not kill the user's main dev backend.
+- **Preview server port already in use** - check the port in `.env` or `.worktree.json`. Stop and rerun only if the current agent started and tracked that preview process; otherwise report the conflict because the listener is user-owned.
+- **PocketBase port already in use** - check `.env` or `.worktree.json` for the actual `PB_PORT` and reuse a healthy listener. Do not stop it because existing backend listeners are user-owned.
 - **Generated messages missing** - run the relevant quality/build command so Paraglide regenerates output; do not hand-edit generated files.

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -7,17 +7,11 @@ description: Local verification workflow - quality checks, running Playwright te
 
 ## Overview
 
-Before handing work off (see [deliver.md](../deliver/SKILL.md)), verify against local PocketBase and the local SvelteKit preview. Canutin has no preview-deployment system; all verification is local.
+Before handing work off (see [commits-and-prs.md](../commits-and-prs/SKILL.md)), verify against local PocketBase and the local SvelteKit preview. Canutin has no preview-deployment system; all verification is local.
 
 ## Local Servers
 
-PocketBase and Vite may already be running in the background. Assume every existing listener belongs to the user: reuse healthy listeners and never stop or replace them. Agents may launch Vite or PocketBase when explicitly requested; before doing so, check the ports from the worktree's `.env` (or `.worktree.json` if the worktree scripts created it), and track the process. Stop only processes the current agent started and tracked.
-
-- Vite dev — default `:5173`, overridable via `VITE_PORT`
-- Vite preview — default `:42069`, overridable via `VITE_PREVIEW_PORT` (falls back to `VITE_PORT`)
-- PocketBase — default `:42070`, overridable via `PB_PORT` (`PUBLIC_PB_URL` points the client at the same host)
-
-Check the worktree's `.env` for the actual numbers before curling or opening a browser.
+Verification runs against the local Vite and PocketBase servers. Ownership rules, ports, and start commands: see [local-servers](../local-servers/SKILL.md).
 
 ## Quality Check
 
@@ -57,5 +51,5 @@ Wipes the PocketBase dev database. The superuser (`superadmin@example.com` / `12
 ## See Also
 
 - [testing.md](../testing/SKILL.md) - Playwright conventions
-- [deliver.md](../deliver/SKILL.md) - PR handoff
+- [commits-and-prs.md](../commits-and-prs/SKILL.md) - PR handoff
 - [failure-discipline.md](../failure-discipline/SKILL.md) - What to do when something fails

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -11,7 +11,7 @@ Before handing work off (see [deliver.md](../deliver/SKILL.md)), verify against 
 
 ## Local Servers
 
-PocketBase and Vite dev are always running in the background. Do not start them. In a worktree, they run on the ports from the worktree's `.env` (or `.worktree.json` if the worktree scripts created it):
+PocketBase and Vite may already be running in the background. Assume every existing listener belongs to the user: reuse healthy listeners and never stop or replace them. Agents may launch Vite or PocketBase when explicitly requested; before doing so, check the ports from the worktree's `.env` (or `.worktree.json` if the worktree scripts created it), and track the process. Stop only processes the current agent started and tracked.
 
 - Vite dev — default `:5173`, overridable via `VITE_PORT`
 - Vite preview — default `:42069`, overridable via `VITE_PREVIEW_PORT` (falls back to `VITE_PORT`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ The checkout at the repository root is the primary worktree and control plane. K
 
 > **Warning:** Never run double-force Git clean with ignored files from the primary checkout, such as `git clean -ffdx`. It can delete the nested `/.worktrees/` checkouts.
 
+## Local servers
+
+Assume existing local servers belong to the user: do not start, stop, or replace them by default. When the user explicitly asks, agents may start Vite (`bun run dev`) and PocketBase (`bun run pb`) from the active managed worktree. Check the worktree's assigned ports and existing listeners first, reuse healthy servers, and track any processes you start. For ordinary agent actions, stop only processes that the agent started and tracked; never terminate a foreign process. Managed worktree removal is governed separately by the [setup skill](./.agents/skills/setup/SKILL.md) and the manager's ownership safeguards.
+
 ## Your role
 
 Before you call any other tool, read any other file, or respond to the user, open your role skill. The skill body is not auto-injected - opening it is your first action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,7 @@ Canutin is a personal finance application: SvelteKit on the frontend, PocketBase
 
 > This file is `AGENTS.md`. `CLAUDE.md` is a symlink to it - edit `AGENTS.md`.
 
-## Worktree workflow
-
-The checkout at the repository root is the primary worktree and control plane. Keep it on `next`, use it to manage linked worktrees, and do not do feature work there. Create or resume feature work in managed checkouts under `/.worktrees/` as documented in the [setup skill](./.agents/skills/setup/SKILL.md); the manager can be invoked from either the primary worktree or a linked worktree.
-
-> **Warning:** Never run double-force Git clean with ignored files from the primary checkout, such as `git clean -ffdx`. It can delete the nested `/.worktrees/` checkouts.
-
-## Local servers
-
-Assume existing local servers belong to the user: do not start, stop, or replace them by default. When the user explicitly asks, agents may start Vite (`bun run dev`) and PocketBase (`bun run pb`) from the active managed worktree. Check the worktree's assigned ports and existing listeners first, reuse healthy servers, and track any processes you start. For ordinary agent actions, stop only processes that the agent started and tracked; never terminate a foreign process. Managed worktree removal is governed separately by the [setup skill](./.agents/skills/setup/SKILL.md) and the manager's ownership safeguards.
+Feature work happens in managed worktrees under `/.worktrees/` - see the [setup skill](./.agents/skills/setup/SKILL.md).
 
 ## Your role
 
@@ -62,6 +54,7 @@ Each skill lives at `.agents/skills/<slug>/SKILL.md`.
 | Synopsis                                               | Slug               |
 | ------------------------------------------------------ | ------------------ |
 | How to create and reuse worktrees for autonomous work  | setup              |
+| Local server ownership, ports, and start/stop rules    | local-servers      |
 | How to verify changes locally before requesting review | verify             |
 | How to diagnose failed checks and avoid wasting CI     | failure-discipline |
 | How to change PocketBase schema safely                 | pb-migrate         |
@@ -82,9 +75,3 @@ Load when your tool list matches the harness. The agent must check tool availabi
 | ---------------------------------------------------------------------------------------- | -------- |
 | Harness-specific quirks for Codex sessions - spawn_agent rules and validation gotchas    | codex    |
 | Harness-specific quirks for opencode sessions - plan mode rules and delegation reminders | opencode |
-
-> `pocketbase/skill.go` hand-maintains the behavioral semantics - custom endpoints, behavioral
-> constraints, and auth - of the `/api/canutin/skill` reference; the import payload shape is
-> generated from the Go structs. Update the hand-maintained sections whenever custom routes or
-> backend hooks change. CI enforces this: a change under `pocketbase/**/*.go` without a matching
-> `pocketbase/skill.go` or `.agents/skills/` update fails the PR unless labeled `skip-skill-check`.

--- a/e2e/portfolio.test.ts
+++ b/e2e/portfolio.test.ts
@@ -17,6 +17,7 @@ import {
 	getUserPB,
 	seedAccount,
 	seedAccountBalance,
+	seedCurrency,
 	seedSecurity,
 	seedSecurityBalance,
 	seedTrade,
@@ -425,7 +426,225 @@ test('portfolio hides sold-out positions while preserving activity history', asy
 	await expect(page.getByRole('row', { name: /Exit Round Trip Stock/ })).toBeVisible();
 });
 
-test('portfolio carries a re-buy after a sell-out forward as unknown', async ({ page }) => {
+test('portfolio carries basis only across unchanged quantities', async ({ page }) => {
+	const user = await seedUser('cassia');
+	const growthAccount = await seedAccount({
+		name: 'Growth Brokerage',
+		balanceGroup: AccountsBalanceGroupOptions.INVESTMENT,
+		owner: user.id,
+		balanceType: 'Brokerage'
+	});
+	const stableAccount = await seedAccount({
+		name: 'Stable Brokerage',
+		balanceGroup: AccountsBalanceGroupOptions.INVESTMENT,
+		owner: user.id,
+		balanceType: 'Brokerage'
+	});
+	const changedSecurity = await seedSecurity({
+		name: 'Changed Basis Fund',
+		symbol: 'CBF',
+		owner: user.id
+	});
+	const partialSaleSecurity = await seedSecurity({
+		name: 'Partial Sale Fund',
+		symbol: 'PSF',
+		owner: user.id
+	});
+	const splitSecurity = await seedSecurity({
+		name: 'Split Fund',
+		symbol: 'SPF',
+		owner: user.id
+	});
+	const unknownQuantitySecurity = await seedSecurity({
+		name: 'Unknown Quantity Fund',
+		symbol: 'UQF',
+		owner: user.id
+	});
+	await seedCurrency({ owner: user.id, code: 'ARS', name: 'Argentine peso', autoUpdate: false });
+	const missingFxSecurity = await seedSecurity({
+		name: 'Missing FX Basis Fund',
+		symbol: 'MFX',
+		owner: user.id
+	});
+	const pb = await getUserPB(user.email);
+	await pb.collection('securities').update(missingFxSecurity.id, { currency: 'ARS' });
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: changedSecurity.id,
+		asOf: '2026-01-01 00:00:00.000Z',
+		quantity: 10,
+		price: 10,
+		value: 100,
+		costBasis: 80
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: changedSecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: 15,
+		price: 10,
+		value: 150,
+		costBasis: null
+	});
+	await seedSecurityBalance({
+		account: stableAccount.id,
+		owner: user.id,
+		security: changedSecurity.id,
+		asOf: '2026-01-01 00:00:00.000Z',
+		quantity: 5,
+		price: 10,
+		value: 50,
+		costBasis: 40
+	});
+	await seedSecurityBalance({
+		account: stableAccount.id,
+		owner: user.id,
+		security: changedSecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: 5,
+		price: 12,
+		value: 60,
+		costBasis: null
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: partialSaleSecurity.id,
+		asOf: '2026-01-01 00:00:00.000Z',
+		quantity: 20,
+		price: 10,
+		value: 200,
+		costBasis: 160
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: partialSaleSecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: 12,
+		price: null,
+		value: null,
+		costBasis: null
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: splitSecurity.id,
+		asOf: '2026-01-01 00:00:00.000Z',
+		quantity: 2,
+		price: 50,
+		value: 100,
+		costBasis: 80
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: splitSecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: 4,
+		price: 60,
+		value: 240,
+		costBasis: null
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: unknownQuantitySecurity.id,
+		asOf: '2026-01-01 00:00:00.000Z',
+		quantity: 3,
+		price: 30,
+		value: 90,
+		costBasis: 60
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: unknownQuantitySecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: null,
+		price: null,
+		value: null,
+		costBasis: 70
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: unknownQuantitySecurity.id,
+		asOf: '2026-03-01 00:00:00.000Z',
+		quantity: null,
+		price: null,
+		value: null,
+		costBasis: null
+	});
+	await seedSecurityBalance({
+		account: growthAccount.id,
+		owner: user.id,
+		security: missingFxSecurity.id,
+		asOf: '2026-02-01 00:00:00.000Z',
+		quantity: 2,
+		price: 500,
+		value: 1000,
+		costBasis: null
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Portfolio');
+	const changedRow = page.getByRole('row', { name: /Changed Basis Fund/ });
+	await expect(changedRow.locator('td').nth(3)).toHaveText('20');
+	await expect(changedRow.locator('td').nth(4)).toHaveText('~');
+	await expect(changedRow.locator('td').nth(5)).toHaveText('~');
+	await expect(changedRow.locator('td').nth(6)).toHaveText('~');
+	await expect(changedRow.locator('td').last()).toHaveText('$210.00');
+
+	const partialSaleRow = page.getByRole('row', { name: /Partial Sale Fund/ });
+	await expect(partialSaleRow.locator('td').nth(4)).toHaveText('~');
+	await expect(partialSaleRow.locator('td').nth(5)).toHaveText('~');
+	await expect(partialSaleRow.locator('td').nth(6)).toHaveText('~');
+	await expect(partialSaleRow.locator('td').last()).toHaveText('$200.00');
+
+	const splitRow = page.getByRole('row', { name: /Split Fund/ });
+	await expect(splitRow.locator('td').nth(4)).toHaveText('~');
+	await expect(splitRow.locator('td').nth(5)).toHaveText('~');
+	await expect(splitRow.locator('td').nth(6)).toHaveText('~');
+	await expect(splitRow.locator('td').last()).toHaveText('$240.00');
+
+	const unknownQuantityRow = page.getByRole('row', { name: /Unknown Quantity Fund/ });
+	await expect(unknownQuantityRow.locator('td').nth(3)).toHaveText('~');
+	await expect(unknownQuantityRow.locator('td').nth(4)).toHaveText('~');
+	await expect(unknownQuantityRow.locator('td').nth(5)).toHaveText('~');
+	await expect(unknownQuantityRow.locator('td').nth(6)).toHaveText('~');
+	await expect(unknownQuantityRow.locator('td').last()).toHaveText('$90.00');
+
+	const missingFxRow = page.getByRole('row', { name: /Missing FX Basis Fund/ });
+	await expect(missingFxRow.locator('td').nth(4)).toHaveText('~');
+	await expect(missingFxRow.locator('td').nth(5)).toHaveText('~');
+	await expect(missingFxRow.locator('td').nth(6)).toHaveText('~');
+	await expect(missingFxRow.locator('td').last()).toHaveText('$0.00');
+	await expect(
+		missingFxRow.locator('td').last().getByLabel('Includes currencies that could not be converted')
+	).toBeVisible();
+	await expect(page.getByRole('region', { name: 'Net gain/loss' })).toHaveText(/~/);
+	await expect(page.getByRole('region', { name: 'Net gain %' })).toHaveText(/~/);
+	await expect(page.getByRole('region', { name: 'Net market value' })).toContainText('$740.00');
+
+	await changedRow.getByRole('link', { name: 'Changed Basis Fund' }).click();
+	const growthRow = page.getByRole('row', { name: /Growth Brokerage/ });
+	await expect(growthRow.locator('td').nth(4)).toHaveText('~');
+	await expect(growthRow.locator('td').nth(5)).toHaveText('~');
+	await expect(growthRow.locator('td').nth(6)).toHaveText('~');
+	await expect(growthRow.locator('td').last()).toHaveText('$150.00');
+
+	const stableRow = page.getByRole('row', { name: /Stable Brokerage/ });
+	await expect(stableRow.locator('td').nth(4)).toHaveText('$40.00');
+	await expect(stableRow.locator('td').nth(5)).toHaveText('$20.00');
+	await expect(stableRow.locator('td').nth(6)).toHaveText('+50.0%');
+	await expect(stableRow.locator('td').last()).toHaveText('$60.00');
+});
+
+test('portfolio stops carry-forward after a sell-out and re-buy', async ({ page }) => {
 	const user = await seedUser('wren');
 	const account = await seedAccount({
 		name: 'Rebuy Brokerage',
@@ -470,6 +689,9 @@ test('portfolio carries a re-buy after a sell-out forward as unknown', async ({ 
 	await goToPageViaSidebar(page, 'Portfolio');
 	const row = page.getByRole('row', { name: /Rebought Stock/ });
 	await expect(row).toContainText('RBT');
+	await expect(row.locator('td').nth(4)).toHaveText('~');
+	await expect(row.locator('td').nth(5)).toHaveText('~');
+	await expect(row.locator('td').nth(6)).toHaveText('~');
 	await expect(row.locator('td').last()).toHaveText('~');
 
 	await row.getByRole('link', { name: 'Rebought Stock' }).click();

--- a/e2e/portfolio.test.ts
+++ b/e2e/portfolio.test.ts
@@ -461,13 +461,13 @@ test('portfolio carries basis only across unchanged quantities', async ({ page }
 		owner: user.id
 	});
 	await seedCurrency({ owner: user.id, code: 'ARS', name: 'Argentine peso', autoUpdate: false });
-	const missingFxSecurity = await seedSecurity({
+	const pb = await getUserPB(user.email);
+	const missingFxSecurity = await pb.collection('securities').create({
 		name: 'Missing FX Basis Fund',
 		symbol: 'MFX',
-		owner: user.id
+		owner: user.id,
+		currency: 'ARS'
 	});
-	const pb = await getUserPB(user.email);
-	await pb.collection('securities').update(missingFxSecurity.id, { currency: 'ARS' });
 	await seedSecurityBalance({
 		account: growthAccount.id,
 		owner: user.id,

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -144,10 +144,15 @@ Backend hooks enforce invariants that are not visible in the access rules:
   ` + "`securityBalances`" + ` holding snapshots. Holdings come exclusively from ` + "`securityBalances`" + `;
   ` + "`securityTransactions`" + ` are display-only trade history that never affect balances. Writing
   portfolio value into an account balance double-counts it.
-- Number fields on ` + "`securityBalances`" + ` and ` + "`securityTransactions`" + ` are nullable and the
-  distinction matters: ` + "`null`" + ` (or an omitted field) means unknown and is carried forward from the
-  last known snapshot, ` + "`0`" + ` is a known zero, and ` + "`quantity = 0`" + ` closes a position and stops
-  carry-forward. Never send ` + "`0`" + ` for a value you do not know.
+- Number fields on ` + "`securityBalances`" + ` and ` + "`securityTransactions`" + ` are nullable:
+  ` + "`null`" + ` (or an omitted field) means unknown, while ` + "`0`" + ` is a known zero. When resolving
+  ` + "`securityBalances`" + ` snapshots, market value (` + "`value`" + `) carries forward from the most recent
+  known value, while ` + "`price`" + ` does not carry forward. ` + "`costBasis`" + ` carries forward only while
+  the current and prior quantities are both known and unchanged. After a quantity-changing event,
+  importers must explicitly provide the resulting basis when known, including after a split; otherwise
+  leave it ` + "`null`" + `. ` + "`quantity = 0`" + `
+  closes the position, resolves value and basis to zero, and stops carry-forward at that lot boundary, so
+  a later re-buy cannot reuse the old lot's data. Never send ` + "`0`" + ` for a value you do not know.
 - Setting ` + "`autoCalculated`" + ` on an account makes the engine recompute its latest cash balance by
   summing imported cash transactions into a new ` + "`source = derived`" + ` row stamped with the current
   time, which overrides any imported cash snapshot and re-fires on later transaction edits. Leave it

--- a/src/lib/securities.svelte.ts
+++ b/src/lib/securities.svelte.ts
@@ -395,7 +395,9 @@ class SecuritiesContext {
 			balances.map((balance) => (balance.isUnconverted ? 0 : balance.value))
 		);
 		const costBasis = sumOrUnknown(
-			balances.map((balance) => (balance.isUnconverted ? 0 : balance.costBasis))
+			balances.map((balance) =>
+				balance.isUnconverted && balance.costBasis !== null ? 0 : balance.costBasis
+			)
 		);
 
 		return {

--- a/src/lib/security-balance-values.ts
+++ b/src/lib/security-balance-values.ts
@@ -91,12 +91,13 @@ export function resolveSecurityBalanceValues(balances: SecurityBalanceValueInput
 		// means UNKNOWN (no recorded value) - distinct from a known `0`. This differs from
 		// assetBalances, which uses native number fields and has no unknown state. This resolver
 		// must therefore preserve `null` as unknown and never coerce it to `0`.
-		if (toNumber(latest.quantity) === 0) {
+		const latestQuantity = toNumber(latest.quantity);
+		if (latestQuantity === 0) {
 			resolved.set(key, { balance: latest, value: 0, costBasis: 0 });
 			continue;
 		}
 
-		// The latest holding has quantity > 0 but possibly no recorded value. Carry forward the
+		// The latest holding is not sold out but possibly has no recorded value. Carry forward the
 		// most recent known value, but stop at a sold-out (quantity 0) balance: its `0` belongs to
 		// the prior lot, so a re-bought holding with no fresh value is genuinely UNKNOWN, not 0.
 		let value = toNumber(latest.value);
@@ -112,9 +113,9 @@ export function resolveSecurityBalanceValues(balances: SecurityBalanceValueInput
 		}
 
 		let costBasis = toNumber(latest.costBasis);
-		if (costBasis === null) {
+		if (costBasis === null && latestQuantity !== null) {
 			for (const balance of sorted) {
-				if (toNumber(balance.quantity) === 0) break;
+				if (toNumber(balance.quantity) !== latestQuantity) break;
 				const known = toNumber(balance.costBasis);
 				if (known !== null) {
 					costBasis = known;


### PR DESCRIPTION
- Stops cost-basis carry-forward when quantity changes while preserving carry-forward for unchanged quantities and zero-quantity lot boundaries.
- Propagates unknown basis through per-security and portfolio aggregate gain/loss, including positions with missing FX conversion.
- Adds portfolio coverage for additional purchases, partial sales, splits, unknown quantities, sell-out/re-buy boundaries, and quantity-neutral snapshots.
- Updates importer and PocketBase skill guidance, and clarifies agent policy for ownership of local server processes.
- Validation: full diff and both commits reviewed against `origin/next`; whitespace checks passed and the changed-content secret scan found no credentials. Runtime E2E was not rerun during this Git/GitHub-only shipping pass; the added scenarios remain for CI validation.

Closes #403