### PR TITLE
fix: improve balance sheet amount ordering

### DIFF
--- a/e2e/balance-sheet.test.ts
+++ b/e2e/balance-sheet.test.ts
@@ -173,11 +173,45 @@ test('balance sheet', async ({ page }) => {
 		asOf: new Date().toISOString(),
 		marketValue: 1234
 	});
+	const excludedAccount = await seedAccount({
+		name: 'Summit Rewards',
+		balanceGroup: AccountsBalanceGroupOptions.DEBT,
+		owner: user.id,
+		balanceType: 'Credit card',
+		excluded: new Date().toISOString()
+	});
+	await seedAccountBalance({
+		account: excludedAccount.id,
+		owner: user.id,
+		asOf: new Date().toISOString(),
+		value: -2000
+	});
 
 	await expect(cash).toContainText('$500');
 	await expect(investments).toContainText('$1,000');
 	await expect(debt).toContainText('-$1,000');
 	await expect(other).toContainText('$1,000');
+
+	const creditCardItems = page
+		.getByRole('region', { name: 'Credit card' })
+		.getByRole('listitem');
+	await expect(creditCardItems).toHaveCount(2);
+	await expect(creditCardItems.nth(0)).toContainText('Summit Rewards');
+	await expect(creditCardItems.nth(0)).toContainText('-$2,000');
+	await expect(creditCardItems.nth(1)).toContainText('Crescent Classic');
+	await expect(creditCardItems.nth(1)).toContainText('-$1,000');
+
+	const excludedBalance = creditCardItems.nth(0).getByRole('button');
+	await expect(excludedBalance).toHaveClass(/border-b/);
+	await expect(excludedBalance).toHaveClass(/border-dashed/);
+
+	// Hover tooltips are unavailable in mobile projects.
+	if (!test.info().project.name.toLowerCase().includes('mobile')) {
+		await excludedBalance.hover();
+		await expect(
+			page.getByText('This account is excluded from totals', { exact: true })
+		).toBeVisible();
+	}
 
 	const autoCalculatedAccount = await seedAccount({
 		name: 'Maple Reserve',

--- a/e2e/balance-sheet.test.ts
+++ b/e2e/balance-sheet.test.ts
@@ -192,9 +192,7 @@ test('balance sheet', async ({ page }) => {
 	await expect(debt).toContainText('-$1,000');
 	await expect(other).toContainText('$1,000');
 
-	const creditCardItems = page
-		.getByRole('region', { name: 'Credit card' })
-		.getByRole('listitem');
+	const creditCardItems = page.getByRole('region', { name: 'Credit card' }).getByRole('listitem');
 	await expect(creditCardItems).toHaveCount(2);
 	await expect(creditCardItems.nth(0)).toContainText('Summit Rewards');
 	await expect(creditCardItems.nth(0)).toContainText('-$2,000');

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -137,6 +137,9 @@
 				const result = sumPartial(values);
 				balanceType.total = result.total;
 				balanceType.isPartial = result.isPartial || hasMixedAccounts;
+				balanceType.items.sort(
+					(a, b) => Math.abs(b.balance ?? 0) - Math.abs(a.balance ?? 0)
+				);
 				groupValues.push(...values);
 				groupHasMixedAccounts ||= hasMixedAccounts;
 			}

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -138,9 +138,7 @@
 				const result = sumPartial(values);
 				balanceType.total = result.total;
 				balanceType.isPartial = result.isPartial || hasMixedAccounts;
-				balanceType.items.sort(
-					(a, b) => Math.abs(b.balance ?? 0) - Math.abs(a.balance ?? 0)
-				);
+				balanceType.items.sort((a, b) => Math.abs(b.balance ?? 0) - Math.abs(a.balance ?? 0));
 				groupValues.push(...values);
 				groupHasMixedAccounts ||= hasMixedAccounts;
 			}

--- a/src/routes/(app)/balance-sheet/+page.svelte
+++ b/src/routes/(app)/balance-sheet/+page.svelte
@@ -2,7 +2,7 @@
 	import { getBalanceGroupMeta } from '$lib/account-utils';
 	import { getAccountsContext } from '$lib/accounts.svelte';
 	import { getAssetsContext } from '$lib/assets.svelte';
-	import Currency from '$lib/components/currency.svelte';
+	import Currency, { getCurrencyFxLabel } from '$lib/components/currency.svelte';
 	import Empty from '$lib/components/empty.svelte';
 	import KeyValue from '$lib/components/key-value.svelte';
 	import Page from '$lib/components/page.svelte';
@@ -10,6 +10,7 @@
 	import SectionTitle from '$lib/components/section-title.svelte';
 	import Section from '$lib/components/section.svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { m } from '$lib/paraglide/messages';
 	import { sumPartial } from '$lib/utils';
 
@@ -205,6 +206,40 @@
 											>
 												{#if item.balance === null}
 													<span class="text-muted-foreground">~</span>
+												{:else if item.excluded}
+													<Tooltip.Root>
+														<Tooltip.Trigger
+															class="border-border inline-block border-b border-dashed leading-none hover:border-current"
+														>
+															<Currency
+																value={item.balance}
+																isConverted={item.isConverted}
+																isUnconverted={item.isUnconverted}
+																missingCurrency={item.missingCurrency}
+																nativeCurrency={item.nativeCurrency}
+																nativeValue={item.nativeValue ?? undefined}
+																showFxTooltip={false}
+															/>
+														</Tooltip.Trigger>
+														<Tooltip.Content sideOffset={6}>
+															<p class="text-xs leading-snug font-normal">
+																{item.type === 'account'
+																	? m.accounts_balance_tooltip_excluded()
+																	: m.assets_balance_tooltip_excluded()}
+															</p>
+															{#if item.isConverted || item.isUnconverted}
+																<p class="text-xs leading-snug font-normal">
+																	{getCurrencyFxLabel({
+																		decimalScale: 0,
+																		isUnconverted: item.isUnconverted,
+																		missingCurrency: item.missingCurrency,
+																		nativeCurrency: item.nativeCurrency,
+																		nativeValue: item.nativeValue ?? undefined
+																	})}
+																</p>
+															{/if}
+														</Tooltip.Content>
+													</Tooltip.Root>
 												{:else}
 													<Currency
 														value={item.balance}


### PR DESCRIPTION
- Sort accounts and assets within each balance type by descending amount
- Use absolute displayed values so debt balances rank by magnitude
- Add the established dashed underline and tooltip to excluded balances
- Reuse localized account and asset wording while preserving currency context

No linked issue (confirmed by user)