### PR TITLE
fix: match mobile browser chrome to the page header

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -181,6 +181,14 @@
 		@apply bg-background text-foreground;
 		text-wrap: pretty;
 	}
+	/* Keeps scroll targets clear of the toolbar in page.svelte, which is sticky below `md`;
+	   without this, anchoring an element to the top of the viewport hides it behind the bar.
+	   Half a step taller than the bar's `h-12` so the target doesn't sit flush against it. */
+	@media (width < 48rem) {
+		html {
+			scroll-padding-top: --spacing(14);
+		}
+	}
 }
 
 @layer utilities {

--- a/src/app.css
+++ b/src/app.css
@@ -65,6 +65,9 @@
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
+	/* --muted paints the page header, whose sticky bar is what iOS Safari samples to tint the
+	   strip behind the status bar; it is also mirrored as hex into the `theme-color` metas in
+	   app.html for other browsers. Keep those values in sync when this token changes. */
 	--muted: oklch(0.98 0 0);
 	--muted-foreground: oklch(0.66 0 0);
 	--accent: oklch(0.97 0 0);

--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,13 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
 		/>
+		<!-- Safari 26 ignores `theme-color` and samples the background of a fixed or sticky element
+		     near the viewport edge instead - the sticky bar in page.svelte is what tints it there.
+		     These stay for the browsers that do honour the tag; they track the system preference
+		     rather than the in-app toggle because Safari only reads them while parsing. Keep them
+		     in sync with light and dark `--muted` in app.css. -->
+		<meta name="theme-color" content="#f8f8f8" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#282828" media="(prefers-color-scheme: dark)" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link

--- a/src/lib/components/page.svelte
+++ b/src/lib/components/page.svelte
@@ -28,7 +28,11 @@
 	<title>{getPageTitle(pageTitle, crumbs)}</title>
 </svelte:head>
 
-<header class="bg-muted border-b">
+<!-- iOS Safari tints the strip behind the status bar with the background of a sticky or fixed
+     element near the viewport edge, so this row has to stay pinned there on mobile or the strip
+     falls back to the body's color. It sits outside <header> because a sticky element can't
+     travel past its own parent's box, and the header ends well before the page does. -->
+<div class="bg-muted sticky top-0 z-10 md:static">
 	<div class="flex h-12 items-center gap-2 px-4">
 		<Sidebar.Trigger class="-ml-1" />
 		<Separator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
@@ -49,7 +53,9 @@
 			</Breadcrumb.List>
 		</Breadcrumb.Root>
 	</div>
+</div>
 
+<header class="bg-muted border-b">
 	<div class="flex items-end justify-between gap-4 px-6 pt-16 pb-6 sm:px-8">
 		<h1 class="text-foreground text-2xl font-bold tracking-tight">{pageTitle}</h1>
 		{#if actions && !subNav}


### PR DESCRIPTION
- On iOS the strip behind the status bar rendered in a colour that matched nothing else on screen, which read as a seam above the app header.
- Safari 26 no longer honours the `theme-color` meta tag. It samples the background of a sticky or fixed element near the viewport edge instead, falling back to the body's colour when there isn't one — and this app had nothing pinned up there.
- Pins the mobile toolbar row (sidebar trigger and breadcrumbs) to the top so Safari samples its `--muted` background. The row moved outside `<header>` because a sticky element can't travel past its own parent's box and the header ends well before the page does.
- Keeps `theme-color` as a static light/dark pair for the browsers that still read the tag. It tracks the system preference rather than the in-app theme toggle, since a dynamic update is ignored where the tag is read at parse time.
- Desktop is unchanged — the row is only sticky below `md`.
- Known limitation: the strip cannot follow UI state, so it stays the header's colour while the mobile sidebar is open. Fixed-element tinting in Safari 26 is buggy enough that the prevailing advice is to wait for the WebKit fix rather than work around it.

No linked issue (confirmed by user)