### PR TITLE
fix: show progress during slow navigation

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onDestroy, untrack } from 'svelte';
 
+	import { navigating } from '$app/state';
 	import { setAccountsContext } from '$lib/accounts.svelte';
 	import { setAssetsContext } from '$lib/assets.svelte';
 	import { getAuthContext } from '$lib/auth.svelte';
@@ -16,6 +17,9 @@
 	import AppSidebar from './app-sidebar.svelte';
 
 	let { children } = $props();
+	let progressState = $state<'idle' | 'starting' | 'pending' | 'complete' | 'fading'>('idle');
+	let wasNavigating = false;
+	const isNavigating = $derived(Boolean(navigating.to));
 
 	const pb = getPocketBaseContext();
 	const auth = getAuthContext();
@@ -28,6 +32,49 @@
 	const securitiesContext = setSecuritiesContext(pb);
 	accountsContext.connectPositions(securitiesContext);
 	const importSessionsContext = setImportSessionsContext(pb);
+
+	$effect(() => {
+		const navigationPending = isNavigating;
+		let revealTimer: ReturnType<typeof setTimeout> | undefined;
+		let startFrame: number | undefined;
+		let advanceFrame: number | undefined;
+		let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+		let removeTimer: ReturnType<typeof setTimeout> | undefined;
+
+		// Fast navigations stay invisible; once shown, the bar remains continuous across redirects.
+		if (navigationPending) {
+			const currentState = untrack(() => progressState);
+			if (currentState === 'complete' || currentState === 'fading') {
+				progressState = 'idle';
+			}
+			if (currentState === 'idle' || currentState === 'complete' || currentState === 'fading') {
+				revealTimer = setTimeout(() => {
+					progressState = 'starting';
+					startFrame = requestAnimationFrame(() => {
+						advanceFrame = requestAnimationFrame(() => {
+							progressState = 'pending';
+						});
+					});
+				}, 300);
+			}
+		} else if (wasNavigating) {
+			const currentState = untrack(() => progressState);
+			if (currentState !== 'idle') {
+				progressState = 'complete';
+				fadeTimer = setTimeout(() => (progressState = 'fading'), 240);
+				removeTimer = setTimeout(() => (progressState = 'idle'), 390);
+			}
+		}
+		wasNavigating = navigationPending;
+
+		return () => {
+			if (revealTimer !== undefined) clearTimeout(revealTimer);
+			if (startFrame !== undefined) cancelAnimationFrame(startFrame);
+			if (advanceFrame !== undefined) cancelAnimationFrame(advanceFrame);
+			if (fadeTimer !== undefined) clearTimeout(fadeTimer);
+			if (removeTimer !== undefined) clearTimeout(removeTimer);
+		};
+	});
 
 	onDestroy(() => {
 		balanceTypesContext.dispose();
@@ -42,9 +89,50 @@
 
 <Sidebar.Provider>
 	<AppSidebar />
-	<Sidebar.Inset>
+	{#if progressState !== 'idle'}
+		<div
+			class="navigation-progress bg-primary fixed inset-x-0 top-0 z-[60] h-[3px] origin-left"
+			data-state={progressState}
+			aria-hidden="true"
+		></div>
+	{/if}
+	<Sidebar.Inset aria-busy={isNavigating}>
 		{#if auth.currentUserId}
 			{@render children?.()}
 		{/if}
 	</Sidebar.Inset>
 </Sidebar.Provider>
+
+<style>
+	.navigation-progress {
+		transition-property: transform, opacity;
+		transition-timing-function: ease-out;
+	}
+
+	.navigation-progress[data-state='starting'] {
+		transform: scaleX(0.1);
+	}
+
+	.navigation-progress[data-state='pending'] {
+		transform: scaleX(0.88);
+		transition-duration: 12s;
+		transition-timing-function: cubic-bezier(0.1, 0.6, 0.2, 1);
+	}
+
+	.navigation-progress[data-state='complete'] {
+		transform: scaleX(1);
+		transition-duration: 140ms;
+	}
+
+	.navigation-progress[data-state='fading'] {
+		transform: scaleX(1);
+		opacity: 0;
+		transition-duration: 150ms;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.navigation-progress[data-state] {
+			transition-duration: 0ms;
+		}
+	}
+</style>

--- a/src/routes/(app)/app-sidebar.svelte
+++ b/src/routes/(app)/app-sidebar.svelte
@@ -11,7 +11,7 @@
 	import WalletCardsIcon from '@lucide/svelte/icons/wallet-cards';
 	import type { ComponentProps } from 'svelte';
 
-	import { afterNavigate } from '$app/navigation';
+	import { beforeNavigate } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import CanutinIcon from '$lib/components/canutin-icon.svelte';
@@ -26,12 +26,8 @@
 
 	const sidebar = Sidebar.useSidebar();
 
-	// The mobile sidebar is a Sheet that only closes explicitly - navigating to a
-	// new route doesn't close it on its own. Close it after every navigation so
-	// tapping a link on mobile both navigates and dismisses the drawer.
-	afterNavigate(() => {
-		if (sidebar.isMobile) sidebar.setOpenMobile(false);
-	});
+	// Begin dismissing the mobile Sheet before the destination loads.
+	beforeNavigate(() => sidebar.setOpenMobile(false));
 
 	const insights = $derived([
 		{


### PR DESCRIPTION
- Adds a delayed global progress bar for navigations that exceed 300 ms, keeping fast transitions quiet.
- Advances the bar while a destination loads, then completes and fades it when navigation resolves.
- Begins closing the mobile navigation drawer as soon as navigation starts.
- Marks app content busy during pending navigation and respects reduced-motion preferences.

Refs #160