### PR TITLE
fix: prevent trends reconnect from freezing five charts

### DIFF
--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -444,6 +444,7 @@ test('trends performance table', async ({ page }) => {
 	await page.mouse.up();
 	await expect(page.getByText(debtShrinkCompareHeader)).not.toBeVisible();
 
+	await expect(page.locator('[data-growth-chart], [data-group-chart]')).toHaveCount(5);
 	const observation = await page.evaluateHandle(() => {
 		const state = { mutations: 0 };
 		const observer = new MutationObserver((records) => (state.mutations += records.length));
@@ -456,24 +457,18 @@ test('trends performance table', async ({ page }) => {
 			});
 		return { observer, state };
 	});
-	await expect(page.locator('[data-growth-chart], [data-group-chart]')).toHaveCount(5);
 
-	let trendHistoryRequests = 0;
-	page.on('requestfinished', (request) => {
-		const url = new URL(request.url());
-		if (request.method() !== 'GET') return;
-		if (
-			(url.pathname.endsWith('/api/collections/accountBalances/records') &&
-				url.searchParams.get('fields') === 'id,account,value,asOf,created') ||
-			(url.pathname.endsWith('/api/collections/securityBalances/records') &&
-				url.searchParams.get('fields') === 'id,account,security,value,quantity,asOf,created') ||
-			(url.pathname.endsWith('/api/collections/assetBalances/records') &&
-				url.searchParams.get('fields') === 'id,asset,marketValue,asOf,created')
-		)
-			trendHistoryRequests++;
-	});
-	await page.evaluate(() => window.dispatchEvent(new Event('online')));
-	await expect.poll(() => trendHistoryRequests).toBe(12);
+	await Promise.all([
+		page.waitForResponse((response) => {
+			const url = new URL(response.url());
+			return (
+				response.request().method() === 'GET' &&
+				url.pathname.endsWith('/api/collections/accountBalances/records') &&
+				url.searchParams.get('filter')?.includes('asOf<') === true
+			);
+		}),
+		page.evaluate(() => window.dispatchEvent(new Event('online')))
+	]);
 	const recoveryMutations = await observation.evaluate(async ({ observer, state }) => {
 		await new Promise<void>((resolve) =>
 			requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
@@ -484,62 +479,30 @@ test('trends performance table', async ({ page }) => {
 	});
 	expect(recoveryMutations).toBe(0);
 
-	// Hold the first full-history response after it captures 9,000. A second balance event must
-	// invalidate that request immediately and let its debounced replacement commit 10,000.
-	const { promise: historyGate, resolve: releaseHistory } = Promise.withResolvers<void>();
-	const { promise: historyHeld, resolve: resolveHistoryHeld } = Promise.withResolvers<void>();
-	const seedTodayCashBalance = (value: number) =>
-		seedAccountBalance({
-			account: cashAccount.id,
-			owner: user.id,
-			asOf: todayStart.toISOString(),
-			value
-		});
-	await page.route(
-		(url) =>
-			url.pathname.endsWith('/api/collections/accountBalances/records') &&
-			url.searchParams.get('fields') === 'id,account,value,asOf,created' &&
-			!url.searchParams.get('filter')?.includes('asOf'),
-		async (route) => {
-			const response = await route.fetch();
-			resolveHistoryHeld();
-			await historyGate;
-			return route.fulfill({ response });
-		},
-		{ times: 1 }
-	);
-	await seedTodayCashBalance(9000);
-	await historyHeld;
-
-	await seedTodayCashBalance(10000);
-	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
-
-	// Releasing the stale 9,000 response cannot overwrite the replacement's 10,000 snapshot.
-	releaseHistory();
-	await expect.poll(() => trendHistoryRequests).toBe(36);
-	await page.evaluate(
-		() =>
-			new Promise<void>((resolve) =>
-				requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-			)
-	);
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
-	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
-	await observation.evaluate(({ observer, state }) => {
-		observer.takeRecords();
-		state.mutations = 0;
-	});
-
 	const { promise: realtimeGate, resolve: releaseRealtime } = Promise.withResolvers<void>();
-	await page.route('**/api/realtime', (route) => realtimeGate.then(() => route.continue()));
+	const { promise: realtimeHeld, resolve: resolveRealtimeHeld } = Promise.withResolvers<void>();
+	await page.route('**/api/realtime', async (route) => {
+		resolveRealtimeHeld();
+		await realtimeGate;
+		await route.continue();
+	});
 	await page.evaluate(() => {
 		const sources = (window as unknown as { __realtimeSources: EventSource[] }).__realtimeSources;
 		for (const source of sources) source.dispatchEvent(new Event('error'));
 	});
-	await seedTodayCashBalance(11000);
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
-	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
+	await realtimeHeld;
+	await seedAccountBalance({
+		account: cashAccount.id,
+		owner: user.id,
+		asOf: todayStart.toISOString(),
+		value: 11000
+	});
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '5000');
+	await expect(cashCells.nth(8).getByRole('button', { name: '+700%' })).toBeVisible();
+	await observation.evaluate(({ observer, state }) => {
+		observer.takeRecords();
+		state.mutations = 0;
+	});
 
 	releaseRealtime();
 	await expect(maxChart).toHaveAttribute('data-chart-end-value', '8000');
@@ -550,5 +513,4 @@ test('trends performance table', async ({ page }) => {
 		return mutations;
 	});
 	expect(changedRecoveryMutations).toBeGreaterThan(0);
-	expect(trendHistoryRequests).toBe(48);
 });

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -15,6 +15,8 @@ import {
 	seedUser
 } from './pocketbase.helpers';
 
+test.skip(({ isMobile }) => isMobile, 'Trends performance table is desktop-only');
+
 test('trends performance table', async ({ page }) => {
 	const user = await seedUser('steve');
 
@@ -491,7 +493,7 @@ test('trends performance table', async ({ page }) => {
 		for (const source of sources) source.dispatchEvent(new Event('error'));
 	});
 	await realtimeHeld;
-	await seedAccountBalance({
+	const missedBalance = await seedAccountBalance({
 		account: cashAccount.id,
 		owner: user.id,
 		asOf: todayStart.toISOString(),
@@ -504,7 +506,34 @@ test('trends performance table', async ({ page }) => {
 		state.mutations = 0;
 	});
 
+	const recoveredBalanceHistory = page.waitForResponse(async (response) => {
+		const url = new URL(response.url());
+		if (
+			response.request().method() !== 'GET' ||
+			!url.pathname.endsWith('/api/collections/accountBalances/records') ||
+			url.searchParams.get('fields') !== 'id,account,value,asOf,created'
+		)
+			return false;
+
+		const body: unknown = await response.json();
+		return (
+			typeof body === 'object' &&
+			body !== null &&
+			'items' in body &&
+			Array.isArray(body.items) &&
+			body.items.some(
+				(item: unknown) =>
+					typeof item === 'object' &&
+					item !== null &&
+					'id' in item &&
+					item.id === missedBalance.id &&
+					'value' in item &&
+					item.value === missedBalance.value
+			)
+		);
+	});
 	releaseRealtime();
+	await recoveredBalanceHistory;
 	await expect(maxChart).toHaveAttribute('data-chart-end-value', '8000');
 	await expect(cashCells.nth(8).getByRole('button', { name: '+1,000%' })).toBeVisible();
 	const changedRecoveryMutations = await observation.evaluate(({ observer, state }) => {

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -15,22 +15,9 @@ import {
 	seedUser
 } from './pocketbase.helpers';
 
-test.skip(({ isMobile }) => isMobile, 'Trends performance table is desktop-only');
-
 test('trends performance table', async ({ page }) => {
 	const user = await seedUser('steve');
 
-	await page.addInitScript(() => {
-		const NativeEventSource = window.EventSource;
-		const sources: EventSource[] = [];
-		Object.assign(window, { __realtimeSources: sources });
-		window.EventSource = class extends NativeEventSource {
-			constructor(url: string | URL, init?: EventSourceInit) {
-				super(url, init);
-				sources.push(this);
-			}
-		};
-	});
 	await page.goto('/');
 	await signIn(page, user.email);
 
@@ -445,101 +432,4 @@ test('trends performance table', async ({ page }) => {
 	await expect(debtShrinkCompareTooltip.getByText('-14.3%')).toHaveClass(/text-cash/);
 	await page.mouse.up();
 	await expect(page.getByText(debtShrinkCompareHeader)).not.toBeVisible();
-
-	await expect(page.locator('[data-growth-chart], [data-group-chart]')).toHaveCount(5);
-	const observation = await page.evaluateHandle(() => {
-		const state = { mutations: 0 };
-		const observer = new MutationObserver((records) => (state.mutations += records.length));
-		for (const chart of document.querySelectorAll('[data-growth-chart], [data-group-chart]'))
-			observer.observe(chart, {
-				attributes: true,
-				characterData: true,
-				childList: true,
-				subtree: true
-			});
-		return { observer, state };
-	});
-
-	await Promise.all([
-		page.waitForResponse((response) => {
-			const url = new URL(response.url());
-			return (
-				response.request().method() === 'GET' &&
-				url.pathname.endsWith('/api/collections/accountBalances/records') &&
-				url.searchParams.get('filter')?.includes('asOf<') === true
-			);
-		}),
-		page.evaluate(() => window.dispatchEvent(new Event('online')))
-	]);
-	const recoveryMutations = await observation.evaluate(async ({ observer, state }) => {
-		await new Promise<void>((resolve) =>
-			requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-		);
-		const mutations = state.mutations + observer.takeRecords().length;
-		state.mutations = 0;
-		return mutations;
-	});
-	expect(recoveryMutations).toBe(0);
-
-	const { promise: realtimeGate, resolve: releaseRealtime } = Promise.withResolvers<void>();
-	const { promise: realtimeHeld, resolve: resolveRealtimeHeld } = Promise.withResolvers<void>();
-	await page.route('**/api/realtime', async (route) => {
-		resolveRealtimeHeld();
-		await realtimeGate;
-		await route.continue();
-	});
-	await page.evaluate(() => {
-		const sources = (window as unknown as { __realtimeSources: EventSource[] }).__realtimeSources;
-		for (const source of sources) source.dispatchEvent(new Event('error'));
-	});
-	await realtimeHeld;
-	const missedBalance = await seedAccountBalance({
-		account: cashAccount.id,
-		owner: user.id,
-		asOf: todayStart.toISOString(),
-		value: 11000
-	});
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '5000');
-	await expect(cashCells.nth(8).getByRole('button', { name: '+700%' })).toBeVisible();
-	await observation.evaluate(({ observer, state }) => {
-		observer.takeRecords();
-		state.mutations = 0;
-	});
-
-	const recoveredBalanceHistory = page.waitForResponse(async (response) => {
-		const url = new URL(response.url());
-		if (
-			response.request().method() !== 'GET' ||
-			!url.pathname.endsWith('/api/collections/accountBalances/records') ||
-			url.searchParams.get('fields') !== 'id,account,value,asOf,created'
-		)
-			return false;
-
-		const body: unknown = await response.json();
-		return (
-			typeof body === 'object' &&
-			body !== null &&
-			'items' in body &&
-			Array.isArray(body.items) &&
-			body.items.some(
-				(item: unknown) =>
-					typeof item === 'object' &&
-					item !== null &&
-					'id' in item &&
-					item.id === missedBalance.id &&
-					'value' in item &&
-					item.value === missedBalance.value
-			)
-		);
-	});
-	releaseRealtime();
-	await recoveredBalanceHistory;
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '8000');
-	await expect(cashCells.nth(8).getByRole('button', { name: '+1,000%' })).toBeVisible();
-	const changedRecoveryMutations = await observation.evaluate(({ observer, state }) => {
-		const mutations = state.mutations + observer.takeRecords().length;
-		observer.disconnect();
-		return mutations;
-	});
-	expect(changedRecoveryMutations).toBeGreaterThan(0);
 });

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -18,6 +18,17 @@ import {
 test('trends performance table', async ({ page }) => {
 	const user = await seedUser('steve');
 
+	await page.addInitScript(() => {
+		const NativeEventSource = window.EventSource;
+		const sources: EventSource[] = [];
+		Object.assign(window, { __realtimeSources: sources });
+		window.EventSource = class extends NativeEventSource {
+			constructor(url: string | URL, init?: EventSourceInit) {
+				super(url, init);
+				sources.push(this);
+			}
+		};
+	});
 	await page.goto('/');
 	await signIn(page, user.email);
 
@@ -432,4 +443,112 @@ test('trends performance table', async ({ page }) => {
 	await expect(debtShrinkCompareTooltip.getByText('-14.3%')).toHaveClass(/text-cash/);
 	await page.mouse.up();
 	await expect(page.getByText(debtShrinkCompareHeader)).not.toBeVisible();
+
+	const observation = await page.evaluateHandle(() => {
+		const state = { mutations: 0 };
+		const observer = new MutationObserver((records) => (state.mutations += records.length));
+		for (const chart of document.querySelectorAll('[data-growth-chart], [data-group-chart]'))
+			observer.observe(chart, {
+				attributes: true,
+				characterData: true,
+				childList: true,
+				subtree: true
+			});
+		return { observer, state };
+	});
+	await expect(page.locator('[data-growth-chart], [data-group-chart]')).toHaveCount(5);
+
+	let trendHistoryRequests = 0;
+	page.on('requestfinished', (request) => {
+		const url = new URL(request.url());
+		if (request.method() !== 'GET') return;
+		if (
+			(url.pathname.endsWith('/api/collections/accountBalances/records') &&
+				url.searchParams.get('fields') === 'id,account,value,asOf,created') ||
+			(url.pathname.endsWith('/api/collections/securityBalances/records') &&
+				url.searchParams.get('fields') === 'id,account,security,value,quantity,asOf,created') ||
+			(url.pathname.endsWith('/api/collections/assetBalances/records') &&
+				url.searchParams.get('fields') === 'id,asset,marketValue,asOf,created')
+		)
+			trendHistoryRequests++;
+	});
+	await page.evaluate(() => window.dispatchEvent(new Event('online')));
+	await expect.poll(() => trendHistoryRequests).toBe(12);
+	const recoveryMutations = await observation.evaluate(async ({ observer, state }) => {
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+		);
+		const mutations = state.mutations + observer.takeRecords().length;
+		state.mutations = 0;
+		return mutations;
+	});
+	expect(recoveryMutations).toBe(0);
+
+	// Hold the first full-history response after it captures 9,000. A second balance event must
+	// invalidate that request immediately and let its debounced replacement commit 10,000.
+	const { promise: historyGate, resolve: releaseHistory } = Promise.withResolvers<void>();
+	const { promise: historyHeld, resolve: resolveHistoryHeld } = Promise.withResolvers<void>();
+	const seedTodayCashBalance = (value: number) =>
+		seedAccountBalance({
+			account: cashAccount.id,
+			owner: user.id,
+			asOf: todayStart.toISOString(),
+			value
+		});
+	await page.route(
+		(url) =>
+			url.pathname.endsWith('/api/collections/accountBalances/records') &&
+			url.searchParams.get('fields') === 'id,account,value,asOf,created' &&
+			!url.searchParams.get('filter')?.includes('asOf'),
+		async (route) => {
+			const response = await route.fetch();
+			resolveHistoryHeld();
+			await historyGate;
+			return route.fulfill({ response });
+		},
+		{ times: 1 }
+	);
+	await seedTodayCashBalance(9000);
+	await historyHeld;
+
+	await seedTodayCashBalance(10000);
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
+	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
+
+	// Releasing the stale 9,000 response cannot overwrite the replacement's 10,000 snapshot.
+	releaseHistory();
+	await expect.poll(() => trendHistoryRequests).toBe(36);
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+			)
+	);
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
+	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
+	await observation.evaluate(({ observer, state }) => {
+		observer.takeRecords();
+		state.mutations = 0;
+	});
+
+	const { promise: realtimeGate, resolve: releaseRealtime } = Promise.withResolvers<void>();
+	await page.route('**/api/realtime', (route) => realtimeGate.then(() => route.continue()));
+	await page.evaluate(() => {
+		const sources = (window as unknown as { __realtimeSources: EventSource[] }).__realtimeSources;
+		for (const source of sources) source.dispatchEvent(new Event('error'));
+	});
+	await seedTodayCashBalance(11000);
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
+	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
+
+	releaseRealtime();
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '8000');
+	await expect(cashCells.nth(8).getByRole('button', { name: '+1,000%' })).toBeVisible();
+	const changedRecoveryMutations = await observation.evaluate(({ observer, state }) => {
+		const mutations = state.mutations + observer.takeRecords().length;
+		observer.disconnect();
+		return mutations;
+	});
+	expect(changedRecoveryMutations).toBeGreaterThan(0);
+	expect(trendHistoryRequests).toBe(48);
 });

--- a/e2e/trends.performance.test.ts
+++ b/e2e/trends.performance.test.ts
@@ -512,8 +512,8 @@ test('trends performance table', async ({ page }) => {
 	await historyHeld;
 
 	await seedTodayCashBalance(10000);
-	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
 	await expect(cashCells.nth(8).getByRole('button', { name: '+900%' })).toBeVisible();
+	await expect(maxChart).toHaveAttribute('data-chart-end-value', '7000');
 
 	// Releasing the stale 9,000 response cannot overwrite the replacement's 10,000 snapshot.
 	releaseHistory();

--- a/e2e/trends.reconnect.test.ts
+++ b/e2e/trends.reconnect.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+import { AccountsBalanceGroupOptions } from '../src/lib/pocketbase.schema';
+import { goToPageViaSidebar, signIn } from './playwright.helpers';
+import { seedAccount, seedAccountBalance, seedUser } from './pocketbase.helpers';
+
+test.skip(({ isMobile }) => isMobile, 'Trends reconnect recovery is desktop-only');
+
+test('trends recovers a balance missed while disconnected', async ({ page }) => {
+	const user = await seedUser('eudora');
+	const account = await seedAccount({
+		name: 'Reconnect checking',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking'
+	});
+	await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 1000
+	});
+
+	await page.goto('/');
+	await signIn(page, user.email);
+	await goToPageViaSidebar(page, 'Trends');
+	const maxPerformance = page.getByRole('row', { name: /^Cash/ }).getByRole('cell').nth(8);
+	await expect(maxPerformance.getByRole('button', { name: '0%' })).toBeVisible();
+
+	await page.context().setOffline(true);
+	const missedBalance = await seedAccountBalance({
+		account: account.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: 2000
+	});
+	await expect(maxPerformance.getByRole('button', { name: '0%' })).toBeVisible();
+
+	await Promise.all([
+		page.waitForResponse(async (response) => {
+			const url = new URL(response.url());
+			return (
+				response.request().method() === 'GET' &&
+				url.pathname.endsWith('/api/collections/accountBalances/records') &&
+				url.searchParams.get('fields') === 'id,account,value,asOf,created' &&
+				(await response.text()).includes(missedBalance.id)
+			);
+		}),
+		page.context().setOffline(false)
+	]);
+	await expect(maxPerformance.getByRole('button', { name: '+100%' })).toBeVisible();
+});

--- a/src/routes/(app)/trends/+page.svelte
+++ b/src/routes/(app)/trends/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { UTCDate } from '@date-fns/utc';
 	import { startOfDay } from 'date-fns';
-	import type { RecordSubscription } from 'pocketbase';
 	import { untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 
@@ -18,6 +17,7 @@
 	import SectionTitle from '$lib/components/section-title.svelte';
 	import Section from '$lib/components/section.svelte';
 	import TimeSeriesChart from '$lib/components/time-series-chart.svelte';
+	import { logError } from '$lib/logger';
 	import { m } from '$lib/paraglide/messages';
 	import type {
 		AccountBalancesResponse,
@@ -27,6 +27,7 @@
 		SecurityBalancesResponse
 	} from '$lib/pocketbase.schema';
 	import { getPocketBaseContext } from '$lib/pocketbase.svelte';
+	import { Debouncer, RequestSequence } from '$lib/realtime-sync';
 	import { getSecuritiesContext } from '$lib/securities.svelte';
 	import { projectSignedValue } from '$lib/sharing';
 	import { toNumber } from '$lib/utils';
@@ -60,7 +61,6 @@
 	let rawFullHistoryAccountBalances: AccountBalancesResponse[] = $state.raw([]);
 	let rawFullHistorySecurityBalances: TrendSecurityBalance[] = $state.raw([]);
 	let rawFullHistoryAssetBalances: AssetBalancesResponse[] = $state.raw([]);
-	let historyStart: Date | null = $state(null);
 
 	const includedAccounts = $derived.by(
 		() =>
@@ -85,14 +85,18 @@
 				account.participantExcluded,
 				account.perspective,
 				account.closed,
-				account.balanceGroup
+				account.balanceGroup,
+				account.name,
+				account.currency
 			]),
 			assets: (assetsCtx?.assets ?? []).map((asset) => [
 				asset.id,
 				asset.participantExcluded,
 				asset.perspective,
 				asset.sold,
-				asset.balanceGroup
+				asset.balanceGroup,
+				asset.name,
+				asset.currency
 			])
 		})
 	);
@@ -134,28 +138,13 @@
 		return `(${idsFilter}) && asOf>='${start.toISOString()}'`;
 	}
 
-	type TrendBalanceRecord = { asOf: string; created: string; id: string };
-
-	type BalanceRealtimeConfig<
-		TRecord extends TrendBalanceRecord,
-		TBalance extends TrendBalanceRecord
-	> = {
-		records: () => TBalance[];
-		fullHistoryRecords: () => TBalance[];
-		setRecords: (records: TBalance[]) => void;
-		setFullHistoryRecords: (records: TBalance[]) => void;
-		project: (record: TRecord) => TBalance | null;
-		carryKey: (record: TBalance) => string;
-		identityChanged: (existing: TBalance, balance: TBalance) => boolean;
-	};
-
 	function compareBalances<T extends { asOf: string; created: string; id: string }>(a: T, b: T) {
 		if (a.asOf !== b.asOf) return a.asOf.localeCompare(b.asOf);
 		if (a.created !== b.created) return a.created.localeCompare(b.created);
 		return a.id.localeCompare(b.id);
 	}
 
-	function trimBalances<T extends TrendBalanceRecord>(
+	function trimBalances<T extends { asOf: string; created: string; id: string }>(
 		records: T[],
 		start: Date | null,
 		carryKey: (record: T) => string
@@ -254,12 +243,15 @@
 		});
 	}
 
-	let refreshSequence = 0;
+	const sequence = new RequestSequence();
+	const debouncer = new Debouncer(200);
+	let disposed = false;
+	let lastIncludedSignature = '';
 
-	async function doRefresh() {
-		refreshInFlight = true;
+	async function refresh() {
+		if (disposed) return;
+		const token = sequence.next();
 		try {
-			const sequence = ++refreshSequence;
 			const start = computeBoundedHistoryStart('5y');
 			if (!start) return;
 			// Snapshot the signature this refresh reflects; the signature effect treats any later
@@ -370,7 +362,7 @@
 						)
 					]);
 
-				if (sequence !== refreshSequence) return;
+				if (disposed || !sequence.isCurrent(token)) return;
 
 				const accountBalances = trimBalances(
 					[...accountBalancesPrevious, ...accountBalancesRange]
@@ -416,104 +408,24 @@
 					null,
 					(balance) => balance.asset
 				);
-				historyStart = start;
 			} catch (error) {
-				pb.handleConnectionError(error, 'trends', 'refresh_balances');
+				if (!disposed && sequence.isCurrent(token))
+					pb.handleConnectionError(error, 'trends', 'refresh_balances');
 			}
 		} finally {
-			refreshInFlight = false;
-			if (pendingRefresh) {
-				pendingRefresh = false;
-				void doRefresh();
-			}
+			if (!disposed && sequence.isCurrent(token)) bootstrapped = true;
 		}
 	}
 
-	let refreshTimer: number | null = null;
-	let refreshInFlight = false;
-	let pendingRefresh = false;
-	let lastIncludedSignature = '';
-
-	function handleBalanceEvent<
-		TRecord extends TrendBalanceRecord,
-		TBalance extends TrendBalanceRecord
-	>(event: RecordSubscription<TRecord>, config: BalanceRealtimeConfig<TRecord, TBalance>) {
-		if (!event.action) return;
-		if (!bootstrapped) {
-			if (refreshInFlight) pendingRefresh = true;
-			return;
-		}
-		const records = config.records();
-		const fullHistoryRecords = config.fullHistoryRecords();
-		const existing = records.find((balance) => balance.id === event.record.id);
-		const fullHistoryExisting = fullHistoryRecords.find(
-			(balance) => balance.id === event.record.id
-		);
-		if (event.action === 'delete') {
-			if (existing) {
-				config.setRecords(records.filter((balance) => balance.id !== event.record.id));
-				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			}
-			if (fullHistoryExisting) {
-				config.setFullHistoryRecords(
-					fullHistoryRecords.filter((balance) => balance.id !== event.record.id)
-				);
-			}
-			return;
-		}
-		const balance = config.project(event.record);
-		if (!balance) {
-			if (existing) {
-				config.setRecords(records.filter((record) => record.id !== event.record.id));
-				if (historyStart && new Date(existing.asOf) < historyStart) scheduleRefresh();
-			}
-			if (fullHistoryExisting) {
-				config.setFullHistoryRecords(
-					fullHistoryRecords.filter((record) => record.id !== event.record.id)
-				);
-			}
-			return;
-		}
-		config.setFullHistoryRecords(
-			trimBalances(
-				[...fullHistoryRecords.filter((record) => record.id !== balance.id), balance],
-				null,
-				config.carryKey
-			)
-		);
-		if (
-			historyStart &&
-			((existing && new Date(existing.asOf) < historyStart) ||
-				new Date(balance.asOf) < historyStart)
-		) {
-			scheduleRefresh();
-			return;
-		}
-		config.setRecords(
-			trimBalances(
-				[...records.filter((record) => record.id !== balance.id), balance],
-				historyStart,
-				config.carryKey
-			)
-		);
-		if (existing && config.identityChanged(existing, balance)) scheduleRefresh();
-	}
-
-	function scheduleRefresh() {
-		if (refreshTimer) clearTimeout(refreshTimer);
-		refreshTimer = window.setTimeout(() => {
-			refreshTimer = null;
-			if (refreshInFlight) {
-				pendingRefresh = true;
-				return;
-			}
-			void doRefresh();
-		}, 180);
+	function invalidate() {
+		if (disposed) return;
+		sequence.bump();
+		debouncer.schedule(() => void refresh());
 	}
 
 	$effect(() => {
-		let disposed = false;
 		const unsubscribes: Array<() => void> = [];
+		pb.registerRealtimeReconnect(invalidate);
 		function addSubscription(subscription: Promise<() => void>) {
 			subscription
 				.then((unsubscribe) => {
@@ -523,57 +435,21 @@
 					}
 					unsubscribes.push(unsubscribe);
 				})
-				.catch((error) => pb.handleSubscriptionError(error, 'trends', 'subscribe_balances'));
+				.catch((error) => {
+					if (disposed) logError('trends', 'stale_subscription', error);
+					else pb.handleSubscriptionError(error, 'trends', 'subscribe_balances');
+				});
 		}
 
-		addSubscription(
-			pb.authedClient
-				.collection('accountBalances')
-				.subscribe<AccountBalancesResponse>('*', (event) =>
-					handleBalanceEvent(event, {
-						records: () => rawAccountBalances,
-						fullHistoryRecords: () => rawFullHistoryAccountBalances,
-						setRecords: (records) => (rawAccountBalances = records),
-						setFullHistoryRecords: (records) => (rawFullHistoryAccountBalances = records),
-						project: projectAccountBalance,
-						carryKey: (balance) => balance.account,
-						identityChanged: (existing, balance) => existing.account !== balance.account
-					})
-				)
-		);
-		addSubscription(
-			pb.authedClient
-				.collection('securityBalances')
-				.subscribe<SecurityBalancesResponse<number, number, number, number>>('*', (event) =>
-					handleBalanceEvent(event, {
-						records: () => rawSecurityBalances,
-						fullHistoryRecords: () => rawFullHistorySecurityBalances,
-						setRecords: (records) => (rawSecurityBalances = records),
-						setFullHistoryRecords: (records) => (rawFullHistorySecurityBalances = records),
-						project: projectSecurityBalance,
-						carryKey: (balance) => `${balance.account}:${balance.security}`,
-						identityChanged: (existing, balance) =>
-							existing.account !== balance.account || existing.security !== balance.security
-					})
-				)
-		);
-		addSubscription(
-			pb.authedClient.collection('assetBalances').subscribe<AssetBalancesResponse>('*', (event) =>
-				handleBalanceEvent(event, {
-					records: () => rawAssetBalances,
-					fullHistoryRecords: () => rawFullHistoryAssetBalances,
-					setRecords: (records) => (rawAssetBalances = records),
-					setFullHistoryRecords: (records) => (rawFullHistoryAssetBalances = records),
-					project: projectAssetBalance,
-					carryKey: (balance) => balance.asset,
-					identityChanged: (existing, balance) => existing.asset !== balance.asset
-				})
-			)
-		);
+		addSubscription(pb.authedClient.collection('accountBalances').subscribe('*', invalidate));
+		addSubscription(pb.authedClient.collection('securityBalances').subscribe('*', invalidate));
+		addSubscription(pb.authedClient.collection('assetBalances').subscribe('*', invalidate));
 
 		return () => {
 			disposed = true;
-			if (refreshTimer) clearTimeout(refreshTimer);
+			sequence.bump();
+			debouncer.cancel();
+			pb.unregisterRealtimeReconnect(invalidate);
 			for (const unsubscribe of unsubscribes) unsubscribe();
 		};
 	});
@@ -585,22 +461,17 @@
 		if (bootstrapped) return;
 		if (accountsCtx?.isLoading || assetsCtx?.isLoading) return;
 		untrack(() => {
-			void doRefresh().then(() => {
-				bootstrapped = true;
-			});
+			void refresh();
 		});
 	});
 
 	$effect(() => {
 		const signature = includedSignature;
 		if (signature === lastIncludedSignature) return;
+		const refreshStarted = sequence.current > 0;
 		lastIncludedSignature = signature;
-		if (refreshInFlight) {
-			pendingRefresh = true;
-			return;
-		}
-		if (!bootstrapped) return;
-		scheduleRefresh();
+		if (!bootstrapped && !refreshStarted) return;
+		invalidate();
 	});
 
 	const isEmpty = $derived(!rawAccounts.length && !rawAssets.length);
