### PR TITLE
fix: require explicit Plaid environment

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -63,7 +63,7 @@ PLAID_SECRET=<secret>
 PLAID_ENV=production
 ```
 
-`PLAID_ENV` defaults to `sandbox` when omitted. Compose's `.env` file supplies substitution values; the `pocketbase.environment` mappings in `docker-compose.prod.yml` pass them into the container. After changing them, recreate PocketBase with `docker compose -f docker-compose.prod.yml up -d --force-recreate pocketbase`. Omit `-f docker-compose.prod.yml` when the deployment uses that content as `docker-compose.yml`.
+Compose's `.env` file supplies substitution values; the `pocketbase.environment` mappings in `docker-compose.prod.yml` pass them into the container. After changing them, recreate PocketBase with `docker compose -f docker-compose.prod.yml up -d --force-recreate pocketbase`. Omit `-f docker-compose.prod.yml` when the deployment uses that content as `docker-compose.yml`.
 
 ## Anti-patterns
 

--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -63,6 +63,8 @@ PLAID_SECRET=<secret>
 PLAID_ENV=production
 ```
 
+Set all three values to enable Plaid. Use `sandbox` for development and `production` for live data; credentials without an explicit environment are rejected.
+
 Compose's `.env` file supplies substitution values; the `pocketbase.environment` mappings in `docker-compose.prod.yml` pass them into the container. After changing them, recreate PocketBase with `docker compose -f docker-compose.prod.yml up -d --force-recreate pocketbase`. Omit `-f docker-compose.prod.yml` when the deployment uses that content as `docker-compose.yml`.
 
 ## Anti-patterns

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ services:
     environment:
       PLAID_CLIENT_ID: ${PLAID_CLIENT_ID:-}
       PLAID_SECRET: ${PLAID_SECRET:-}
-      PLAID_ENV: ${PLAID_ENV:-sandbox}
+      PLAID_ENV: ${PLAID_ENV:-}
     volumes:
       - canutin-data:/app/pocketbase/pb_data
     restart: unless-stopped

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ volumes:
   canutin-data:
 ```
 
-To enable Plaid, create a `.env` file beside `docker-compose.yml` with production credentials:
+To enable Plaid, create a `.env` file beside `docker-compose.yml` with all three production values:
 
 ```dotenv
 PLAID_CLIENT_ID=<client-id>
 PLAID_SECRET=<secret>
 PLAID_ENV=production
 ```
+
+`PLAID_ENV` has no default. Use `production` for live data and `sandbox` only for development.
 
 Then run:
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
       PUBLIC_DEMO_ENABLED: 'true'
       PLAID_CLIENT_ID: ${PLAID_CLIENT_ID:-}
       PLAID_SECRET: ${PLAID_SECRET:-}
-      PLAID_ENV: ${PLAID_ENV:-sandbox}
+      PLAID_ENV: ${PLAID_ENV:-}
     volumes:
       - pocketbase-data:/app/pocketbase/pb_data
     restart: unless-stopped

--- a/pocketbase/plaid.go
+++ b/pocketbase/plaid.go
@@ -128,16 +128,18 @@ func plaidConfigFromEnv() (plaidConfig, error) {
 	config := plaidConfig{
 		clientID: os.Getenv("PLAID_CLIENT_ID"),
 		secret:   os.Getenv("PLAID_SECRET"),
-		baseURL:  plaidSandboxURL,
 	}
 	if config.clientID == "" || config.secret == "" {
 		return plaidConfig{}, fmt.Errorf("%w: PLAID_CLIENT_ID and PLAID_SECRET are required", errPlaidNotConfigured)
 	}
 
 	switch os.Getenv("PLAID_ENV") {
-	case "", "sandbox":
+	case "sandbox":
+		config.baseURL = plaidSandboxURL
 	case "production":
 		config.baseURL = plaidProductionURL
+	case "":
+		return plaidConfig{}, fmt.Errorf("%w: PLAID_ENV is required", errPlaidNotConfigured)
 	default:
 		return plaidConfig{}, fmt.Errorf("%w: PLAID_ENV must be sandbox or production", errPlaidNotConfigured)
 	}

--- a/pocketbase/plaid_test.go
+++ b/pocketbase/plaid_test.go
@@ -1,0 +1,22 @@
+package main
+
+// The Playwright suite shares one PocketBase process with fixed Plaid configuration, so it cannot
+// exercise process environment variants. Keep these tests limited to configuration selection before
+// any outbound request.
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPlaidConfigRequiresExplicitEnvironment(t *testing.T) {
+	t.Setenv("PLAID_CLIENT_ID", "client-id")
+	t.Setenv("PLAID_SECRET", "secret")
+	t.Setenv("PLAID_ENV", "")
+	t.Setenv("PLAID_BASE_URL", "")
+
+	_, err := plaidConfigFromEnv()
+	if !errors.Is(err, errPlaidNotConfigured) {
+		t.Fatalf("error = %v, want errPlaidNotConfigured", err)
+	}
+}

--- a/pocketbase/skill.go
+++ b/pocketbase/skill.go
@@ -139,7 +139,7 @@ const skillCustomEndpointsSection = "## Custom endpoints\n\n" +
 	"same connection return `{ error: \"plaid_sync_in_progress\" }` with status 409, " +
 	"and a connection requiring renewed Plaid login completes with status `failed` and is marked " +
 	"`reauth_required`. A missing or foreign connection returns status 404. Returns " +
-	"`{ error: \"plaid_not_configured\" }` with status 503 when Plaid credentials are unavailable, or " +
+	"`{ error: \"plaid_not_configured\" }` with status 503 when any required Plaid setting is missing or invalid, or " +
 	"`{ error: \"plaid_request_failed\", message: \"Plaid is temporarily unavailable\" }` with status 502 " +
 	"when Plaid rejects or cannot complete an upstream request.\n" +
 	"- `DELETE /api/canutin/plaid/connections/{id}` — requires a `users` token and an owned Plaid " +
@@ -217,9 +217,10 @@ Backend hooks enforce invariants that are not visible in the access rules:
   runtime kill-switch. The scheduled refresh runs daily at 05:00 UTC.
 - Plaid connections sync sequentially every night at 06:00 UTC. Connections marked
   ` + "`reauth_required`" + ` are skipped, as is the whole job when Plaid is not configured.
-- Plaid requests go to the host selected by ` + "`PLAID_ENV`" + ` (` + "`sandbox`" + ` or ` + "`production`" + `),
-  unless ` + "`PLAID_BASE_URL`" + ` overrides it with another origin. The override exists so automated tests
-  can run the whole linking and syncing flow against a local stand-in for the Plaid API.
+- Plaid requires ` + "`PLAID_CLIENT_ID`" + `, ` + "`PLAID_SECRET`" + `, and an explicit ` + "`PLAID_ENV`" + `
+  (` + "`sandbox`" + ` or ` + "`production`" + `). Requests go to the selected host unless ` + "`PLAID_BASE_URL`" + `
+  overrides it with another origin. The override lets automated tests run the whole linking and syncing flow
+  against a local stand-in for the Plaid API.
 `
 
 // canutinSkillHandler serves a live, SKILL.md-formatted reference of the Canutin API,


### PR DESCRIPTION
> [!WARNING]
> Plaid deployments must set `PLAID_ENV` explicitly to `sandbox` or `production`.

- Requires an explicit Plaid environment whenever credentials are configured
- Keeps Plaid unavailable when credentials or environment selection are missing
- Passes deployment values into PocketBase without inventing a default
- Documents production and development environment selection
- Adds focused regression coverage for the missing-environment case

No linked issue (confirmed by user)