### PR TITLE
fix: allow deleting users with currencies in use

### DIFF
--- a/e2e/currencies.test.ts
+++ b/e2e/currencies.test.ts
@@ -9,7 +9,9 @@ import {
 	signIn
 } from './playwright.helpers';
 import {
+	deleteUser,
 	getUserPB,
+	recordExists,
 	seedAccount,
 	seedCurrency,
 	seedExchangeRate,
@@ -446,4 +448,28 @@ test('currency delete blocks in-use currencies and removes unused quotes', async
 		filter: `owner='${user.id}' && currency='${unusedCode}'`
 	});
 	expect(quotes).toHaveLength(0);
+});
+
+test('deleting a user cascades through an in-use currency', async () => {
+	const user = await seedUser('josephine');
+	const code = uniqueCurrency('QD');
+	const currency = await seedCurrency({
+		owner: user.id,
+		code,
+		name: 'Delete cascade coin',
+		autoUpdate: false
+	});
+	const account = await seedAccount({
+		name: 'Delete cascade account',
+		balanceGroup: AccountsBalanceGroupOptions.CASH,
+		owner: user.id,
+		balanceType: 'Checking',
+		currency: code
+	});
+
+	await deleteUser(user.id);
+
+	expect(await recordExists('users', user.id)).toBe(false);
+	expect(await recordExists('currencies', currency.id)).toBe(false);
+	expect(await recordExists('accounts', account.id)).toBe(false);
 });

--- a/pocketbase/main.go
+++ b/pocketbase/main.go
@@ -189,6 +189,13 @@ func main() {
 	app.OnRecordDelete("currencies").BindFunc(func(e *core.RecordEvent) error {
 		code := e.Record.GetString("code")
 		owner := e.Record.GetString("owner")
+		_, err := e.App.FindRecordById("users", owner)
+		if errors.Is(err, sql.ErrNoRows) {
+			return e.Next()
+		}
+		if err != nil {
+			return fmt.Errorf("check currency owner: %w", err)
+		}
 		for _, collection := range []string{"accounts", "assets", "securities"} {
 			_, err := e.App.FindFirstRecordByFilter(collection,
 				"owner = {:owner} && currency = {:currency}",

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -172,8 +172,9 @@ Backend hooks enforce invariants that are not visible in the access rules:
   rate unless ` + "`FX_FETCH_DISABLED=true`" + ` is set. A failed upstream request rejects the create with
   ` + "`currency_auto_update_request_failed`" + ` on ` + "`autoUpdate`" + `; an unavailable code rejects it with
   ` + "`currency_auto_update_code_unavailable`" + `.
-  Deleting a currency is rejected with a 400 while any owned account, asset, or security references
-  its code; successful deletion also deletes that user's manual quotes for the code.
+  Deleting a currency while its owner exists is rejected with a 400 if any owned account, asset, or
+  security references its code. Deleting the owner cascades through currencies and their references;
+  successful direct currency deletion also deletes that user's manual quotes for the code.
 - Exchange rates (` + "`exchangeRates`" + `) are a two-tier store. Rows with empty ` + "`owner`" + ` are the
   global fetched cache (` + "`source = fetched`" + `) and are visible to all users but engine-written only.
   Rows with ` + "`owner = @request.auth.id`" + ` are the user's manual quotes (` + "`source = manual`" + `).


### PR DESCRIPTION
- Allows PocketBase user deletion to cascade through owned currencies even when financial records reference them
- Preserves the existing guard against directly deleting currencies that remain in use
- Adds focused coverage proving the user, currency, and account are removed together
- Updates the served API reference with the cascade behavior

Closes #417