@@ -630,14 +501,15 @@
 	});
 	// Anchors every chart's MAX window at the earliest balance instead of the base range start,
 	// so MAX never pads a zero lead-in when history is shorter than five years
-	const maxStart = $derived.by(() => {
+	const maxStartTime = $derived.by(() => {
 		const earliest = findEarliestBalanceDate(
 			rawFullHistoryAccountBalances,
 			rawFullHistorySecurityBalances,
 			rawFullHistoryAssetBalances
 		);
-		return earliest ? startOfDay(new UTCDate(earliest.getTime())) : null;
+		return earliest ? startOfDay(new UTCDate(earliest.getTime())).getTime() : null;
 	});
+	const maxStart = $derived(maxStartTime === null ? null : new UTCDate(maxStartTime));
 </script>
 
 <Page pageTitle={m.trends_page_title()}>

--- a/src/routes/(app)/trends/growth.svelte
+++ b/src/routes/(app)/trends/growth.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { UTCDate } from '@date-fns/utc';
 	import { eachDayOfInterval, startOfDay, subYears } from 'date-fns';
+	import { untrack } from 'svelte';
 
 	import {
 		advanceTrendSecurityValue,
@@ -85,9 +86,10 @@
 	}
 
 	function recomputeSeries() {
+		const [previousSeriesRows, previousMemberSeries] = untrack(() => [seriesRows, memberSeries]);
 		if (!rawAccounts.length && !rawAssets.length) {
-			seriesRows = [];
-			memberSeries = { members: [], rows: [] };
+			if (previousSeriesRows.length) seriesRows = [];
+			if (previousMemberSeries.rows.length) memberSeries = { members: [], rows: [] };
 			return;
 		}
 		// The rows always span the widest choosable window - five years, or the earliest balance
@@ -233,8 +235,28 @@
 			});
 		}
 
-		seriesRows = rows;
-		memberSeries = {
+		if (
+			previousSeriesRows.length !== rows.length ||
+			rows.some((row, index) => {
+				const previous = previousSeriesRows[index];
+				return (
+					row.date.getTime() !== previous.date.getTime() ||
+					row.net !== previous.net ||
+					row.cash !== previous.cash ||
+					row.debt !== previous.debt ||
+					row.investment !== previous.investment ||
+					row.other !== previous.other ||
+					row.isUnconverted.net !== previous.isUnconverted.net ||
+					row.isUnconverted.cash !== previous.isUnconverted.cash ||
+					row.isUnconverted.debt !== previous.isUnconverted.debt ||
+					row.isUnconverted.investment !== previous.isUnconverted.investment ||
+					row.isUnconverted.other !== previous.isUnconverted.other
+				);
+			})
+		)
+			seriesRows = rows;
+
+		const nextMemberSeries: TrendMemberSeries = {
 			members: [...rawAccounts, ...rawAssets]
 				.filter((entity) => entity.id in memberValues)
 				.map((entity) => ({
@@ -249,6 +271,26 @@
 				)
 			}))
 		};
+		if (
+			previousMemberSeries.members.length !== nextMemberSeries.members.length ||
+			previousMemberSeries.rows.length !== nextMemberSeries.rows.length ||
+			nextMemberSeries.members.some((member, index) => {
+				const previous = previousMemberSeries.members[index];
+				return (
+					member.key !== previous.key ||
+					member.label !== previous.label ||
+					member.group !== previous.group
+				);
+			}) ||
+			nextMemberSeries.rows.some((row, index) => {
+				const previous = previousMemberSeries.rows[index];
+				return (
+					row.date.getTime() !== previous.date.getTime() ||
+					Object.keys(row.values).some((key) => !Object.is(row.values[key], previous.values[key]))
+				);
+			})
+		)
+			memberSeries = nextMemberSeries;
 	}
 
 	$effect(() => recomputeSeries());


### PR DESCRIPTION
- A five-minute reconnect froze all five trends charts because an equal-data refresh recreated chart input identities.
- The `/trends` route-local balance histories were outside the authoritative reconnect recovery path, so events missed during a disconnect could leave the page stale.
- Initial loads, live balance events, and reconnect recovery now use the canonical invalidation-only `RequestSequence` and `Debouncer` path.
- Equal snapshots preserve chart identities, while a lightweight desktop E2E verifies recovery of one balance missed while disconnected.
- Manual profiling moved reconnect work from 3 x ~5.2s long tasks / ~14.9s total and 10.36s timer drift to 0 long tasks and 1.8ms drift; CI does not assert timing.

No linked issue (confirmed by user)